### PR TITLE
Implement `no_sync` for `thunder.distributed.fsdp` (PR2457)

### DIFF
--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -216,9 +216,11 @@ class Benchmark_litGPT:
                 from thunder.distributed import fsdp, FSDPType, FSDPBucketingStrategy
 
                 sharding_strategy = {"zero2": FSDPType.ZERO2, "zero3": FSDPType.ZERO3}[self.shard_mode]
-                bucketing_strategy = {"none": FSDPBucketingStrategy.NONE, "block": FSDPBucketingStrategy.BLOCK, "layer": FSDPBucketingStrategy.LAYER,}[
-                    self.bucketing_mode
-                ]
+                bucketing_strategy = {
+                    "none": FSDPBucketingStrategy.NONE,
+                    "block": FSDPBucketingStrategy.BLOCK,
+                    "layer": FSDPBucketingStrategy.LAYER,
+                }[self.bucketing_mode]
                 model = fsdp(
                     model,
                     broadcast_from=None,

--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -216,7 +216,7 @@ class Benchmark_litGPT:
                 from thunder.distributed import fsdp, FSDPType, FSDPBucketingStrategy
 
                 sharding_strategy = {"zero2": FSDPType.ZERO2, "zero3": FSDPType.ZERO3}[self.shard_mode]
-                bucketing_strategy = {"none": FSDPBucketingStrategy.NONE, "block": FSDPBucketingStrategy.BLOCK}[
+                bucketing_strategy = {"none": FSDPBucketingStrategy.NONE, "block": FSDPBucketingStrategy.BLOCK, "layer": FSDPBucketingStrategy.LAYER,}[
                     self.bucketing_mode
                 ]
                 model = fsdp(

--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -1,5 +1,6 @@
 import os
 import time
+from typing import Any
 
 import torch
 import functools
@@ -35,6 +36,22 @@ def configure_optimizers(model, weight_decay, learning_rate, betas, device_type)
     return optimizer
 
 
+def run_fwd_bwd_one_microbatch(
+    model: torch.nn.Module,
+    input_ids: torch.Tensor,
+    targets: torch.Tensor,
+    gradient_accumulation_steps: int,
+    te_ctx: Any,
+) -> torch.Tensor:
+    with te_ctx():
+        logits = model(input_ids)
+    logits = logits.reshape(-1, logits.size(-1))
+    targets = targets.reshape(-1)
+    loss = torch.nn.functional.cross_entropy(logits, targets, ignore_index=-1) / gradient_accumulation_steps
+    loss.backward()
+    return loss
+
+
 class Benchmark_litGPT:
     def __init__(
         self,
@@ -53,6 +70,7 @@ class Benchmark_litGPT:
         n_layers: int | None = None,
         profiler_start: int = 15,
         profiler_stop: int = 15,
+        skip_data_sync: bool = False,
     ):
         seed = 1337
         torch.manual_seed(seed)
@@ -132,11 +150,7 @@ class Benchmark_litGPT:
             assert (
                 self.global_batch_size % self.micro_batch_size * world_size == 0
             ), f"Global Batch Size {self.global_batch_size} should be a multiple Micro Batch Size {self.micro_batch_size} * World Size {world_size}."
-            # TODO: Remove when gradient accumulation is ready for benchmarking.
-            if self.gradient_accumulation_steps > 1:
-                print(
-                    f"[WARNING] Gradient Accumulation is not fully supported yet. Benchmarking results may not be accurate. Gradient Accumulation Steps = {self.gradient_accumulation_steps}"
-                )
+        self.skip_data_sync = skip_data_sync
 
         # Profiling Args
         self.nsys_enabled = nsys_enabled
@@ -331,45 +345,52 @@ class Benchmark_litGPT:
             # Setup throughput Collection
             self.throughput = Throughput(window_size=self.max_iters - self.warmup_iter, world_size=world_size)
 
+        if "transformerengine" in self.compile:
+            import transformer_engine.pytorch as te
+
+            te_ctx = te.fp8_autocast
+        else:
+            from contextlib import nullcontext
+
+            te_ctx = nullcontext
+
+        if self.skip_data_sync:
+            data_sync_ctx = self.model.no_sync
+        else:
+            data_sync_ctx = nullcontext
+
         for i in range(self.max_iters):
             iter_t0 = time.perf_counter()
             if i == self.warmup_iter:  # warmup
                 t0 = iter_t0
 
-            for step_idx in range(self.gradient_accumulation_steps):
-                input_ids, targets = next(self.train_data_iter)
-                input_ids = input_ids.to(device=self.device)
-                targets = targets.to(device=self.device)
+            with data_sync_ctx():
+                for step_idx in range(self.gradient_accumulation_steps - 1):
+                    input_ids, targets = next(self.train_data_iter)
+                    input_ids = input_ids.to(device=self.device)
+                    targets = targets.to(device=self.device)
 
-                if self.nsys_enabled and i == self.profiler_start and global_rank in [0, None] and step_idx == 0:
-                    print("=====Start NSYS Profiling======")
-                    torch.cuda.cudart().cudaProfilerStart()
+                    if self.nsys_enabled and i == self.profiler_start and global_rank in [0, None] and step_idx == 0:
+                        print("=====Start NSYS Profiling======")
+                        torch.cuda.cudart().cudaProfilerStart()
 
-                logits = self.model(input_ids)
+                    loss = run_fwd_bwd_one_microbatch(
+                        self.model, input_ids, targets, self.gradient_accumulation_steps, te_ctx
+                    )
 
-                logits = logits.reshape(-1, logits.size(-1))
-                targets = targets.reshape(-1)
-                loss = (
-                    torch.nn.functional.cross_entropy(logits, targets, ignore_index=-1)
-                    / self.gradient_accumulation_steps
-                )
+            input_ids, targets = next(self.train_data_iter)
+            input_ids = input_ids.to(device=self.device)
+            targets = targets.to(device=self.device)
+            loss = run_fwd_bwd_one_microbatch(self.model, input_ids, targets, self.gradient_accumulation_steps, te_ctx)
 
-                loss.backward()
+            # Simple Gradient Accumulation Implementation
+            if (step_idx + 1) % self.gradient_accumulation_steps == 0:
+                self.optimizer.step()
+                self.optimizer.zero_grad(set_to_none=True)
 
-                # Simple Gradient Accumulation Implementation
-                if (step_idx + 1) % self.gradient_accumulation_steps == 0:
-                    self.optimizer.step()
-                    self.optimizer.zero_grad(set_to_none=True)
-
-                # torch.cuda.synchronize()
-                if (
-                    self.nsys_enabled
-                    and i == self.profiler_stop
-                    and global_rank in [0, None]
-                    and ((step_idx + 1) % self.gradient_accumulation_steps == 0)
-                ):
-                    print("=====Stop NSYS Profiling======")
-                    torch.cuda.cudart().cudaProfilerStop()
+            if self.nsys_enabled and i == self.profiler_stop and global_rank in [0, None]:
+                print("=====Stop NSYS Profiling======")
+                torch.cuda.cudart().cudaProfilerStop()
 
             loss_item = loss.item()  # synchronization
             t1 = time.perf_counter()

--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -384,9 +384,8 @@ class Benchmark_litGPT:
             loss = run_fwd_bwd_one_microbatch(self.model, input_ids, targets, self.gradient_accumulation_steps, te_ctx)
 
             # Simple Gradient Accumulation Implementation
-            if (step_idx + 1) % self.gradient_accumulation_steps == 0:
-                self.optimizer.step()
-                self.optimizer.zero_grad(set_to_none=True)
+            self.optimizer.step()
+            self.optimizer.zero_grad(set_to_none=True)
 
             if self.nsys_enabled and i == self.profiler_stop and global_rank in [0, None]:
                 print("=====Stop NSYS Profiling======")

--- a/thunder/common.py
+++ b/thunder/common.py
@@ -674,10 +674,10 @@ def _create_callable(
             )
             autocast_thunder_dtype = autocast_cpu_dtype if torch.is_autocast_cpu_enabled() else autocast_gpu_dtype
 
-        # TODO(crcrpar): support FSDP as well
         is_ddp_enabled = getattr(cd.fn, "use_ddp", False)
+        is_fsdp_enabled = getattr(cd.fn, "use_fsdp", False)
         no_grad_sync = False
-        if is_ddp_enabled:
+        if is_ddp_enabled or is_fsdp_enabled:
             from thunder.distributed import get_skip_data_parallel_grad_sync
 
             no_grad_sync = get_skip_data_parallel_grad_sync()

--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -574,17 +574,7 @@ class GeneralJitCtx(MinimalCtx):
             # TensorProxy attributes should be considered derived quantities, so we flag TensorProxies here
             value.provenance.ext_flag |= EXT_FLAG_IS_TENSOR_PROXY
 
-            from thunder.core import utils
-            from thunder.distributed import get_skip_data_parallel_grad_sync
-
-            no_sync = get_skip_data_parallel_grad_sync()
-            compile_data = get_compile_data()
-            utils.check(
-                not (no_sync and getattr(compile_data, "use_fsdp", False)),
-                lambda: "`thunder.distributed.fsdp` does not support `no_sync`",
-            )
-
-            if not no_sync and isinstance(p, TensorProxy) and p.ddp_type in (DDPType.REPLICATED, DDPType.FULLY_SHARDED):
+            if isinstance(p, TensorProxy) and p.ddp_type in (DDPType.REPLICATED, DDPType.FULLY_SHARDED):
                 p_new = thunder.distributed.prims.synchronize(p, self._process_group_for_ddp)
                 p_orig = p
                 p = p_new

--- a/thunder/distributed/__init__.py
+++ b/thunder/distributed/__init__.py
@@ -84,9 +84,10 @@ def _sync_grads(module: torch.nn.Module) -> None:
             f"Expected `{type(module).__name__}` to have been jitted or to contain a `process_group_for_ddp` attribute"
         )
 
-    process_group: ProcessGroup = thunder.compile_data(module).process_group_for_ddp
     if getattr(module, "use_ddp", False):
         params_with_grad = [p for p in module.parameters() if p.grad is not None]
+        if not params_with_grad:
+            return
         grads = [p.grad for p in params_with_grad]
         torch._foreach_div_(grads, process_group.size())
         with tdist.distributed_c10d._coalescing_manager(group=process_group, async_ops=True) as cm:

--- a/thunder/distributed/prims.py
+++ b/thunder/distributed/prims.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
 from enum import auto, Enum
 from numbers import Number
+from typing import TYPE_CHECKING
 
 import torch.distributed
 
@@ -8,6 +10,9 @@ from thunder.core.prims import make_prim
 
 from thunder.core.proxies import DDPType, FutureTensorProxy, pytype, TensorProxy
 from thunder.core.transforms import register_augmented_forward, register_backward
+
+if TYPE_CHECKING:
+    from thunder.common import CompileData
 
 
 class PrimIDs(Enum):
@@ -23,6 +28,7 @@ class PrimIDs(Enum):
     UNPACK_FOR_FSDP = auto()
     UPDATE_BUCKET_VIEW = auto()
     PACK_FOR_FSDP = auto()
+    STASH_GRAD_FOR_FSDP = auto()
 
 
 # This enum describes what all_reduce (below) will actually do
@@ -244,6 +250,21 @@ def update_bucket_view_meta(tensor: TensorProxy, index_of_dst_view: int, bucket_
     return TensorProxy(like=tensor)
 
 
+# [NOTE - shape of output]
+# `ThunderFunction.backward` replaces outputs of this function with None, so the shape wouldn't matter a lot.
+def stash_grad_for_fsdp_meta(
+    grad: TensorProxy,
+    param_fqn: str,
+    compile_data: CompileData,
+) -> None:
+    from thunder.common import CompileData
+
+    utils.check_type(grad, TensorProxy)
+    utils.check_type(param_fqn, str)
+    utils.check_type(compile_data, CompileData)
+    return TensorProxy(like=grad)
+
+
 all_gather = make_prim(PrimIDs.ALL_GATHER, "all_gather", meta=all_gather_meta)
 all_reduce = make_prim(PrimIDs.ALL_REDUCE, "all_reduce", meta=all_reduce_meta)
 broadcast = make_prim(PrimIDs.BROADCAST, "broadcast", meta=broadcast_meta)
@@ -255,6 +276,11 @@ pack_for_fsdp = make_prim(PrimIDs.PACK_FOR_FSDP, "pack_for_fsdp", meta=pack_for_
 unpack = make_prim(PrimIDs.UNPACK, "unpack", meta=unpack_meta)
 unpack_for_fsdp = make_prim(PrimIDs.UNPACK_FOR_FSDP, "unpack_for_fsdp", meta=unpack_for_fsdp_meta)
 update_bucket_view = make_prim(PrimIDs.UPDATE_BUCKET_VIEW, "update_bucket_view", meta=update_bucket_view_meta)
+stash_grad_for_fsdp = make_prim(
+    PrimIDs.STASH_GRAD_FOR_FSDP,
+    "stash_grad_for_fsdp",
+    meta=stash_grad_for_fsdp_meta,
+)
 
 
 @register_augmented_forward(PrimIDs.SYNCHRONIZE)

--- a/thunder/distributed/prims.py
+++ b/thunder/distributed/prims.py
@@ -252,11 +252,12 @@ def update_bucket_view_meta(tensor: TensorProxy, index_of_dst_view: int, bucket_
 
 # [NOTE - shape of output]
 # `ThunderFunction.backward` replaces outputs of this function with None, so the shape wouldn't matter a lot.
+# TODO(crcrpar): Update this to return `None`
 def stash_grad_for_fsdp_meta(
     grad: TensorProxy,
     param_fqn: str,
     compile_data: CompileData,
-) -> None:
+) -> TensorProxy:
     from thunder.common import CompileData
 
     utils.check_type(grad, TensorProxy)

--- a/thunder/distributed/transforms/fsdp.py
+++ b/thunder/distributed/transforms/fsdp.py
@@ -19,11 +19,13 @@ from thunder.core.pytree import tree_unflatten
 from thunder.core.symbol import BoundSymbol
 from thunder.core.trace import VariableInterface
 from thunder.core.trace import from_trace
+from thunder.core.trace import TraceCtx
 from thunder.core.transforms import VISIT_TYPE
 from thunder.core.transforms import visitor_transform
 from thunder.distributed import FSDPBucketingStrategy
 from thunder.distributed import FSDPType
 from thunder.distributed import get_extract_bucket_name_from_tensor_proxy
+from thunder.distributed import get_skip_data_parallel_grad_sync
 from thunder.distributed.bucketing import FSDPBackwardBucket
 from thunder.distributed.bucketing import FSDPForwardBucket
 from thunder.distributed import prims as dist_prims
@@ -36,8 +38,8 @@ from thunder.executors.torchex import unpack_for_fsdp_prim_impl
 from thunder.executors.torchex import wait_prim_impl
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from thunder import CompileData
-    from thunder.core.trace import TraceCtx
     from thunder.distributed.bucketing import Bucket
 
 
@@ -113,6 +115,73 @@ def create_map_of_before_after_comm(
         return map_from_sharded_to_unsharded, (params_before_comm, params_after_comm)
     else:
         return map_from_sharded_to_unsharded
+
+
+def stash_unsharded_grads_and_return_none_as_grads(
+    fsdp_bwd_trace: TraceCtx,
+    compile_data: CompileData,
+    computation_trc_flat_args: list[Proxy],
+    proxy_name_to_fqn: dict[str, str],
+) -> TraceCtx:
+    """Set or accumulate unsharded grads to ``param._thunder_fsdp_unsharded_grad``
+    This function removes :func:`~thunder.distributed.prims.reduce_scatter`s and following :func:`~thunder.distributed.prims.wait`
+    and inserts :func:`~thunder.distributed.prims.stash_grad_for_fsdp` so that the unsharded gradients are stored and accumulated
+    when :class:`~thunder.ThunderModule` is called in the context of :func:`~thunder.ThunderModule.no_sync`.
+    Args:
+        fsdp_bwd_trace:
+        compile_data:
+        computation_trc_flat_args:
+    Returns:
+        - TraceCtx
+    """
+    producers, consumers = utils.producers_and_consumers(fsdp_bwd_trace)
+    bsyms_of_unsharded_grad_to_index_and_fqn_of_param: dict[BoundSymbol, tuple[int, str]] = {}
+    bsyms_to_skip: dict[BoundSymbol, BoundSymbol] = {}
+
+    flat_outputs, output_spec = tree_flatten(fsdp_bwd_trace.output)
+    for index, output_proxy in enumerate(flat_outputs):
+        if isinstance(output_proxy, TensorProxy):
+            reduce_scatter_bsym = get_bsym_of_reduce_scatter(output_proxy, producers)
+            preaverage_bsym: BoundSymbol = producers[reduce_scatter_bsym.flat_proxy_args[0]]
+            prod_of_unsharded_grad = producers[preaverage_bsym.flat_proxy_args[0]]
+            utils.check(
+                preaverage_bsym.sym.id in {PrimIDs.DIV, "torch.true_divide"},
+                lambda: f"expected to be either of {(PrimIDs.DIV, 'torch.true_divide')} but {preaverage_bsym.sym.id=} for {output_proxy=}",
+            )
+            wait_bsym = consumers[reduce_scatter_bsym.flat_proxy_outs[0]][0]
+
+            bsyms_to_skip[reduce_scatter_bsym] = reduce_scatter_bsym
+            bsyms_to_skip[preaverage_bsym] = preaverage_bsym
+            bsyms_to_skip[wait_bsym] = wait_bsym
+
+            param = computation_trc_flat_args[index]
+            utils.check_type(param, TensorProxy)
+            param_fqn = proxy_name_to_fqn[param.name]
+            bsyms_of_unsharded_grad_to_index_and_fqn_of_param[prod_of_unsharded_grad] = (index, param_fqn)
+
+    index_to_new_grad = {}
+
+    def visit(bsym: BoundSymbol) -> VISIT_TYPE:
+        if bsym in bsyms_to_skip:
+            return VISIT_TYPE.REPLACE
+        elif bsym in bsyms_of_unsharded_grad_to_index_and_fqn_of_param:
+            unsharded_grad = bsym.flat_proxy_outs[0]
+            index, param_fqn = bsyms_of_unsharded_grad_to_index_and_fqn_of_param[bsym]
+            stashed_grad = dist_prims.stash_grad_for_fsdp(unsharded_grad, param_fqn, compile_data)
+            index_to_new_grad[index] = stashed_grad
+            return VISIT_TYPE.INSERT_AFTER
+        elif bsym.sym.id == prims.PrimIDs.RETURN:
+            new_return_args = [index_to_new_grad.get(i, g) for i, g in enumerate(flat_outputs)]
+            prims.python_return(tree_unflatten(new_return_args, output_spec))
+            return VISIT_TYPE.REPLACE
+        else:
+            return VISIT_TYPE.NO_OP
+
+    return visitor_transform(
+        fsdp_bwd_trace,
+        visit,
+        provenance="Trace without grad sync",
+    )
 
 
 @dataclass
@@ -381,6 +450,7 @@ class FSDPCommBucketing:
     def __init__(
         self,
         compile_data: CompileData,
+        computation_trc: TraceCtx | Callable,
     ) -> None:
         self.compile_data = compile_data
         utils.check(
@@ -395,6 +465,37 @@ class FSDPCommBucketing:
         self.group: ProcessGroup = compile_data.fn.process_group_for_ddp
 
         self.requires_bwd_bucketing_allgather = compile_data.fn.sharding_strategy == FSDPType.ZERO3
+
+        # Information for no_sync transform
+        self.computation_trc = computation_trc
+        if not isinstance(self.computation_trc, TraceCtx):
+            import warnings
+
+            warnings.warn("`computation_trc` is not `TraceCtx`")
+            self.computation_trc_flat_args = []
+            self.computation_trc_flat_args_spec = None
+            self.proxy_name_to_fqn = {}
+        else:
+            self.computation_trc_flat_args, self._computation_trc_flat_args_spec = tree_flatten(
+                (self.computation_trc.args, self.computation_trc.kwargs)
+            )
+            rev_fqn_to_proxy_name: dict[str, str] = {}
+            fqn: str
+            for fqn, _ in compile_data.fn.named_parameters():
+                proxy_name = fqn.replace(".", "_")
+                rev_fqn_to_proxy_name[proxy_name] = fqn
+
+            orig_proxy_name_to_fqn: dict[str, str] = {}
+            for proxy_name in tuple(
+                p.name for p in filter(lambda p: isinstance(p, TensorProxy), self.computation_trc_flat_args)
+            ):
+                if proxy_name in rev_fqn_to_proxy_name:
+                    orig_proxy_name_to_fqn[proxy_name] = rev_fqn_to_proxy_name[proxy_name]
+                elif proxy_name.startswith("t_"):
+                    tmp_name = proxy_name[2:]
+                    if tmp_name in rev_fqn_to_proxy_name:
+                        orig_proxy_name_to_fqn[proxy_name] = rev_fqn_to_proxy_name[tmp_name]
+            self.proxy_name_to_fqn = orig_proxy_name_to_fqn
 
     def update_name_set(self, backward_trace: TraceCtx) -> TraceCtx:
         if not self.apply_bucketing:
@@ -620,6 +721,20 @@ class FSDPCommBucketing:
         Returns:
             - :class:`TraceCtx`
         """
+
+        if get_skip_data_parallel_grad_sync():
+            utils.check(
+                self.proxy_name_to_fqn,
+                lambda: f"`computation_trc` passed to the dunder init expected to be a `TraceCtx`",
+            )
+            if self.requires_bwd_bucketing_allgather:
+                fsdp_bwd_trace = self._apply_bucketing_to_backward_all_gather(fsdp_bwd_trace)
+            return stash_unsharded_grads_and_return_none_as_grads(
+                fsdp_bwd_trace,
+                self.compile_data,
+                self.computation_trc_flat_args,
+                self.proxy_name_to_fqn,
+            )
 
         if not self.apply_bucketing:
             return fsdp_bwd_trace

--- a/thunder/distributed/transforms/fsdp.py
+++ b/thunder/distributed/transforms/fsdp.py
@@ -625,6 +625,8 @@ class FSDPCommBucketing:
         return bwd_trace
 
     def _apply_bucketing_to_backward_all_gather(self, fsdp_bwd_trace: TraceCtx) -> TraceCtx:
+        if not self.apply_bucketing:
+            return fsdp_bwd_trace
         fwd_trace_flat_args = self._collect_sharded_parameters(self.fsdp_fwd_trace)
         arg_to_index_in_flat_args = utils.ProxyDict()
         for i, a in enumerate(fwd_trace_flat_args):

--- a/thunder/executors/torch_autograd.py
+++ b/thunder/executors/torch_autograd.py
@@ -56,11 +56,10 @@ class ThunderFunction(torch.autograd.Function):
         # Inside the compiled backward we must clear the saved_tensors_list
         assert not saved_tensors_list, "saved_tensors_list must be empty after calling compiled_backward"
         # TODO(crcrpar): Remove if-else once `dist_prims.stash_grad_for_fsdp` starts to return `None`
-        return (
-            (None, None, None, None, None, *grads)
-            if not ctx.return_none_instead_of_grads
-            else (None, None, None, None, None, *([None] * len(grads)))
-        )
+        # NOTE(crcrpar): In fsdp no-sync, unsharded gradients are attached and accumulated to their parameters as the attr of `_thunder_fsdp_unsharded_grad` in order to avoid shape mismatch of a param and its grad. When exiting the no_sync context, the accumulated, unsharded gradients are reduce-scattered into the attr of `grad` and `_thunder_fsdp_unsharded_grad` is removed.
+        if ctx.return_none_instead_of_grads:
+            return (None, None, None, None, None, *([None] * len(grads)))
+        return (None, None, None, None, None, *grads)
 
 
 def split_forward_backward(computation_trc: TraceCtx, compile_data, compile_stats, /, *flat_args):

--- a/thunder/executors/torch_autograd.py
+++ b/thunder/executors/torch_autograd.py
@@ -53,6 +53,7 @@ class ThunderFunction(torch.autograd.Function):
 
         # Inside the compiled backward we must clear the saved_tensors_list
         assert not saved_tensors_list, "saved_tensors_list must be empty after calling compiled_backward"
+        # TODO(crcrpar): Remove if-else once `dist_prims.stash_grad_for_fsdp` starts to return `None`
         return (
             (None, None, None, None, None, *grads)
             if not ctx.return_none_instead_of_grads

--- a/thunder/executors/torch_autograd.py
+++ b/thunder/executors/torch_autograd.py
@@ -20,8 +20,9 @@ from thunder.core.transform_common import replace_redundant_inputs
 
 class ThunderFunction(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, compiled_backward, saved_tensors, saved_other, flat_output, *flat_args):
+    def forward(ctx, return_none_instead_of_grads, compiled_backward, saved_tensors, saved_other, flat_output, *flat_args):
         # Here we just propagate the tensors through the autograd graph
+        ctx.return_none_instead_of_grads = return_none_instead_of_grads
         ctx.saved_other = saved_other
         ctx.compiled_backward = compiled_backward
 
@@ -52,7 +53,11 @@ class ThunderFunction(torch.autograd.Function):
 
         # Inside the compiled backward we must clear the saved_tensors_list
         assert not saved_tensors_list, "saved_tensors_list must be empty after calling compiled_backward"
-        return (None, None, None, None, *grads)
+        return (
+            (None, None, None, None, None, *grads)
+            if not ctx.return_none_instead_of_grads
+            else (None, None, None, None, None, *([None] * len(grads)))
+        )
 
 
 def split_forward_backward(computation_trc: TraceCtx, compile_data, compile_stats, /, *flat_args):

--- a/thunder/executors/torch_autograd.py
+++ b/thunder/executors/torch_autograd.py
@@ -20,7 +20,9 @@ from thunder.core.transform_common import replace_redundant_inputs
 
 class ThunderFunction(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, return_none_instead_of_grads, compiled_backward, saved_tensors, saved_other, flat_output, *flat_args):
+    def forward(
+        ctx, return_none_instead_of_grads, compiled_backward, saved_tensors, saved_other, flat_output, *flat_args
+    ):
         # Here we just propagate the tensors through the autograd graph
         ctx.return_none_instead_of_grads = return_none_instead_of_grads
         ctx.saved_other = saved_other

--- a/thunder/executors/torch_autograd.py
+++ b/thunder/executors/torch_autograd.py
@@ -114,7 +114,7 @@ def split_forward_backward(computation_trc: TraceCtx, compile_data, compile_stat
 
     _fsdp_comm_bucketing: FSDPCommBucketing | None = None
     if getattr(compile_data.fn, "use_fsdp", False):
-        _fsdp_comm_bucketing = FSDPCommBucketing(compile_data)
+        _fsdp_comm_bucketing = FSDPCommBucketing(compile_data, computation_trc)
         fw_trace = _fsdp_comm_bucketing.apply_bucketing_to_forward_trace(fw_trace, bw_trace.names)
         _fsdp_comm_bucketing.update_name_set(bw_trace)
 

--- a/thunder/executors/torchex.py
+++ b/thunder/executors/torchex.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import operator
 import importlib
 from dataclasses import replace
@@ -6,7 +7,7 @@ from functools import wraps, partial
 from inspect import signature
 from itertools import groupby
 from numbers import Number
-from typing import Union, Any, Tuple, Optional
+from typing import TYPE_CHECKING
 from collections.abc import Callable
 from collections.abc import Hashable, Sequence
 from collections.abc import Sequence
@@ -41,6 +42,9 @@ from thunder.core.transforms import (
     get_grad,
     put_grad,
 )
+
+if TYPE_CHECKING:
+    from thunder.common import CompileData
 
 ex = OperatorExecutor("torch", version=torch.__version__)
 register_executor(ex)
@@ -1892,6 +1896,20 @@ if torch.distributed.is_available():
         views[index_of_dst_view].copy_(tensor)
         return tensor
 
+    def _stash_grad_for_fsdp_prim_impl(
+        grad: torch.Tensor,
+        param_fqn: str,
+        compile_data: CompileData,
+    ) -> None:
+        grad_name = "_thunder_fsdp_unsharded_grad"
+        param = compile_data.fn.get_parameter(param_fqn)
+        if torch.is_tensor(unsharded_grad := getattr(param, grad_name, None)):
+            unsharded_grad += grad
+        else:
+            setattr(param, grad_name, grad)
+
+        return grad
+
     all_gather_prim_impl = ex.register_operator(
         "torch_all_gather_prim_impl", meta=dist_prims.all_gather.meta, fn=_all_gather_prim_impl
     )
@@ -1933,6 +1951,17 @@ if torch.distributed.is_available():
     _register_implementation(
         dist_prims.pack_for_fsdp,
         pack_for_fsdp_prim_impl,
+        checker=_always_executable,
+    )
+
+    stash_grad_for_fsdp_prim_impl = ex.register_operator(
+        "torch_stash_grad_for_fsdp_prim_impl",
+        meta=dist_prims.stash_grad_for_fsdp.meta,
+        fn=_stash_grad_for_fsdp_prim_impl,
+    )
+    _register_implementation(
+        dist_prims.stash_grad_for_fsdp,
+        stash_grad_for_fsdp_prim_impl,
         checker=_always_executable,
     )
 

--- a/thunder/executors/torchex.py
+++ b/thunder/executors/torchex.py
@@ -1896,6 +1896,7 @@ if torch.distributed.is_available():
         views[index_of_dst_view].copy_(tensor)
         return tensor
 
+    # TODO(crcrpar): Update to return None instead
     def _stash_grad_for_fsdp_prim_impl(
         grad: torch.Tensor,
         param_fqn: str,

--- a/thunder/tests/distributed/test_ddp.py
+++ b/thunder/tests/distributed/test_ddp.py
@@ -557,23 +557,21 @@ class CompileDDPTest(DataParallelTestCase):
         self._run_no_sync_grad_accumulation_test(get_model_and_optimizer, is_comm, dataset_size)
 
     @common_utils.parametrize(
-        "executor,bucketing_strategy,fsdptype,dataset_size",
+        "executor,bucketing_strategy,fsdptype",
         product(
             tuple(executors_map.keys()),
-            (FSDPBucketingStrategy.LAYER, FSDPBucketingStrategy.BLOCK),
+            (FSDPBucketingStrategy.BLOCK,),
             (FSDPType.ZERO2, FSDPType.ZERO3),
-            (1, 2),
         ),
-        name_fn=lambda executor, bucketing_strategy, fsdptype, dataset_size: (
-            f"executor_{executor}_bucketing_{str(bucketing_strategy).split('.')[1].lower()}_{(str(fsdptype).lower().split('.')[1])}_dataset_size_{dataset_size}"
+        name_fn=lambda executor, bucketing_strategy, fsdptype: (
+            f"executor_{executor}_bucketing_{str(bucketing_strategy).split('.')[1].lower()}_{(str(fsdptype).lower().split('.')[1])}"
         ),
     )
     def test_fsdp_with_no_sync_grad_accumulation(
         self,
-        executor,
+        executor: str,
         bucketing_strategy: FSDPBucketingStrategy,
         fsdptype: FSDPType,
-        dataset_size: int,
     ):
         from thunder.common import CACHE_OPTIONS
         from thunder.distributed import fsdp
@@ -592,7 +590,7 @@ class CompileDDPTest(DataParallelTestCase):
         def is_comm(k: str) -> bool:
             return "reducescatter" in k or "reduce_scatter" in k
 
-        self._run_no_sync_grad_accumulation_test(get_model_and_optimizer, is_comm, dataset_size)
+        self._run_no_sync_grad_accumulation_test(get_model_and_optimizer, is_comm, dataset_size=2)
 
     def _run_no_sync_grad_accumulation_test(
         self,

--- a/thunder/tests/distributed/test_ddp.py
+++ b/thunder/tests/distributed/test_ddp.py
@@ -8,6 +8,7 @@ import weakref
 from collections.abc import Sequence
 from functools import partial, wraps
 from itertools import product
+from collections.abc import Callable
 
 import pytest
 import torch
@@ -535,11 +536,83 @@ class CompileDDPTest(DataParallelTestCase):
         # the trace should have.
         # For numerical parity, we compare the accumulated gradients with and without `no_sync` and even against gradients without accumulation.
         # If they are different, it'd be impossible to keep replicas identical.
-        from collections import defaultdict
-        from contextlib import nullcontext
         from thunder.common import CACHE_OPTIONS
         from thunder.distributed import ddp
         from thunder.distributed import get_skip_data_parallel_grad_sync
+
+        def get_model_and_optimizer(device):
+            m = ToyModel().to(device)
+            ddp_m = ddp(m, bucket_size_in_mb=bucket_size_in_mb)
+            jitted_ddp_m = thunder.jit(
+                ddp_m,
+                cache_mode=CACHE_OPTIONS.CONSTANT_VALUES,
+                executors=executors_map[executor].executors_list(),
+            )
+            optimizer = torch.optim.SGD(jitted_ddp_m.parameters(), lr=1e-3)
+            return jitted_ddp_m, optimizer
+
+        def is_comm(k: str) -> bool:
+            return "allreduce_" in k or "all_reduce" in k
+
+        self._run_no_sync_grad_accumulation_test(get_model_and_optimizer, is_comm, dataset_size)
+
+    @common_utils.parametrize(
+        "executor,bucketing_strategy,fsdptype,dataset_size",
+        product(
+            tuple(executors_map.keys()),
+            (FSDPBucketingStrategy.LAYER, FSDPBucketingStrategy.BLOCK),
+            (FSDPType.ZERO2, FSDPType.ZERO3),
+            (1, 2),
+        ),
+        name_fn=lambda executor, bucketing_strategy, fsdptype, dataset_size: (
+            f"executor_{executor}_bucketing_{str(bucketing_strategy).split('.')[1].lower()}_{(str(fsdptype).lower().split('.')[1])}_dataset_size_{dataset_size}"
+        ),
+    )
+    def test_fsdp_with_no_sync_grad_accumulation(
+        self,
+        executor,
+        bucketing_strategy: FSDPBucketingStrategy,
+        fsdptype: FSDPType,
+        dataset_size: int,
+    ):
+        from thunder.common import CACHE_OPTIONS
+        from thunder.distributed import fsdp
+
+        def get_model_and_optimizer(device):
+            m = ToyModel().to(device)
+            fsdp_m = fsdp(m, bucketing_strategy=bucketing_strategy, sharding_strategy=fsdptype)
+            jitted_ddp_m = thunder.jit(
+                fsdp_m,
+                cache_mode=CACHE_OPTIONS.CONSTANT_VALUES,
+                executors=executors_map[executor].executors_list(),
+            )
+            optimizer = torch.optim.SGD(jitted_ddp_m.parameters(), lr=1e-3)
+            return jitted_ddp_m, optimizer
+
+        def is_comm(k: str) -> bool:
+            return "reducescatter" in k or "reduce_scatter" in k
+
+        self._run_no_sync_grad_accumulation_test(get_model_and_optimizer, is_comm, dataset_size)
+
+    def _run_no_sync_grad_accumulation_test(
+        self,
+        get_model_and_optimizer: Callable[[torch.device], tuple[torch.nn.Module, torch.optim.Optimizer]],
+        is_comm: Callable[[str], bool],
+        dataset_size,
+    ):
+        from collections import defaultdict
+        from contextlib import nullcontext
+        from thunder.distributed import get_skip_data_parallel_grad_sync
+
+        device = torch.device("cuda", self.rank)
+        batch_size = 128
+        num_micro_batch = 4
+        micro_batch_size = batch_size // num_micro_batch
+        with torch.no_grad():
+            dataloader = [
+                (torch.randn(batch_size, 12, device=device), torch.randn(batch_size, 8, device=device))
+                for _ in range(dataset_size)
+            ]
 
         # TODO(crcrpar): Use `last_traces` to check if allreduce was called, instead of `torch.profiler.profile`
         # See: https://github.com/Lightning-AI/lightning-thunder/pull/1881#issuecomment-1910455732
@@ -552,25 +625,14 @@ class CompileDDPTest(DataParallelTestCase):
                 loss.backward()
 
             keys = tuple([e.key for e in prof.key_averages()])
-            has_allreduce = any(("allreduce_" in k or "all_reduce" in k) for k in keys)
+            has_comms = any(is_comm(k) for k in keys)
             msg = f"{keys=}"
             if get_skip_data_parallel_grad_sync():
-                self.assertFalse(has_allreduce, msg=msg)
+                self.assertFalse(has_comms, msg=msg)
             else:
-                self.assertTrue(has_allreduce, msg=msg)
+                self.assertTrue(has_comms, msg=msg)
 
             return loss
-
-        def get_model_and_optimizer(device):
-            m = ToyModel().to(device)
-            ddp_m = ddp(m, bucket_size_in_mb=bucket_size_in_mb)
-            compiled_ddp_m = thunder.jit(
-                ddp_m,
-                cache_mode=CACHE_OPTIONS.CONSTANT_VALUES,
-                executors=executors_map[executor].executors_list(),
-            )
-            optimizer = torch.optim.SGD(compiled_ddp_m.parameters(), lr=1e-3)
-            return compiled_ddp_m, optimizer
 
         def get_ground_truth_loss_grads(device, dataloader):
             compiled_ddp_m, optimizer = get_model_and_optimizer(device)
@@ -587,30 +649,20 @@ class CompileDDPTest(DataParallelTestCase):
             return initial_state_dict, losses, grads
 
         device = torch.device("cuda", self.rank)
-
-        batch_size = 128
-        num_micro_batch = 4
-        micro_batch_size = batch_size // num_micro_batch
-        with torch.no_grad():
-            dataloader = [
-                (torch.randn(batch_size, 12, device=device), torch.randn(batch_size, 8, device=device))
-                for _ in range(dataset_size)
-            ]
-
         initial_state_dict, ground_truth_losses, ground_truth_grads = get_ground_truth_loss_grads(device, dataloader)
 
         gradients = defaultdict(list)
         for use_no_sync in (True, False):
-            compiled_ddp_m, optimizer = get_model_and_optimizer(device)
-            compiled_ddp_m.load_state_dict(initial_state_dict)
+            jitted_model, optimizer = get_model_and_optimizer(device)
+            jitted_model.load_state_dict(initial_state_dict)
 
             for iter_count, (x, y) in enumerate(dataloader):
                 loss = torch.zeros((), device=device)
-                with compiled_ddp_m.no_sync() if use_no_sync else nullcontext():
+                with jitted_model.no_sync() if use_no_sync else nullcontext():
                     for i in range(num_micro_batch - 1):
                         cur_loss = run_fwd_bwd(
                             iter_count,
-                            compiled_ddp_m,
+                            jitted_model,
                             x[i * micro_batch_size : (i + 1) * micro_batch_size, :],
                             y[i * micro_batch_size : (i + 1) * micro_batch_size, :],
                             num_micro_batch,
@@ -618,12 +670,12 @@ class CompileDDPTest(DataParallelTestCase):
                         with torch.no_grad():
                             loss += cur_loss
                 cur_loss = run_fwd_bwd(
-                    iter_count, compiled_ddp_m, x[-micro_batch_size:, :], y[-micro_batch_size:, :], num_micro_batch
+                    iter_count, jitted_model, x[-micro_batch_size:, :], y[-micro_batch_size:, :], num_micro_batch
                 )
                 with torch.no_grad():
                     loss += cur_loss
                 optimizer.step()
-                gradients[use_no_sync].append([p.grad for p in compiled_ddp_m.parameters() if p.grad is not None])
+                gradients[use_no_sync].append([p.grad for p in jitted_model.parameters() if p.grad is not None])
                 optimizer.zero_grad(set_to_none=True)
 
                 num_expected_caches: int
@@ -631,7 +683,7 @@ class CompileDDPTest(DataParallelTestCase):
                     num_expected_caches = 2
                 else:
                     num_expected_caches = 1
-                self.assertEqual(len(compiled_ddp_m._lc_cs.interpreter_cache), num_expected_caches)
+                self.assertEqual(len(jitted_model._lc_cs.interpreter_cache), num_expected_caches)
 
                 torch.testing.assert_close(loss, ground_truth_losses[iter_count], atol=1e-4, rtol=1e-4)
                 torch.testing.assert_close(

--- a/thunder/tests/distributed/test_ddp.py
+++ b/thunder/tests/distributed/test_ddp.py
@@ -667,6 +667,10 @@ class CompileDDPTest(DataParallelTestCase):
                         )
                         with torch.no_grad():
                             loss += cur_loss
+                        if use_no_sync and i == 0 and iter_count == 0:
+                            # make sure the backward trace under `no_sync` has actual math computations.
+                            no_sync_bwd_trc = thunder.last_backward_traces(jitted_model)[-1]
+                            self.assertGreater(len(no_sync_bwd_trc.bound_symbols), 1)
                 cur_loss = run_fwd_bwd(
                     iter_count, jitted_model, x[-micro_batch_size:, :], y[-micro_batch_size:, :], num_micro_batch
                 )


### PR DESCRIPTION
## tldr

Enables `no_sync` for `thunder.jit(thunder.distributed.fsdp(model))`. The accompanied changes are:
- new argument of `return_none_instead_of_grads` of `ThunderFunction.forward`
  - This could be eliminated once a `TraceCtx`'s bound symbols are not deleted even if it just returns one or more `None`s
- removal of `no_sync` check before applying `dist_prims.synchronize` to args and kwargs
  - FSDP's forward needs this prim for its param AllGather
  - [ddp] `visitor_transform` removes `dist_prims.all_reduce`, `dist_prims.wait`, and preaveraging when `no_sync`
  - [fsdp] `visitor_transform` removes comms and puts `dist_prims.stash_grad_for_fsdp` and optional param `AllGather` when `no_sync`
    - The generated trace and its executable python code return unsynchronized unsharded gradients.
    - The prim's implementation accumulates the grads as `param._thunder_fsdp_unsharded_grad`.
    - `ThunderFunction`'s `backward` returns `None`s instead of such grads to avoid shape mismatch between params and unsharded grads.

---

as of https://github.com/Lightning-AI/lightning-thunder/pull/45/commits/fa61c49c480bfc16536f0575a81d76c873513f5d

- llama-2-7b-hf
- world size 8 H100s
- micro batch size 1
- global batch size 32
- gradient accumulation 4
- no bucketing (of AllGather and ReduceScatter)

### zero2

command: `torchrun --nproc-per-node=8 thunder/benchmarks/benchmark_litgpt.py --compile=thunder_inductor --distributed_mode=fsdp --nsys_enabled=False --micro_batch_size=1 --global_batch_size=32 --skip_data_sync <false|true> --model_name=Llama-2-7b-hf --shard_mode=zero2 --bucketing_mode=none --json_path "<filename>.json" --return_metrics_as_json=true`

|                         | w/ `no_sync` | w/o `no_sync` |
|-------------------------|--------------|---------------|
| tokens/sec              | 82713.0      | 80341.0       |
| memory consumption [GB] | 65.6         | 40.3          |

### zero3

command: `torchrun --nproc-per-node=8 thunder/benchmarks/benchmark_litgpt.py --compile=thunder_inductor --distributed_mode=fsdp --nsys_enabled=False --micro_batch_size=1 --global_batch_size=32 --skip_data_sync <false|true> --model_name=Llama-2-7b-hf --shard_mode=zero3 --bucketing_mode=none --json_path "<filename>.json" --return_metrics_as_json=true`

|                         | w/ `no_sync` | w/o `no_sync` |
|-------------------------|--------------|---------------|
| tokens/sec              | 77839.0      | 75511.9       |
| memory consumption [GB] | 52.5         | 27.1          |