### PR TITLE
Remove thunder_backward; it became obsolete with new thunder.jit() code

### DIFF
--- a/docs/source/reference/executors/torchex.rst
+++ b/docs/source/reference/executors/torchex.rst
@@ -8,5 +8,3 @@ PyTorch Executor
 
 .. autosummary::
     :toctree: generated/
-
-    thunder_backward

--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -583,10 +583,6 @@ def jit(
                 requires_grad = any(isinstance(arg, tensor_cls) and arg.requires_grad for arg in inps)
 
                 if requires_grad:
-                    # thunder_backward may recursively call compile and wraps the result in a
-                    # torch.autograd.Function to support embedding of Thunder-compiled
-                    # functions in torch's Autograd
-
                     # Currently split_forward_backward also includes
                     # transform_for_execution and various sorting of symbols,
                     # applying transform_for_execution after this would be

--- a/thunder/common.py
+++ b/thunder/common.py
@@ -38,7 +38,6 @@ import thunder.distributed as dist
 import thunder.torch as ltorch
 from thunder.extend import Executor, get_default_executors, get_always_executors, OperatorExecutor, add_executor_lists
 import thunder.executors as executors
-from thunder.executors.torch_autograd import thunder_backward
 from thunder.core.transforms import autocast
 from thunder.core.dtypes import to_dtype
 
@@ -734,26 +733,10 @@ def _create_callable(
                 tensor_cls = (torch.Tensor, TensorProxy)
                 requires_grad = any(isinstance(arg, tensor_cls) and arg.requires_grad for arg in flat_args)
                 if not cd.disable_torch_autograd_support and requires_grad:
-                    # thunder_backward may recursively call compile and wraps the result in a
-                    # torch.autograd.Function to support embedding of Thunder-compiled
-                    # functions in torch's Autograd
-                    cs.last_trace_host_execution_start = time.time_ns()
-                    c = thunder_backward(compile_data=cd, compile_stats=cs)(processed_function)
-                    result = c(*args, **kwargs)
-                    cs.last_trace_host_execution_stop = time.time_ns()
-                    cs.last_executed = c
-                    if cd.cache_option is CACHE_OPTIONS.CONSTANT_VALUES:
-                        cache_put(
-                            cs.cache,
-                            c,
-                            None,
-                            args[cd.num_constant_args :],
-                            kwargs,
-                            autocast_key=None,
-                            distributed_key=distributed_key,
-                        )
-                    cs.last_trace_host_stop = time.time_ns()
-                    return result
+                    raise NotImplementedError(
+                        "torch.autograd.Function integration is not supported in thunder.compile(). "
+                        "Please use thunder.jit() to compile functions that require torch.autograd.Function."
+                    )
 
             # TODO Revisit jit() behavior when hit in a trace ctx
             #   This will inline the invocation of compile into the current

--- a/thunder/tests/framework.py
+++ b/thunder/tests/framework.py
@@ -135,7 +135,13 @@ class TestExecutor:
     def make_callable_legacy(self, fn, **kwargs):
         assert kwargs.pop("disable_preprocessing", True)
         assert kwargs.pop("disable_torch_autograd_support", True)
-        return thunder.compile(fn, executors_list=self.executors_list(), disable_preprocessing=True, disable_torch_autograd_support=True, **kwargs)
+        return thunder.compile(
+            fn,
+            executors_list=self.executors_list(),
+            disable_preprocessing=True,
+            disable_torch_autograd_support=True,
+            **kwargs,
+        )
 
     @singledispatchmethod
     def make_callable(self, fn, **kwargs):

--- a/thunder/tests/framework.py
+++ b/thunder/tests/framework.py
@@ -134,7 +134,8 @@ class TestExecutor:
     @singledispatchmethod
     def make_callable_legacy(self, fn, **kwargs):
         assert kwargs.pop("disable_preprocessing", True)
-        return thunder.compile(fn, executors_list=self.executors_list(), disable_preprocessing=True, **kwargs)
+        assert kwargs.pop("disable_torch_autograd_support", True)
+        return thunder.compile(fn, executors_list=self.executors_list(), disable_preprocessing=True, disable_torch_autograd_support=True, **kwargs)
 
     @singledispatchmethod
     def make_callable(self, fn, **kwargs):

--- a/thunder/tests/test_grad.py
+++ b/thunder/tests/test_grad.py
@@ -897,8 +897,6 @@ def test_no_duplicate_backward_registered():
     dtypes=NOTHING,
 )
 def test_torch_autograd_function(executor, device, _):
-    from thunder.executors.torch_autograd import thunder_backward
-    from thunder.common import CompileData
     from thunder.clang import cos, sin
     import thunder.torch as ltorch
 
@@ -907,8 +905,7 @@ def test_torch_autograd_function(executor, device, _):
         e = d * a + d * b + d * c
         return sin(e) + cos(e), e, ltorch.sin(e) + ltorch.cos(e)
 
-    compile_data = CompileData(fn=func, disable_preprocessing=True, executors_list=executor.executors_list())
-    func = thunder_backward(compile_data=compile_data)(func)
+    func = thunder.jit(func, executors=executor.executors_list(), disable_torch_autograd=False)
 
     a = make_tensor((2, 3), device=device, dtype=torch.float64, requires_grad=True)
     b = make_tensor((2, 3), device=device, dtype=torch.float64, requires_grad=True)
@@ -922,14 +919,11 @@ def test_torch_autograd_function(executor, device, _):
 )
 def test_torch_autograd_function_single_input(executor, device, _):
     from thunder.clang import sin
-    from thunder.executors.torch_autograd import thunder_backward
-    from thunder.common import CompileData
 
     def func(a):
         return sin(a)
 
-    compile_data = CompileData(fn=func, disable_preprocessing=True, executors_list=executor.executors_list())
-    func = thunder_backward(compile_data=compile_data)(func)
+    func = thunder.jit(func, executors=executor.executors_list(), disable_torch_autograd=False)
 
     a = make_tensor((2, 3), device=device, dtype=torch.float64, requires_grad=True)
     assert torch.autograd.gradcheck(func, (a,))
@@ -939,8 +933,6 @@ def test_torch_autograd_function_single_input(executor, device, _):
     dtypes=(dtypes.float32,),
 )
 def test_torch_autograd_crazy_collections_in_and_out(executor, device, dtype):
-    from thunder.executors.torch_autograd import thunder_backward
-
     # Borrowed from `test_crazy_collections_in_and_out`.
     def foo(a, b, c, *, ka, kb, kc):
         d = {
@@ -1057,14 +1049,10 @@ def test_torch_autograd_module_get_compile_stats(executor, device, _):
     dtypes=NOTHING,
 )
 def test_torch_autograd_function_with_kwargs_static_caching(executor, device, _):
-    from thunder.executors.torch_autograd import thunder_backward
-    from thunder.common import CompileData
-
     def func(a, b):
         return a - b
 
-    compile_data = CompileData(fn=func, disable_preprocessing=True, executors_list=executor.executors_list())
-    func = thunder_backward(compile_data=compile_data)(func)
+    func = thunder.jit(func, executors=executor.executors_list(), disable_torch_autograd=False)
 
     a = make_tensor((2, 3), device=device, dtype=torch.float64, requires_grad=True)
     b = make_tensor((2, 3), device=device, dtype=torch.float64, requires_grad=True)
@@ -1116,8 +1104,6 @@ def test_torch_autograd_redundant_casts(executor, device, _):
     # but backward wasn't updated with the new proxies. This test ensures that
     # we don't regress.
     from thunder.core.prims import convert_element_type
-    from thunder.executors.torch_autograd import thunder_backward
-    from thunder.common import CompileData
     import thunder.torch as ltorch
 
     def func(a, b, c):
@@ -1125,8 +1111,7 @@ def test_torch_autograd_redundant_casts(executor, device, _):
         e = d * a + d * b + d * c
         return ltorch.sin(e) + ltorch.cos(e)
 
-    compile_data = CompileData(fn=func, disable_preprocessing=True, executors_list=executor.executors_list())
-    func = thunder_backward(compile_data=compile_data)(func)
+    func = thunder.jit(func, executors=executor.executors_list(), disable_torch_autograd=False)
 
     a = make_tensor((2, 3), device=device, dtype=torch.float16, requires_grad=True)
     b = make_tensor((2, 3), device=device, dtype=torch.float16, requires_grad=True)


### PR DESCRIPTION
`thunder_backward` existed to show it's possible to integrate Thunder with PyTorch's Autograd. Currently, this integration is done inside `thunder.jit` code:
https://github.com/Lightning-AI/lightning-thunder/blob/139cc2246b87f3e58d80b13897286a61d55826d8/thunder/__init__.py#L657-L669
making `thunder_backward` unnecessary.

cc @borda @apaz-cli