### PR TITLE
Move Grad AllReduce Bucketing to inside of `thunder.executors.passes.transform_for_execution` from `torch_autograd.split_forward_backward`

### DIFF
--- a/thunder/common.py
+++ b/thunder/common.py
@@ -617,6 +617,15 @@ def transform_for_execution(
 ) -> list[TraceCtx]:
     traces: list[TraceCtx] = []
 
+    if torch.distributed.is_available():
+        # Apply AllReduce bucketing if possible & needed
+        from thunder.distributed.prims import PrimIDs as DistPrimIDs
+        from thunder.distributed.transforms.ddp import apply_bucketing_to_grad_allreduce
+
+        trace, is_modified = apply_bucketing_to_grad_allreduce(trace, compile_data=None)
+        if is_modified:
+            traces.append(trace)
+
     # TODO If only_execute_prims, then flatten to prims here
 
     # Runs passes that are generally useful

--- a/thunder/common.py
+++ b/thunder/common.py
@@ -617,15 +617,6 @@ def transform_for_execution(
 ) -> list[TraceCtx]:
     traces: list[TraceCtx] = []
 
-    if torch.distributed.is_available():
-        # Apply AllReduce bucketing if possible & needed
-        from thunder.distributed.prims import PrimIDs as DistPrimIDs
-        from thunder.distributed.transforms.ddp import apply_bucketing_to_grad_allreduce
-
-        trace, is_modified = apply_bucketing_to_grad_allreduce(trace, compile_data=None)
-        if is_modified:
-            traces.append(trace)
-
     # TODO If only_execute_prims, then flatten to prims here
 
     # Runs passes that are generally useful

--- a/thunder/distributed/prims.py
+++ b/thunder/distributed/prims.py
@@ -10,6 +10,7 @@ from thunder.core.prims import make_prim
 
 from thunder.core.proxies import DDPType, FutureTensorProxy, pytype, TensorProxy
 from thunder.core.transforms import register_augmented_forward, register_backward
+from thunder.distributed import get_skip_data_parallel_grad_sync
 
 if TYPE_CHECKING:
     from thunder.common import CompileData
@@ -321,6 +322,8 @@ def synchronize_backward_rule(
     group: torch.distributed.ProcessGroup,
     grad: TensorProxy,
 ) -> tuple[TensorProxy, None]:
+    if get_skip_data_parallel_grad_sync() and ddp_type == DDPType.REPLICATED:
+        return grad, None
     preaverage_grad = grad / group.size()
     match ddp_type:
         case DDPType.REPLICATED:

--- a/thunder/distributed/transforms/__init__.py
+++ b/thunder/distributed/transforms/__init__.py
@@ -1,13 +1,13 @@
 import torch
 
 if torch.distributed.is_available():
-    from .ddp import optimize_allreduce_in_ddp_backward
+    from .ddp import apply_bucketing_to_grad_allreduce
     from .fsdp import FSDPCommBucketing
 else:
-    optimize_allreduce_in_ddp_backward = None
+    apply_bucketing_to_grad_allreduce = None
     FSDPCommBucketing = None
 
 __all__ = [
-    "optimize_allreduce_in_ddp_backward",
+    "apply_bucketing_to_grad_allreduce",
     "FSDPCommBucketing",
 ]

--- a/thunder/distributed/transforms/ddp.py
+++ b/thunder/distributed/transforms/ddp.py
@@ -267,6 +267,9 @@ def apply_bucketing_to_grad_allreduce(trace: TraceCtx) -> TraceCtx:
         import thunder
 
         compile_data = thunder.compile_data(trace)
+    # There's no ways to move forward if `compile_data` is None, so early exit.
+    if compile_data is None:
+        return trace
     utils.check_type(compile_data, CompileData)
 
     if not compile_data.is_module:

--- a/thunder/distributed/transforms/ddp.py
+++ b/thunder/distributed/transforms/ddp.py
@@ -263,7 +263,7 @@ def apply_bucketing_to_grad_allreduce(
     grad_before_after_allreduce = utils.ProxyDict()
     bsym: BoundSymbol
     for key in output_tensor_to_index_and_prod_bsym._dict:
-        _, bsym = output_tensor_to_index_and_prod_bsym[key]
+        _, bsym = output_tensor_to_index_and_prod_bsym.get_by_name(key)
         if bsym.sym.id == dist_prims.PrimIDs.WAIT:
             bsym_of_allreduce: BoundSymbol = producers[bsym.flat_proxy_args[0]]
             utils.check(

--- a/thunder/executors/passes.py
+++ b/thunder/executors/passes.py
@@ -129,7 +129,15 @@ def _transform_for_operator_executor_execution(trace: TraceCtx, executors_list: 
 
 
 def transform_for_execution(trace: TraceCtx, executors_list: Sequence[Executor]) -> TraceCtx:
+    import torch
+
     start_time_ns = time.time_ns()
+
+    if torch.distributed.is_available():
+        # Apply AllReduce bucketing if possible & needed
+        from thunder.distributed.transforms.ddp import apply_bucketing_to_grad_allreduce
+
+        trace = apply_bucketing_to_grad_allreduce(trace)
 
     trace = dce(trace)
 

--- a/thunder/executors/torch_autograd.py
+++ b/thunder/executors/torch_autograd.py
@@ -196,10 +196,7 @@ def split_forward_backward(computation_trc: TraceCtx, compile_data, compile_stat
         skip_subsymbols=False,
     )
     bw_trace.bound_symbols = new_bsyms
-    # if getattr(compile_data.fn, "use_ddp", False):
-    #     from thunder.distributed.transforms import optimize_allreduce_in_ddp_backward
 
-    #     bw_trace = optimize_allreduce_in_ddp_backward(bw_trace, compile_data)
     if getattr(compile_data.fn, "use_fsdp", False):
         bw_trace = _fsdp_comm_bucketing.apply_bucketing_to_backward_trace(bw_trace)
 

--- a/thunder/executors/torch_autograd.py
+++ b/thunder/executors/torch_autograd.py
@@ -196,10 +196,10 @@ def split_forward_backward(computation_trc: TraceCtx, compile_data, compile_stat
         skip_subsymbols=False,
     )
     bw_trace.bound_symbols = new_bsyms
-    if getattr(compile_data.fn, "use_ddp", False):
-        from thunder.distributed.transforms import optimize_allreduce_in_ddp_backward
+    # if getattr(compile_data.fn, "use_ddp", False):
+    #     from thunder.distributed.transforms import optimize_allreduce_in_ddp_backward
 
-        bw_trace = optimize_allreduce_in_ddp_backward(bw_trace, compile_data)
+    #     bw_trace = optimize_allreduce_in_ddp_backward(bw_trace, compile_data)
     if getattr(compile_data.fn, "use_fsdp", False):
         bw_trace = _fsdp_comm_bucketing.apply_bucketing_to_backward_trace(bw_trace)
 


### PR DESCRIPTION
## What does this PR do?

Fixes #184

As per title. The changes are addition of a logic to tell whether or not the input `TraceCtx` represents DDP backward.

cc @carmocca @awaelchli @crcrpar