### PR TITLE
Fix TransformerEngine grad transform

### DIFF
--- a/thunder/executors/transformer_engineex.py
+++ b/thunder/executors/transformer_engineex.py
@@ -19,6 +19,7 @@ import thunder.core.devices as devices
 import thunder.core.prims as prims
 from thunder.core.proxies import TensorProxy, CollectionProxy
 from thunder.core.symbol import Symbol
+from thunder.core.vjp_utils import disable_caching_split_forward_and_backward
 from thunder.extend import OperatorExecutor, register_executor
 from thunder.core.langctxs import langctx, Languages
 
@@ -412,6 +413,7 @@ def _linear_transform(a: TensorProxy, w: TensorProxy, b: TensorProxy) -> torch.T
     return _create_fp8_linear_bound_symbol(a, w, b, is_grad_enabled=False)
 
 
+@disable_caching_split_forward_and_backward
 def _linear_grad(a: TensorProxy, w: TensorProxy, b: TensorProxy) -> TensorProxy:
     out, saved_for_backward = linear_forwad_rule(a, w, b)
     g = prims.get_grad(out)

--- a/thunder/tests/test_transformer_engine_executor.py
+++ b/thunder/tests/test_transformer_engine_executor.py
@@ -33,7 +33,7 @@ def test_te_linear_forward_backward():
     # TE inputs (3D input)
     x_te = torch.randn(3, 768, 4096, device=device, dtype=dtype, requires_grad=True)
     te_linear1 = te.Linear(4096, 4096, params_dtype=dtype)
-    te_linear2 = te.Linear(4096, 2048, params_dtype=dtype)
+    te_linear2 = te.Linear(4096, 4096, params_dtype=dtype)
 
     # thunder inputs
     x = x_te.detach().clone()


### PR DESCRIPTION
Today we split `grad_transform` into forward and backward with https://github.com/Lightning-AI/lightning-thunder/blob/bdf5c3fe360a7cbaf6c1cc68eba91631e55ed190/thunder/core/vjp_utils.py#L18-L36

It has built-in caching which is meant to speed up the initial trace construction, but this caching assumes the result of the split is only dependent on input metadata. This is not true in the case of TransformerEngine which creates its own BoundSymbol on the fly for each call to the grad transform, this new bound symbol must be unique and not cached because it holds a state related to fp8 scaling.
This PR introduces a skip path to disable caching when needed.

**Test plan:**
Modified test case fails on main and passes on this PR. 

Fixes https://github.com/Lightning-AI/lightning-thunder/issues/81

cc @kshitij12345 