### PR TITLE
topk: add as a primitive

### DIFF
--- a/thunder/clang/__init__.py
+++ b/thunder/clang/__init__.py
@@ -1914,3 +1914,12 @@ def argmax(a: TensorProxy, /, dim: int | None = None, keepdim: bool | None = Fal
 @clangop()
 def argmin(a: TensorProxy, /, dim: int | None = None, keepdim: bool | None = False):
     return _argmaxmin_helper(prims.argmin, a, dim, keepdim)
+
+
+@clangop()
+def topk(a: TensorLike, /, k: int, dim: int | None = None, largest: bool = True, sorted: bool = True, *, out = None) -> (TensorProxy, TensorProxy):
+    if dim is None:
+        dim = a.ndim - 1 if a.ndim > 0 else 0
+    dim = utils.canonicalize_dim(a.ndim, dim)
+
+    return prims.topk(a, k, dim, bool(largest), bool(sorted), out=out)

--- a/thunder/clang/__init__.py
+++ b/thunder/clang/__init__.py
@@ -1917,7 +1917,9 @@ def argmin(a: TensorProxy, /, dim: int | None = None, keepdim: bool | None = Fal
 
 
 @clangop()
-def topk(a: TensorLike, /, k: int, dim: int | None = None, largest: bool = True, sorted: bool = True, *, out = None) -> (TensorProxy, TensorProxy):
+def topk(
+    a: TensorLike, /, k: int, dim: int | None = None, largest: bool = True, sorted: bool = True, *, out=None
+) -> (TensorProxy, TensorProxy):
     if dim is None:
         dim = a.ndim - 1 if a.ndim > 0 else 0
     dim = utils.canonicalize_dim(a.ndim, dim)

--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -3028,7 +3028,9 @@ def scatter_add_meta(a: TensorProxy, /, index: TensorProxy, value: TensorProxy, 
 scatter_add = make_prim(PrimIDs.SCATTER_ADD, "scatter_add", meta=scatter_add_meta)
 
 
-def topk_meta(a: TensorProxy, /, k: int, dim: int, largest: Number, sorted: Number, *, out: None | TensorProxy) -> (TensorProxy, TensorProxy):
+def topk_meta(
+    a: TensorProxy, /, k: int, dim: int, largest: Number, sorted: Number, *, out: None | TensorProxy
+) -> (TensorProxy, TensorProxy):
     utils.check(
         out is None,
         lambda: "Only `out` which is None is currently supported",
@@ -3040,10 +3042,7 @@ def topk_meta(a: TensorProxy, /, k: int, dim: int, largest: Number, sorted: Numb
     utils.check(pytype(largest) is bool, lambda: f"Expected {largest=} to be a boolean value")
     utils.check(pytype(sorted) is bool, lambda: f"Expected {sorted=} to be a boolean value")
 
-    utils.check(
-        k >= 0 and k <= (a.shape[dim] if a.ndim > 0 else 1),
-        lambda: f"selected index {k=} is out of range"
-    )
+    utils.check(k >= 0 and k <= (a.shape[dim] if a.ndim > 0 else 1), lambda: f"selected index {k=} is out of range")
 
     new_shape = a.shape
     if a.ndim > 0:

--- a/thunder/executors/torchex.py
+++ b/thunder/executors/torchex.py
@@ -1009,6 +1009,7 @@ var = _register_torch_operation("var")
 var_mean = _register_torch_operation("var_mean")
 argmax = _register_torch_operation("argmax")
 argmin = _register_torch_operation("argmin")
+topk = _register_torch_operation("topk")
 
 
 # NOTE The following transforms are necessary because thunder uses the parameter name 'dims' while PyTorch
@@ -1052,6 +1053,23 @@ def _argmax_transform(a: TensorProxy, /, dim: int):
 def _argmin_transform(a: TensorProxy, /, dim: int):
     return argmin(a, dim)
 
+# NOTE This transform translates number proxies to boolean values
+# and handles dim = None
+def _topk_transform(
+    a: TensorProxy,
+    /,
+    k: int,
+    dim: int | None = None,
+    largest: Number = 1,
+    sorted: Number = 1,
+    *,
+    out = None
+):
+    if dim is None:
+        dim = a.ndim - 1 if a.ndim > 0 else 0
+
+    return topk(a, k, dim, bool(largest), bool(sorted), out=out)
+
 
 _register_implementation(prims.amax, checker=_always_executable, execution_transform=_amax_prim_transform)
 _register_implementation(prims.amin, checker=_always_executable, execution_transform=_amin_prim_transform)
@@ -1061,6 +1079,7 @@ _register_implementation(prims.var, checker=_always_executable, execution_transf
 _register_implementation(prims.var_mean, checker=_always_executable, execution_transform=_var_mean_prim_transform)
 _register_implementation(prims.argmax, checker=_always_executable, execution_transform=_argmax_transform)
 _register_implementation(prims.argmin, checker=_always_executable, execution_transform=_argmin_transform)
+_register_implementation(prims.topk, checker=_always_executable, execution_transform=_topk_transform)
 
 _register_implementation(ltorch.amax, amax, checker=_always_executable)
 _register_implementation(ltorch.amin, amin, checker=_always_executable)
@@ -1072,6 +1091,7 @@ _register_implementation(ltorch.var, var, checker=_always_executable)
 _register_implementation(ltorch.var_mean, var_mean, checker=_always_executable)
 _register_implementation(ltorch.argmax, argmax, checker=_always_executable)
 _register_implementation(ltorch.argmin, argmin, checker=_always_executable)
+_register_implementation(ltorch.topk, topk, checker=_always_executable, execution_transform=_topk_transform)
 
 #
 # Scatter and gather operations

--- a/thunder/executors/torchex.py
+++ b/thunder/executors/torchex.py
@@ -1053,17 +1053,11 @@ def _argmax_transform(a: TensorProxy, /, dim: int):
 def _argmin_transform(a: TensorProxy, /, dim: int):
     return argmin(a, dim)
 
+
 # NOTE This transform translates number proxies to boolean values
 # and handles dim = None
 def _topk_transform(
-    a: TensorProxy,
-    /,
-    k: int,
-    dim: int | None = None,
-    largest: Number = 1,
-    sorted: Number = 1,
-    *,
-    out = None
+    a: TensorProxy, /, k: int, dim: int | None = None, largest: Number = 1, sorted: Number = 1, *, out=None
 ):
     if dim is None:
         dim = a.ndim - 1 if a.ndim > 0 else 0

--- a/thunder/tests/test_jit_general.py
+++ b/thunder/tests/test_jit_general.py
@@ -613,7 +613,7 @@ def test_nanogpt():
         "falcon-7b-like",
         "falcon-40b-like",
         "codellama2-like",
-        pytest.param("mixtral-like", marks=pytest.mark.xfail(raises=NotImplementedError, reason="topk", strict=True)),
+        pytest.param("mixtral-like", marks=pytest.mark.xfail(raises=TypeError, reason="topk", strict=True)),
     ),
 )
 @pytest.mark.parametrize(
@@ -662,7 +662,7 @@ def test_litgpt_variants(name, device):
         "falcon-7b-like",
         "falcon-40b-like",
         "codellama2-like",
-        pytest.param("mixtral-like", marks=pytest.mark.xfail(raises=NotImplementedError, reason="topk", strict=True)),
+        pytest.param("mixtral-like", marks=pytest.mark.xfail(raises=TypeError, reason="topk", strict=True)),
     ),
 )
 @pytest.mark.parametrize(

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -1797,6 +1797,11 @@ def argmin(a: TensorLike, /, dim: int | None = None, keepdim: bool | None = Fals
     return clang.argmin(a, dim, keepdim)
 
 
+@torchsymbol(torch.topk, is_method=True)
+def topk(a: TensorLike, /,  k: int, dim: None | int = None, largest: bool = True, sorted: bool = True, *, out = None) -> (TensorLike, TensorLike):
+    return clang.topk(a, k, dim, largest, sorted, out=out)
+
+
 #
 # Scatter and gather-related operations
 #

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -1798,7 +1798,9 @@ def argmin(a: TensorLike, /, dim: int | None = None, keepdim: bool | None = Fals
 
 
 @torchsymbol(torch.topk, is_method=True)
-def topk(a: TensorLike, /,  k: int, dim: None | int = None, largest: bool = True, sorted: bool = True, *, out = None) -> (TensorLike, TensorLike):
+def topk(
+    a: TensorLike, /, k: int, dim: None | int = None, largest: bool = True, sorted: bool = True, *, out=None
+) -> (TensorLike, TensorLike):
     return clang.topk(a, k, dim, largest, sorted, out=out)
 
 


### PR DESCRIPTION
As per title. The underlying PyTorch implementation is not trivial, so it is best to model this op as a prim.

There are still some to be done follow-ups to make the op functional and useful. These are:
- backward support
- named tuple wrap so that `indices` and `values` are accessible in the jit. Currently, these are not supported and these could be accessed only with indices.
