### PR TITLE
Break all long lines, not just the first

### DIFF
--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -625,7 +625,7 @@ def unpack_trivial_printer(
     )
 
     result_str = "_" if bsym.output is None else f"{codeutils.prettyprint(out_printables, with_type=True)}"
-    s = f"# {result_str} {'(unused)' if bsym.output is None else ''}"
+    s = f"# {result_str}{' (unused)' if bsym.output is None else ''}"
     return s
 
 
@@ -741,6 +741,7 @@ def _make_parts_into_line_or_lines(parts: list[str], out: list[str] | None = Non
         if pos and pos + len(p) > 80:
             lines.append("".join(line_parts) + "\\")
             line_parts = []
+            pos = 0
         line_parts.append(p)
         pos += len(p)
 


### PR DESCRIPTION
## What does this PR do?

Follow-up to #42

Before:

```python
def backward_fn(saved_for_backward, cotangents):
  # saved_for_backward: "Collection" 
  # cotangents: "Collection" 
  C0, C1, = saved_for_backward
  clear_collection(saved_for_backward)
  del saved_for_backward
  t178, = cotangents
  clear_collection(cotangents)
  del cotangents
  t0, t101, t104, t105, t114, t136, t138, t139, t140, t141, t142, t144, t146, \
  t15, \
  t152, \
  t155, \
  t156, \
  t157, \
  t158, \
  t16, \
  t164, \
  t166, \
  t17, \
  t172, \
  t175, \
  t176, \
  t18, \
  t24, \
  t3, \
  t30, \
  t33, \
  t34, \
  t4, \
  t43, \
  t49, \
  t5, \
  t51, \
  t6, \
  t65, \
  t67, \
  t68, \
  t69, \
  t7, \
  t70, \
  t71, \
  t73, \
  t75, \
  t8, \
  t81, \
  t84, \
  t85, \
  t86, \
  t87, \
  t9, \
  t93, \
  t95, \
  = C0
```

After:

```python
def backward_fn(saved_for_backward, cotangents):
  # saved_for_backward: "Collection"
  # cotangents: "Collection"
  C0, C1, = saved_for_backward
  clear_collection(saved_for_backward)
  del saved_for_backward
  t178, = cotangents
  clear_collection(cotangents)
  del cotangents
  t0, t101, t104, t105, t114, t136, t138, t139, t140, t141, t142, t144, t146, \
  t15, t152, t155, t156, t157, t158, t16, t164, t166, t17, t172, t175, t176, t18, \
  t24, t3, t30, t33, t34, t4, t43, t49, t5, t51, t6, t65, t67, t68, t69, t7, t70, \
  t71, t73, t75, t8, t81, t84, t85, t86, t87, t9, t93, t95, = C0
  clear_collection(C0)
```

Also included a fix to avoid leaving a trailing whitespace in comments:

```python
def backward_fn(saved_for_backward, cotangents):
  # saved_for_backward: "Collection"<SPACE_REMOVED>
  # cotangents: "Collection"<SPACE_REMOVED>
  ...
```