### PR TITLE
Guard thunder/distributed/transforms/ by torch.distributed.is_available

### DIFF
--- a/thunder/distributed/transforms/__init__.py
+++ b/thunder/distributed/transforms/__init__.py
@@ -1,6 +1,10 @@
-from .ddp import optimize_allreduce_in_ddp_backward
-from .fsdp import FSDPCommBucketing
-
+import torch
+if torch.distributed.is_available():
+    from .ddp import optimize_allreduce_in_ddp_backward
+    from .fsdp import FSDPCommBucketing
+else:
+    optimize_allreduce_in_ddp_backward = None
+    FSDPCommBucketing = None
 
 __all__ = [
     "optimize_allreduce_in_ddp_backward",

--- a/thunder/distributed/transforms/__init__.py
+++ b/thunder/distributed/transforms/__init__.py
@@ -1,4 +1,5 @@
 import torch
+
 if torch.distributed.is_available():
     from .ddp import optimize_allreduce_in_ddp_backward
     from .fsdp import FSDPCommBucketing


### PR DESCRIPTION
This is needed for a PyTorch build without distributed features.