### PR TITLE
Preserve parameter names in the torch autograd path

### DIFF
--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -3802,7 +3802,7 @@ def forward_and_backward_from_trace(trace: Trace, torch_autograd=False) -> Forwa
     # Copy the signature of the original function so that the arguments are
     # named correctly in the augmented forward pass instead of being named
     # "args" and "kwargs".
-    augmented_forward_fn.__signature__ = inspect.signature(trace.fn)
+    augmented_forward_fn.__signature__ = inspect.signature(trace.fn or trace.python_callable())
 
     def ones_like(x):
         if isinstance(x, TensorProxy):

--- a/thunder/executors/torch_autograd.py
+++ b/thunder/executors/torch_autograd.py
@@ -202,7 +202,7 @@ def split_forward_backward(computation_trc, compile_data, compile_stats, /, *arg
     if not any(requires_grad_mask):
         raise RuntimeError("PyTorch's Autograd interface requires at least one tensor input with requires_grad=True")
 
-    primal_trace = make_trace(func)(*args, **kwargs)
+    primal_trace = make_trace(func)(*args, **kwargs) if not compile_data.using_jit else computation_trc
     primal_trace = sort_data_parallel_syncs(primal_trace)
 
     if compile_stats is not None:


### PR DESCRIPTION
Currently, FSDP bucketing relies on parameter names to determine parameters coming from the same nn.Module and group them together. If we don't preserve parameter names, then bucketing is broken. This PR fixes that and adds a test.