### PR TITLE
Only downloads cudnn in docker images when doing torch source builds

### DIFF
--- a/dockers/ubuntu-cuda/Dockerfile
+++ b/dockers/ubuntu-cuda/Dockerfile
@@ -71,29 +71,30 @@ RUN \
     apt-get autoremove -y && \
     apt-get clean && \
     rm -rf /root/.cache && \
-    rm -rf /var/lib/apt/lists/* \
+    rm -rf /var/lib/apt/lists/*;
 
 # cuda TK is only needed for building from source, otherwise PyTorch wheels include it
 RUN if [ "${TORCH_INSTALL}" == "source" ]; then \
-        echo "CUDA_VERSION=$CUDA_VERSION ; CUDNN_VERSION=$CUDNN_VERSION " && \
+        echo "CUDA_VERSION=$CUDA_VERSION ; CUDNN_VERSION=$CUDNN_VERSION" && \
         CUDNN_BASE_VER=${CUDNN_VERSION%%.*} && \
         CUDA_VERSION_M=${CUDA_VERSION%%.*} && \
         apt update -qq --fix-missing && \
-        apt upgrade -y --allow-downgrades --allow-change-held-packages \
         if [ "${CUDNN_BASE_VER}" == "9" ]; then \
             CUDNN_PACKAGE_NAME="${CUDNN_VERSION}-1" && \
-            libcudnn9-cuda-${CUDA_VERSION_M}=${CUDNN_PACKAGE_NAME} \
-            libcudnn9-dev-cuda-${CUDA_VERSION_M}=${CUDNN_PACKAGE_NAME} \
+            apt upgrade -y --allow-downgrades --allow-change-held-packages && \
+            apt install -y libcudnn9-cuda-${CUDA_VERSION_M}=${CUDNN_PACKAGE_NAME} \
+                           libcudnn9-dev-cuda-${CUDA_VERSION_M}=${CUDNN_PACKAGE_NAME}; \
         else \
             CUDA_VERSION_MM=${CUDA_VERSION%.*} && \
-            # There are some test failures from cuDNN 12.1, so 'upgrade' requests for 12.1 to 12.2.
+            # There are some test failures from cuDNN 12.1, so 'upgrade' requests for 12.1 to 12.2. \
             CUDA_VERSION_MM="${CUDA_VERSION_MM/12.1/12.2}" && \
             CUDNN_PACKAGE_NAME="${CUDNN_VERSION}-1+cuda${CUDA_VERSION_MM}" && \
-            libcudnn8=${CUDNN_PACKAGE_NAME} \
-            libcudnn8-dev=${CUDNN_PACKAGE_NAME} \
+            apt upgrade -y --allow-downgrades --allow-change-held-packages && \
+            apt install -y libcudnn8=${CUDNN_PACKAGE_NAME} \
+                           libcudnn8-dev=${CUDNN_PACKAGE_NAME}; \
         fi && \
         rm -rf /root/.cache && \
-        rm -rf /var/lib/apt/lists/* && \
+        rm -rf /var/lib/apt/lists/*; \
     fi
 
 RUN \

--- a/dockers/ubuntu-cuda/Dockerfile
+++ b/dockers/ubuntu-cuda/Dockerfile
@@ -97,12 +97,6 @@ RUN if [ "${TORCH_INSTALL}" == "source" ]; then \
         rm -rf /var/lib/apt/lists/*; \
     fi
 
-RUN \
-    # building cudnn-frontend from source
-    git clone --branch ${CUDNN_FRONTEND_CHECKOUT} https://github.com/NVIDIA/cudnn-frontend.git && \
-    CMAKE_BUILD_PARALLEL_LEVEL=16 pip install cudnn-frontend/ -v && \
-    rm -rf cudnn-frontend
-
 COPY requirements/ requirements/
 
 ENV \
@@ -180,6 +174,12 @@ RUN \
       . && \
     cd .. && \
     rm -rf apex
+
+RUN \
+    # building cudnn-frontend from source
+    git clone --branch ${CUDNN_FRONTEND_CHECKOUT} https://github.com/NVIDIA/cudnn-frontend.git && \
+    CMAKE_BUILD_PARALLEL_LEVEL=16 pip install cudnn-frontend/ -v && \
+    rm -rf cudnn-frontend
 
 RUN \
     ls -lh requirements/ && \

--- a/dockers/ubuntu-cuda/Dockerfile
+++ b/dockers/ubuntu-cuda/Dockerfile
@@ -19,7 +19,7 @@ ARG IMAGE_TYPE="devel"
 
 FROM nvidia/cuda:${CUDA_VERSION}-${IMAGE_TYPE}-ubuntu${UBUNTU_VERSION}
 
-ARG CUDNN_VERSION="8.9.7.29-1"
+ARG CUDNN_VERSION="9.1.0.70"
 ARG CUDNN_FRONTEND_CHECKOUT="v1.3.0"
 ARG PYTHON_VERSION="3.10"
 ARG TORCH_VERSION="2.2.1"
@@ -73,20 +73,31 @@ RUN \
     rm -rf /root/.cache && \
     rm -rf /var/lib/apt/lists/* \
 
+# cuda TK is only needed for building from source, otherwise PyTorch wheels include it
+RUN if [ "${TORCH_INSTALL}" == "source" ]; then \
+        echo "CUDA_VERSION=$CUDA_VERSION ; CUDNN_VERSION=$CUDNN_VERSION " && \
+        CUDNN_BASE_VER=${CUDNN_VERSION%%.*} && \
+        CUDA_VERSION_M=${CUDA_VERSION%%.*} && \
+        apt update -qq --fix-missing && \
+        apt upgrade -y --allow-downgrades --allow-change-held-packages \
+        if [ "${CUDNN_BASE_VER}" == "9" ]; then \
+            CUDNN_PACKAGE_NAME="${CUDNN_VERSION}-1" && \
+            libcudnn9-cuda-${CUDA_VERSION_M}=${CUDNN_PACKAGE_NAME} \
+            libcudnn9-dev-cuda-${CUDA_VERSION_M}=${CUDNN_PACKAGE_NAME} \
+        else \
+            CUDA_VERSION_MM=${CUDA_VERSION%.*} && \
+            # There are some test failures from cuDNN 12.1, so 'upgrade' requests for 12.1 to 12.2.
+            CUDA_VERSION_MM="${CUDA_VERSION_MM/12.1/12.2}" && \
+            CUDNN_PACKAGE_NAME="${CUDNN_VERSION}-1+cuda${CUDA_VERSION_MM}" && \
+            libcudnn8=${CUDNN_PACKAGE_NAME} \
+            libcudnn8-dev=${CUDNN_PACKAGE_NAME} \
+        fi && \
+        rm -rf /root/.cache && \
+        rm -rf /var/lib/apt/lists/* && \
+    fi
+
 RUN \
-    echo "CUDA_VERSION=$CUDA_VERSION ; CUDNN_VERSION=$CUDNN_VERSION " && \
-    CUDA_VERSION_MM=${CUDA_VERSION%.*} && \
-    # There are some test failures from cuDNN 12.1, so 'upgrade' requests for 12.1 to 12.2.
-    CUDA_VERSION_MM="${CUDA_VERSION_MM/12.1/12.2}" && \
-    CUDNN_BASE_VER=${CUDNN_VERSION%%.*} && \
-    CUDNN_PACKAGE_VER="${CUDNN_VERSION}+cuda${CUDA_VERSION_MM}" && \
-    apt update -qq --fix-missing && \
-    apt upgrade -y --allow-change-held-packages \
-      libcudnn${CUDNN_BASE_VER}=${CUDNN_PACKAGE_VER} \
-      libcudnn${CUDNN_BASE_VER}-dev=${CUDNN_PACKAGE_VER} \
-    && \
-    rm -rf /root/.cache && \
-    rm -rf /var/lib/apt/lists/* && \
+    # building cudnn-frontend from source
     git clone --branch ${CUDNN_FRONTEND_CHECKOUT} https://github.com/NVIDIA/cudnn-frontend.git && \
     CMAKE_BUILD_PARALLEL_LEVEL=16 pip install cudnn-frontend/ -v && \
     rm -rf cudnn-frontend


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

## What does this PR do?
1. As pytorch wheels already download cudnn from pypi, this PR stops downloading cudnn debian package when torch wheels are present
2. Only in the case of torch source install, cudnn debian packages are installed.
3. Lastly, updates to latest cudnn v9 version.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
