### PR TITLE
[test_ddp] Make check a bit more strict for `test_rematerialize_allgather`

### DIFF
--- a/thunder/tests/distributed/test_ddp.py
+++ b/thunder/tests/distributed/test_ddp.py
@@ -504,16 +504,16 @@ class CompileDDPTest(DataParallelTestCase):
         # TODO: this is not stable w.r.t. details of the processing, the sharded correspond to ("t_net1_weight", "t_net2_weight")
         #       in the original trace and are inputs to all_gather, the unshard are the outputs fo the corresponding wait
         #       If you fix this to be dynamically discerned, you'll be my hero.
-        sharded_param_names = ("t3", "t4")
-        unshard_param_names = ("t10", "t21")
+        sharded_param_names = ("t_net1_weight", "t_net2_weight")
+        # t1, t3, t5 and t16 are all-gather'ed t_net1_bias, t_net2_bias, t_net1_weight and t_net2_weight, respectively.
+        unshard_param_names = ("t1", "t3", "t5", "t16")
         result_saved_for_bwd = [x.name for x in fwd_trc.bound_symbols[-1].args[1][0]]
         self.assertTrue(all(t not in sharded_param_names for t in result_saved_for_bwd))
-        # todo/fixme: Investigate why the following assertion is failing
-        # self.assertTrue(all(t in result_saved_for_bwd for t in unshard_param_names))
+        # NOTE(crcrpar): It seems something changed so that `all` is not working, `any` can
+        self.assertTrue(any(t in result_saved_for_bwd for t in unshard_param_names))
 
         result_saved_for_bwd = [x.name for x in result_fwd_trc.bound_symbols[-1].args[1][0]]
-        # todo/fixme: Investigate why the following assertion is failing
-        # self.assertTrue(all(t in result_saved_for_bwd for t in sharded_param_names))
+        self.assertTrue(all(t in result_saved_for_bwd for t in sharded_param_names))
         self.assertTrue(all(t not in unshard_param_names for t in result_saved_for_bwd))
 
         # check allgather is inserted in backward trace

--- a/thunder/tests/distributed/test_ddp.py
+++ b/thunder/tests/distributed/test_ddp.py
@@ -505,12 +505,11 @@ class CompileDDPTest(DataParallelTestCase):
         #       in the original trace and are inputs to all_gather, the unshard are the outputs fo the corresponding wait
         #       If you fix this to be dynamically discerned, you'll be my hero.
         sharded_param_names = ("t_net1_weight", "t_net2_weight")
-        # t1, t3, t5 and t16 are all-gather'ed t_net1_bias, t_net2_bias, t_net1_weight and t_net2_weight, respectively.
-        unshard_param_names = ("t1", "t3", "t5", "t16")
+        # t5 and t16 are all-gather'ed t_net1_weight and t_net2_weight, respectively.
+        unshard_param_names = ("t5", "t16")
         result_saved_for_bwd = [x.name for x in fwd_trc.bound_symbols[-1].args[1][0]]
         self.assertTrue(all(t not in sharded_param_names for t in result_saved_for_bwd))
-        # NOTE(crcrpar): It seems something changed so that `all` is not working, `any` can
-        self.assertTrue(any(t in result_saved_for_bwd for t in unshard_param_names))
+        self.assertTrue(all(t in result_saved_for_bwd for t in unshard_param_names))
 
         result_saved_for_bwd = [x.name for x in result_fwd_trc.bound_symbols[-1].args[1][0]]
         self.assertTrue(all(t in result_saved_for_bwd for t in sharded_param_names))


### PR DESCRIPTION
It seems that 2ea1933e2a33c81f3b347dea0493e1064ee3734a has something to do with the test case in question: argument name change from `t_<number>` to `t_<fqn>` and accompanied index changes to tensor proxies.