### PR TITLE
Fix Tensor indexing with `None`

### DIFF
--- a/thunder/clang/__init__.py
+++ b/thunder/clang/__init__.py
@@ -566,7 +566,7 @@ def _basic_indexing(a: TensorLike, /, key) -> TensorLike:
     specified_slices = 0
     ellipsis_idx = None
 
-    if isinstance(key, (Number, slice, EllipsisType)):
+    if key is None or isinstance(key, (Number, slice, EllipsisType)):
         key = (key,)
 
     for idx, x in enumerate(key):

--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -3128,7 +3128,7 @@ def getitem_sample_generator(op, device, dtype, requires_grad, **kwargs):
         # NOTE: nvfuser cannot handle more than 8 dims.
         ((1, 5, 3), (None, 0, None, 2, ..., None, None)),
         ((1, 5, 3), (None, None, 0, None, 2, ..., None, None)),
-        ((1, 5, 3), (None,)),
+        ((1, 5, 3), None),
         # Addtl. cases
         # NOTE: nvfuser cannot handle more than 8 dims.
         ((7, 9, 5), (slice(2, 6, 2), None, ..., slice(3, 7), None, 2, None)),

--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -3128,6 +3128,7 @@ def getitem_sample_generator(op, device, dtype, requires_grad, **kwargs):
         # NOTE: nvfuser cannot handle more than 8 dims.
         ((1, 5, 3), (None, 0, None, 2, ..., None, None)),
         ((1, 5, 3), (None, None, 0, None, 2, ..., None, None)),
+        ((1, 5, 3), (None,)),
         # Addtl. cases
         # NOTE: nvfuser cannot handle more than 8 dims.
         ((7, 9, 5), (slice(2, 6, 2), None, ..., slice(3, 7), None, 2, None)),


### PR DESCRIPTION
## What does this PR do?

Fix cases where we have
```
# tensor = torch.tensor(...)
tensor[None]
```