### PR TITLE
add large_mem test marker for memory-intense tests

### DIFF
--- a/.azure/gpu-tests.yml
+++ b/.azure/gpu-tests.yml
@@ -95,7 +95,7 @@ jobs:
               --durations=250 \
               --timeout=240 \
               --numprocesses=9 \
-	      -m "not large_mem"\
+              -m "not large_mem"\
               --ignore=thunder/tests/distributed --ignore=thunder/tests/test_networks.py
           coverage run --source thunder -m \
             pytest thunder/tests/ \
@@ -106,7 +106,7 @@ jobs:
               --durations=250 \
               --timeout=240 \
               --numprocesses=4 \
-	      -m "large_mem"\
+              -m "large_mem"\
               --ignore=thunder/tests/distributed --ignore=thunder/tests/test_networks.py
           # compile coverage results
           python -m coverage report

--- a/.azure/gpu-tests.yml
+++ b/.azure/gpu-tests.yml
@@ -95,6 +95,18 @@ jobs:
               --durations=250 \
               --timeout=240 \
               --numprocesses=9 \
+	      -m "not large_mem"\
+              --ignore=thunder/tests/distributed --ignore=thunder/tests/test_networks.py
+          coverage run --source thunder -m \
+            pytest thunder/tests/ \
+              -m "not standalone" \
+              -v --datefmt="%Y%m%d-%H:%M:%S.%f" \
+              --timeout=240 \
+              --random-order-seed=42 \
+              --durations=250 \
+              --timeout=240 \
+              --numprocesses=4 \
+	      -m "large_mem"\
               --ignore=thunder/tests/distributed --ignore=thunder/tests/test_networks.py
           # compile coverage results
           python -m coverage report

--- a/.azure/gpu-tests.yml
+++ b/.azure/gpu-tests.yml
@@ -95,7 +95,7 @@ jobs:
               --durations=250 \
               --timeout=240 \
               --numprocesses=9 \
-              -m "not large_mem"\
+              -m "not large_mem" \
               --ignore=thunder/tests/distributed --ignore=thunder/tests/test_networks.py
           coverage run --source thunder -m \
             pytest thunder/tests/ \
@@ -106,7 +106,7 @@ jobs:
               --durations=250 \
               --timeout=240 \
               --numprocesses=4 \
-              -m "large_mem"\
+              -m "large_mem" \
               --ignore=thunder/tests/distributed --ignore=thunder/tests/test_networks.py
           # compile coverage results
           python -m coverage report

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ addopts = [
 ]
 markers = [
     "standalone: mark a test as standalone",
+    'large_mem: needs a lot of gpu memory (select/deselect with -m large_mem / -m "not large_mem")',
 ]
 filterwarnings = [
     "error::FutureWarning",

--- a/thunder/tests/pytest.ini
+++ b/thunder/tests/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-markers =
-   large_mem: needs a lot of gpu memory (select/deselect with -m large_mem / -m "not large_mem")

--- a/thunder/tests/pytest.ini
+++ b/thunder/tests/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+   large_mem: needs a lot of gpu memory (select/deselect with -m large_mem / -m "not large_mem")

--- a/thunder/tests/test_jit_general.py
+++ b/thunder/tests/test_jit_general.py
@@ -631,6 +631,7 @@ def test_nanogpt():
     "device",
     ("cpu", "cuda"),
 )
+@pytest.mark.large_mem
 def test_litgpt_variants(name, device):
     if device == "cuda" and not torch.cuda.is_available():
         pytest.skip("CUDA not available")
@@ -683,6 +684,7 @@ def test_litgpt_variants(name, device):
     "device",
     ("cpu", "cuda"),
 )
+@pytest.mark.large_mem
 def test_litgpt_variants_kvcache(name, device):
     import torch._dynamo  # this monkeypatches torch.manual_seed
 


### PR DESCRIPTION
Tests requiring a lot of (GPU) mem can be marked with @pytest.mark.large_mem .
Those will be run with 4 workers rather than the default of 9 in the GPU "test regular" step.
