### PR TITLE
Error on `torch` functions which are not part of the `ltorch`

### DIFF
--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -912,11 +912,15 @@ def general_jit_lookaside(fn, *args, **kwargs) -> None | Callable:
             # Torch functions have __name__ defined
             fn_name = f"{fn.__module__}.{fn.__name__}"
 
-            # For now, only torch-like opaque functions are sharp edges
-            return _general_jit_sharp_edge(
-                f"Trying to call function {fn_name}, but it's unsupported. Please file an issue requesting support.",
-                None,
-            )
+            # Probably merge with sharp edges
+            calling_opaque_torch_msg = f"Trying to call function {fn_name}, but it is not yet supported. " \
+                                           "Please file an issue requesting support. " \
+                                           "To find out which operations are not yet recongnized by `thunder.jit`, " \
+                                           "please run `examine` as per:\n\n" \
+                                           "from thunder.examine import examine\n" \
+                                           "examine(<your thunder.jit callable argument>, ...)\n"
+
+            return do_raise(NotImplementedError(calling_opaque_torch_msg))
 
     return lookaside
 

--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -913,12 +913,14 @@ def general_jit_lookaside(fn, *args, **kwargs) -> None | Callable:
             fn_name = f"{fn.__module__}.{fn.__name__}"
 
             # Probably merge with sharp edges
-            calling_opaque_torch_msg = f"Trying to call function {fn_name}, but it is not yet supported. " \
-                                           "Please file an issue requesting support. " \
-                                           "To find out which operations are not yet recongnized by `thunder.jit`, " \
-                                           "please run `examine` as per:\n\n" \
-                                           "from thunder.examine import examine\n" \
-                                           "examine(<your thunder.jit callable argument>, ...)\n"
+            calling_opaque_torch_msg = (
+                f"Trying to call function {fn_name}, but it is not yet supported. "
+                "Please file an issue requesting support. "
+                "To find out which operations are not yet recongnized by `thunder.jit`, "
+                "please run `examine` as per:\n\n"
+                "from thunder.examine import examine\n"
+                "examine(<your thunder.jit callable argument>, ...)\n"
+            )
 
             return do_raise(NotImplementedError(calling_opaque_torch_msg))
 

--- a/thunder/tests/test_jit_general.py
+++ b/thunder/tests/test_jit_general.py
@@ -50,23 +50,23 @@ def skipif_not_pytorch_2_1(f):
     )(f)
 
 
-def test_jitting_through_opaque_torch_symbols_sharp_edge():
-    def no_sharp_edge(x):
+def test_jitting_through_opaque_torch_symbols_error():
+    def no_error(x):
         # randn_like is in ltorch
         return torch.randn_like(x)
 
-    def sharp_edge(x):
+    def should_error(x):
         # rand_like is not yet in ltroch
         return torch.rand_like(x)
 
     x = torch.rand(1)
 
-    jno_sharp_edge = thunder.jit(no_sharp_edge, sharp_edges="error")
-    jno_sharp_edge(x)
+    jno_error = thunder.jit(no_error)
+    jno_error(x)
 
-    jsharp_edge = thunder.jit(sharp_edge, sharp_edges="error")
-    with pytest.raises(JITSharpEdgeError):
-        jsharp_edge(x)
+    jshould_error = thunder.jit(should_error)
+    with pytest.raises(NotImplementedError):
+        jshould_error(x)
 
 
 def test_binary_add_tensors():
@@ -613,7 +613,7 @@ def test_nanogpt():
         "falcon-7b-like",
         "falcon-40b-like",
         "codellama2-like",
-        pytest.param("mixtral-like", marks=pytest.mark.xfail(raises=TypeError, reason="topk", strict=True)),
+        pytest.param("mixtral-like", marks=pytest.mark.xfail(raises=NotImplementedError, reason="topk", strict=True)),
     ),
 )
 @pytest.mark.parametrize(
@@ -662,7 +662,7 @@ def test_litgpt_variants(name, device):
         "falcon-7b-like",
         "falcon-40b-like",
         "codellama2-like",
-        pytest.param("mixtral-like", marks=pytest.mark.xfail(raises=TypeError, reason="topk", strict=True)),
+        pytest.param("mixtral-like", marks=pytest.mark.xfail(raises=NotImplementedError, reason="topk", strict=True)),
     ),
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
As per title. We error and recommending using `thunder.examine.examine` for checking support.
