### PR TITLE
Make cudnnex tests deterministic.

### DIFF
--- a/thunder/tests/test_cudnn_executor.py
+++ b/thunder/tests/test_cudnn_executor.py
@@ -34,13 +34,10 @@ def grad_scaled_dot_product_attention_reference_generator(op, device, dtype, req
 
     n_head = 2
     N = 8  # batch size
-
     L = 640  # query's sequence length
-
-    alignment_factor = 8
-    S = 10 * alignment_factor  # key/value's sequence length
-    E = 16 * alignment_factor  # query/key's embedding size
-    Ev = 16 * alignment_factor  # value's embedding size
+    S = 80  # key/value's sequence length
+    E = 128  # query/key's embedding size
+    Ev = 64  # value's embedding size
 
     # 4-dim (multiheaded) causal cases
     q, k, v = make(N, n_head, L, E), make(N, n_head, S, E), make(N, n_head, S, Ev)

--- a/thunder/tests/test_cudnn_executor.py
+++ b/thunder/tests/test_cudnn_executor.py
@@ -1,4 +1,3 @@
-import random
 from functools import partial
 from typing import Any
 
@@ -36,13 +35,12 @@ def grad_scaled_dot_product_attention_reference_generator(op, device, dtype, req
     n_head = 2
     N = 8  # batch size
 
-    # TODO: multiple of 8 seems to produce NaNs
-    L = random.randint(1, 10) * 64  # query's sequence length
+    L = 640  # query's sequence length
 
     alignment_factor = 8
-    S = random.randint(1, 10) * alignment_factor  # key/value's sequence length
-    E = random.randint(8, 16) * alignment_factor  # query/key's embedding size
-    Ev = random.randint(8, 16) * alignment_factor  # value's embedding size
+    S = 10 * alignment_factor  # key/value's sequence length
+    E = 16 * alignment_factor  # query/key's embedding size
+    Ev = 16 * alignment_factor  # value's embedding size
 
     # 4-dim (multiheaded) causal cases
     q, k, v = make(N, n_head, L, E), make(N, n_head, S, E), make(N, n_head, S, Ev)


### PR DESCRIPTION
**If** we really want to cover multiple configs in the current randomization ranges, we should sweep the range instead of randomly picking one.