### PR TITLE
topk: backward implementation

### DIFF
--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -1109,7 +1109,9 @@ register_grad(pids.SUM, _sum_prim_grad)
 
 
 @torchctx
-def _topk_prim_grad(a: TensorProxy, /, k: int, dim: None | int = None, largest: bool = True, sorted: bool = True, *, out=None):
+def _topk_prim_grad(
+    a: TensorProxy, /, k: int, dim: None | int = None, largest: bool = True, sorted: bool = True, *, out=None
+):
     fwd = prims.topk(a, k, dim, largest, sorted, out=out)
     val, idx = fwd
 

--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -4771,6 +4771,8 @@ def topk_thunder_ref(*args, **kwargs):
 
 def topk_torch_ref(*args, **kwargs):
     return torch.topk(*args, **kwargs)[0]
+
+
 # }
 
 

--- a/thunder/tests/test_grad.py
+++ b/thunder/tests/test_grad.py
@@ -1394,8 +1394,8 @@ def test_populate_grads_nanogpt(executor, device, dtype):
 
     from thunder.benchmarks import NanoGPTBenchmark, NanoGPTConfig
 
-    # NOTE Currently setting dropout to zero for reproducibility, other settings taken from gpt2 config
-    config = NanoGPTConfig(dropout=0, n_layer=12, n_head=12, n_embd=768)
+    # NOTE Currently setting dropout to zero for reproducibility
+    config = NanoGPTConfig(dropout=0, n_layer=2, n_head=1, n_embd=64)
 
     bench = NanoGPTBenchmark(config=config, requires_grad=True, device=device, dtype=dtype)
     model = bench.fn()


### PR DESCRIPTION
As per title. Required to unblock testing of some variants of litgpt models.
