### PR TITLE
Remove callable arg split forward backward

### DIFF
--- a/thunder/core/trace.py
+++ b/thunder/core/trace.py
@@ -51,7 +51,7 @@ class TraceCtx:
         self._is_prologue: bool = is_prologue
 
         self.args = None
-        self.kwargs = None
+        self.kwargs = {}
 
         self.bound_symbols: list[BoundSymbolInterface] = []
         self.scopes = [self.bound_symbols]

--- a/thunder/distributed/transforms/__init__.py
+++ b/thunder/distributed/transforms/__init__.py
@@ -1,6 +1,10 @@
-from .ddp import optimize_allreduce_in_ddp_backward
-from .fsdp import FSDPCommBucketing
-
+import torch
+if torch.distributed.is_available():
+    from .ddp import optimize_allreduce_in_ddp_backward
+    from .fsdp import FSDPCommBucketing
+else:
+    optimize_allreduce_in_ddp_backward = None
+    FSDPCommBucketing = None
 
 __all__ = [
     "optimize_allreduce_in_ddp_backward",

--- a/thunder/distributed/transforms/__init__.py
+++ b/thunder/distributed/transforms/__init__.py
@@ -1,4 +1,5 @@
 import torch
+
 if torch.distributed.is_available():
     from .ddp import optimize_allreduce_in_ddp_backward
     from .fsdp import FSDPCommBucketing

--- a/thunder/executors/torch_autograd.py
+++ b/thunder/executors/torch_autograd.py
@@ -63,7 +63,6 @@ def split_forward_backward(computation_trc: TraceCtx, compile_data, compile_stat
     from thunder.executors.passes import del_last_used, transform_for_execution
 
     utils.check(compile_data is not None, lambda: "`compile_data` is required")
-    computation_trc.kwargs = {}
     # NOTE: This function is rather slow, so it's intended to be used
     # behind a cache.
     tensor_cls = (torch.Tensor, TensorProxy)


### PR DESCRIPTION
Continuation of https://github.com/Lightning-AI/lightning-thunder/pull/188. Here I remove more of the dead code.