### PR TITLE
Relax erroring on calling torch functions without thunder equivalents

### DIFF
--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -907,11 +907,11 @@ def general_jit_lookaside(fn, *args, **kwargs) -> None | Callable:
 
         has_tensor_arg = False
         for a in args:
-            if isinstance(a, TensorProxy):
+            if isinstance(a.value, TensorProxy):
                 has_tensor_arg = True
                 break
-            if isinstance(a, Sequence):
-                if any(isinstance(i, TensorProxy) for i in a):
+            if isinstance(a.value, Sequence):
+                if any(isinstance(i, TensorProxy) for i in a.value):
                     has_tensor_arg = True
                     break
 

--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -905,7 +905,17 @@ def general_jit_lookaside(fn, *args, **kwargs) -> None | Callable:
         def is_from_torch(fn):
             return hasattr(fn, "__module__") and fn.__module__ and fn.__module__.startswith("torch")
 
-        if is_opaque(fn) and is_from_torch(fn):
+        has_tensor_arg = False
+        for a in args:
+            if isinstance(a, TensorProxy):
+                has_tensor_arg = True
+                break
+            if isinstance(a, Sequence):
+                if any(isinstance(i, TensorProxy) for i in a):
+                    has_tensor_arg = True
+                    break
+
+        if is_opaque(fn) and is_from_torch(fn) and has_tensor_arg:
             if fn.__module__.startswith("torch._C"):
                 return lookaside
 

--- a/thunder/tests/test_jit_general.py
+++ b/thunder/tests/test_jit_general.py
@@ -467,6 +467,14 @@ def test_lookaside_bool():
     assert_close(expected, actual)
 
 
+# see https://github.com/Lightning-AI/lightning-thunder/issues/95
+def test_get_default_dtype():
+    def foo():
+        return torch.get_default_dtype()
+
+    assert foo() == thunder.jit(foo)()
+
+
 @pytest.mark.parametrize(
     "device",
     ("cpu", "cuda"),


### PR DESCRIPTION
Some functions are actually OK, so we leave those alone.

Fixes #95 