### PR TITLE
skip checking github links to pytorch

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,6 +50,7 @@ github_repo = project
 linkcheck_ignore = [
     rf"https://github.com/Lightning-AI/lightning-thunder(/.*|\.git)",
     rf"https://github.com/Lightning-AI/.*/blob/.*#.*",  # github anchors are tricky
+    rf"https://github.com/pytorch/.*/blob/.*#.*",  # github anchors are tricky
 ]
 
 # -- Project documents -------------------------------------------------------


### PR DESCRIPTION
linkcheck cannot handle the `#L123` part of the links because the anchors are dynamically generated in github