### PR TITLE
[ddp] in-place AllReduce of Grad Buckets (PR#2333)

### DIFF
--- a/thunder/distributed/bucketing.py
+++ b/thunder/distributed/bucketing.py
@@ -140,7 +140,7 @@ class GradBuckets:
                 dist_prims.DistributedReduceOps.SUM,
                 group=group,
                 do_async=True,
-                skip_clone=False,
+                skip_clone=True,
             )
 
     def tell(self, grad: TensorProxy, group: ProcessGroup) -> None:

--- a/thunder/executors/torchex.py
+++ b/thunder/executors/torchex.py
@@ -1600,7 +1600,9 @@ if torch.distributed.is_available():
         tensors: list[torch.Tensor],
         bucket_key: str,
     ) -> list[torch.Tensor]:
-        return torch._utils._unflatten_dense_tensors(buffer, tensors)
+        _, views = _key_to_bucket_and_views[bucket_key]
+        torch._foreach_copy_(tensors, views, non_blocking=True)
+        return tensors
 
     # TODO(crcrpar): Make this compatible with the torch.compile executor as it's doing really well for cat and reshape.
     # NOTE(crcrpar): why no caching/resue of buffer?


### PR DESCRIPTION
## tldr
Skipping `Tensor.clone` inside of [`_all_reduce_prim_impl`](https://github.com/Lightning-AI/lightning-thunder/blob/1222864529cf6a8e43803c03f98f6697959ffdb0/thunder/executors/torchex.py#L1512-L1532) even when bucketing is enabled.

This would let us
- increase batch size
- try [NCCL's User Buffer Registration](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/usage/bufferreg.html#user-buffer-registration)

## Changes
The major difference, besides clone skip, from the current main branch is that in this branch `unpack` does D2D copy from a bucket to its gradient tensors while not in main. This is because in main a bucket, i.e., the input to `dist_prims.all_reduce` is cloned so that `unpack` can just be slice and reshape.
The target branch has `Tensor.clone()`s before AllReduce but this branch has `torch._foreach_copy_(grads, views)` after AllReduce.

## benchmark

For both gpt2-xl and open_llama_3b, while the perf is not that improved with the setup mentioned below, memory footprint is better with this pr.

- main: 1222864529cf6a8e43803c03f98f6697959ffdb0
- pr: 79619daae1c236cdf444e74dc1d9861610800078
- torch: 2.4.0a0+gitb70899
- 2 H100s

### gpt2-xl
| bucket size | branch          | perf | peak allocated memory | peak reserved memory |
|-------------|-----------------|------------|------------|------------|
| 0MB         | main            | 8.55e+04μs | 11200.00MB | 11840.00MB |
| 0MB         | pr              | 8.54e+04μs | 11200.00MB | 11792.00MB |
| 25MB        | main            | 8.15e+04μs | 14374.65MB | 18054.00MB |
| 25MB        | pr              | 8.21e+04μs | 14369.90MB | 15130.00MB |
| 512MB       | main            | 7.90e+04μs | 14326.08MB | 17858.00MB |
| 512MB       | pr              | 7.90e+04μs | 14326.08MB | 14924.00MB |

### open_llama_3b
| bucket size | branch          | perf | peak allocated memory | peak reserved memory |
|-------------|-----------------|------------|------------|------------|
| 0MB         | main            | 1.34e+05μs | 14537.00MB | 21294.00MB |
| 0MB         | pr              | 1.34e+05μs | 14534.70MB | 21106.00MB |
| 25MB        | main            | 1.45e+05μs | 26728.43MB | 34590.00MB |
| 25MB        | pr              | 1.48e+05μs | 21074.31MB | 27960.00MB |
| 512MB       | main            | 1.49e+05μs | 26737.56MB | 35030.00MB |
| 512MB       | pr              | 1.48e+05μs | 21080.05MB | 27980.00MB |
