### PR TITLE
Add benchmark reporting tool and mistral example

### DIFF
--- a/thunder/benchmarks/benchmark_scripts.py
+++ b/thunder/benchmarks/benchmark_scripts.py
@@ -85,8 +85,8 @@ class Benchmarks(parameterized.TestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        if flags.FLAGS.benchmark_output_dir and not os.path.exists(flags.FLAGS.benchmark_output_dir):
-            os.makedirs(flags.FLAGS.benchmark_output_dir)
+        if flags.FLAGS.benchmark_output_dir:
+            os.makedirs(flags.FLAGS.benchmark_output_dir, exist_ok=True)
 
     @classmethod
     def tearDownClass(cls) -> None:

--- a/thunder/benchmarks/benchmark_scripts.py
+++ b/thunder/benchmarks/benchmark_scripts.py
@@ -80,6 +80,7 @@ class Benchmarks(parameterized.TestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._summary_metrics = {}
+        self._benchmakr_dir = os.path.dirname(__file__)
 
     @classmethod
     def setUpClass(cls):
@@ -93,7 +94,7 @@ class Benchmarks(parameterized.TestCase):
         super().tearDownClass()
 
     def run_standalone_script(self, filename: str, kwargs: dict[str, Any]) -> None:
-        cmd_string = ["python", f"{filename}"]
+        cmd_string = ["python", "".join([self._benchmakr_dir, "/", filename])]
         for key, val in kwargs.items():
             cmd_string.append("--" + str(key) + "=" + str(val))
 

--- a/thunder/benchmarks/benchmark_scripts.py
+++ b/thunder/benchmarks/benchmark_scripts.py
@@ -1,0 +1,117 @@
+import json
+import os
+import subprocess
+
+from typing import Any
+from datetime import datetime
+from functools import partial
+
+from absl import flags
+from absl import logging
+from absl.testing import absltest, parameterized
+
+flags.DEFINE_string("benchmark_output_dir", default="./benchmark_results", help="Output directory for benchmark JSONs")
+
+
+class Target(absltest.TestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._failed_tests = []
+
+        for fn_name in dir(self):
+            if fn_name.startswith("test"):
+                fn = getattr(self, fn_name)
+                wrapped_fn = partial(self._test_wrapper, fn=fn)
+                setattr(self, fn_name, wrapped_fn)
+
+    # Add timestamp and defer exceptions so we can save the test status.
+    def _test_wrapper(self, *args, fn=None, **kwargs):
+        self._start_time = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+        try:
+            return fn(*args, **kwargs)
+        except Exception as ex:
+            self._failed_tests.append(ex)
+
+    def _get_git_revision(self) -> str:
+        cmd = ["git", "rev-parse", "--short", "HEAD"]
+        return subprocess.check_output(cmd).decode("ascii").strip()
+
+    def _report_benchmark_results(self):
+        out_dir = flags.FLAGS.benchmark_output_dir
+        filename = os.path.join(out_dir, f"{self._name}_{self._start_time}.json")
+        git_revision = self._get_git_revision()
+
+        with open(filename, mode="w") as json_report:
+            json.dump(
+                {
+                    "test_class": self._name,
+                    "timestamp": self._start_time,
+                    "head": git_revision,
+                    "succeeded": not self.has_failed_tests(),
+                    **self._reported_metrics,
+                    **self._flags,
+                },
+                json_report,
+            )
+
+    def has_failed_tests(self):
+        return len(self._failed_tests) > 0
+
+    def setUp(self) -> None:
+        super().setUp()
+        self._name = type(self).__name__
+        self._reported_metrics: dict = {}
+        self._flags: dict = {}
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        self._report_benchmark_results()
+        for exception in self._failed_tests:
+            raise exception
+
+    def report_flag(self, name: str, value: Any) -> None:
+        self._flags[name] = value
+
+    def report_metrics(self, metrics: dict[str, Any]) -> None:
+        self._reported_metrics.update(metrics)
+
+
+class Benchmarks(parameterized.TestCase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._summary_metrics = {}
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        if flags.FLAGS.benchmark_output_dir and not os.path.exists(flags.FLAGS.benchmark_output_dir):
+            os.makedirs(flags.FLAGS.benchmark_output_dir)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        super().tearDownClass()
+
+    def run_standalone_script(self, filename: str, kwargs: dict[str, Any]) -> None:
+        cmd_string = ["python", f"{filename}"]
+        for key, val in kwargs.items():
+            cmd_string.append("--" + str(key) + "=" + str(val))
+
+        logging.info(f'Running: {" ".join(cmd_string)!r}')
+        self.assertCommandSucceeds(cmd_string, env=os.environ)
+
+    @parameterized.product(
+        compile=(
+            "eager",
+            "inductor",
+            "thunder",
+        ),
+        input_len=(4_096,),
+        batch_size=(1,),
+    )
+    def test_mistral(self, **kwargs):
+        self.run_standalone_script("mistral.py", kwargs)
+
+
+if __name__ == "__main__":
+    absltest.main()

--- a/thunder/benchmarks/benchmark_scripts.py
+++ b/thunder/benchmarks/benchmark_scripts.py
@@ -10,7 +10,7 @@ from absl import flags
 from absl import logging
 from absl.testing import absltest, parameterized
 
-flags.DEFINE_string("benchmark_output_dir", default="./benchmark_results", help="Output directory for benchmark JSONs")
+flags.DEFINE_string("output_dir", default="./benchmark_results", help="Output directory for benchmark JSONs")
 
 
 class Target(absltest.TestCase):
@@ -37,7 +37,7 @@ class Target(absltest.TestCase):
         return subprocess.check_output(cmd).decode("ascii").strip()
 
     def _report_benchmark_results(self):
-        out_dir = flags.FLAGS.benchmark_output_dir
+        out_dir = flags.FLAGS.output_dir
         filename = os.path.join(out_dir, f"{self._name}_{self._start_time}.json")
         git_revision = self._get_git_revision()
 
@@ -85,8 +85,8 @@ class Benchmarks(parameterized.TestCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        if flags.FLAGS.benchmark_output_dir:
-            os.makedirs(flags.FLAGS.benchmark_output_dir, exist_ok=True)
+        if flags.FLAGS.output_dir:
+            os.makedirs(flags.FLAGS.output_dir, exist_ok=True)
 
     @classmethod
     def tearDownClass(cls) -> None:

--- a/thunder/benchmarks/mistral.py
+++ b/thunder/benchmarks/mistral.py
@@ -1,0 +1,176 @@
+import random
+import string
+import time
+
+from benchmark_scripts import Target
+
+from absl import logging, flags
+from absl.testing import absltest
+
+import torch
+from torch.optim import AdamW
+from torch.utils.data import DataLoader, IterableDataset
+
+from thunder.tests.litgpt_model import Config, GPT
+from transformers import AutoTokenizer
+
+flags.DEFINE_string("compile", default="eager", help="Specify compile option: thunder|inductor|eager")
+
+flags.DEFINE_integer("input_len", default=22_000, help="Specify input sequence length")
+flags.DEFINE_integer("batch_size", default=1, help="Specify batch size")
+
+flags.DEFINE_integer("max_iters", default=100, help="Specify number of training iterations")
+flags.DEFINE_integer("warmup_iters", default=20, help="Specify number of warmup iterations")
+
+flags = flags.FLAGS
+
+
+class SecondsPerIter:
+    def __init__(self, average_iters: int = 10) -> None:
+        super().__init__()
+
+        self.last_call = None
+        self.count_calls = -1
+
+        self.average_iters = average_iters
+        self.last_iters = torch.zeros(average_iters)
+
+    def add_batch(self, start_time: int = None) -> None:
+        torch.cuda.synchronize()
+        now = time.perf_counter_ns()
+
+        if start_time:
+            self.last_call = start_time
+
+        if self.last_call is not None:
+            te = now - self.last_call
+            self.last_iters[self.count_calls % self.average_iters] = te
+        self.last_call = now
+        self.count_calls += 1
+
+    def compute(self) -> float:
+        if self.count_calls == 0:
+            return 0.0
+        return self.last_iters[: self.count_calls].mean().item()
+
+
+class DummyIterableDataset(IterableDataset):
+    def __init__(self, tokenizer: AutoTokenizer) -> None:
+        super().__init__()
+        self._tokenizer = tokenizer
+
+    def __iter__(self):
+        while True:
+            input_text = "".join(random.choices(string.ascii_letters + string.digits, k=flags.input_len))
+            encoded = self._tokenizer(
+                input_text, return_token_type_ids=True, max_length=flags.input_len, padding="max_length"
+            )
+            for k, v in encoded.items():
+                encoded[k] = torch.tensor(v)
+
+            yield encoded
+
+
+def shift_targets_to_left(targets: torch.Tensor) -> torch.Tensor:
+    targets = torch.roll(targets, dims=-1, shifts=-1)
+    targets[:, -1] = 0
+    return targets
+
+
+def get_model(vocab_size: int) -> GPT:
+    config = Config.from_name("Mistral-7B-v0.1")
+    config.block_size = 32768
+    config.padded_vocab_size = vocab_size
+
+    return GPT(config)
+
+
+def setup_compile(model) -> GPT:
+    logging.info(f"Setting up compile option: {flags.compile}")
+    if flags.compile == "thunder":
+        import thunder
+
+        return thunder.jit(model)
+    elif flags.compile == "inductor":
+        return torch.compile(model)
+    else:
+        return model
+
+
+class MistralBenchmark(Target):
+    def setUp(self):
+        super().setUp()
+        self.report_flag("input_len", flags.input_len)
+        self.report_flag("batch_size", flags.batch_size)
+        self.report_flag("max_iters", flags.max_iters)
+        self.report_flag("warmup_iters", flags.warmup_iters)
+        self.report_flag("compile", flags.compile)
+
+        self.device = torch.device("cuda", 0)
+        torch.cuda.set_device(self.device)
+
+        tokenizer = AutoTokenizer.from_pretrained("mistralai/Mistral-7B-v0.1")
+        tokenizer.add_special_tokens({"pad_token": "[PAD]"})
+        vocab_size = len(tokenizer.get_vocab())
+
+        model = get_model(vocab_size)
+        model.to(dtype=torch.bfloat16)
+        model.to(device=self.device)
+        self.model = setup_compile(model)
+
+        self.mixed_ctx = torch.amp.autocast(device_type="cuda", dtype=torch.bfloat16)
+
+        logging.info(f"Running on {self.device}")
+
+        self.optimizer = AdamW(
+            params=self.model.parameters(),
+            lr=1e-4,
+            betas=(0.9, 0.995),
+            eps=1e-6,
+            weight_decay=1e-3,
+        )
+
+        train_dataset = DummyIterableDataset(tokenizer)
+        self.train_dataloader = DataLoader(dataset=train_dataset, batch_size=1)
+
+        self.metric = SecondsPerIter(average_iters=10)
+
+    def tearDown(self) -> None:
+        self.report_metrics(
+            {"iter_time": self.metric.compute(), "max_memory_allocated": torch.cuda.max_memory_allocated() / 1e9}
+        )
+        super().tearDown()
+
+    def test_training(self) -> None:
+        self.model.train()
+        train_iter = iter(self.train_dataloader)
+        logging.info("Started training")
+
+        for step in range(flags.max_iters):
+            batch = next(train_iter)
+            input_ids = batch["input_ids"].to(self.device)
+
+            with self.mixed_ctx:
+                logits = self.model(input_ids)
+
+            vocab_size = logits.size(-1)
+            logits = logits.view(-1, vocab_size)
+
+            targets = shift_targets_to_left(input_ids).view(-1)
+            targets = targets.to(self.device)
+
+            loss = torch.nn.functional.cross_entropy(logits, targets, ignore_index=0)
+
+            loss.backward()
+
+            self.optimizer.step()
+            self.optimizer.zero_grad()
+
+            if step > flags.warmup_iters:
+                self.metric.add_batch()
+
+        logging.info(f"Iter {step} with {self.metric.compute()*1e-6:.4f} ms per iteration.")
+
+
+if __name__ == "__main__":
+    absltest.main()


### PR DESCRIPTION
## What does this PR do?

As part of #183 this fixes #224 by introducing an abseil based template that can be used to setup benchmarks and report results in from of JSONs. Also this PR includes an example benchmark of Mistral.

## How does this work?
This contribution consist of two main parts:
- It defines a template for creating standalone benchmarking scripts and provides the functionality record info and metrics. At the end of the run the recorded information is stored in the form of a JSON file.
-  The `Benchmarking` class provides a place where practitioners can register previously written scripts and parametrize them. Doing so allows to automate running benchmarks.

### Benchmark scripts template
The idea here is that developers can write scripts with the following structure:
``` python
from absl.testing import absltest
from benchmark_scripts import Target

class MyBenchmarkClass(Target):
    def setUp(self):
        super().setUp()
        # setup benchmark here

    def tearDown(self) -> None:
        super().tearDown()
        # teardown for the benchmark just ran

    def test_my_benchmark(self):
        # code to be benchmarked
        pass

if __name__ == "__main__":
    absltest.main()
```
The reason behind having a separate script for each benchmark is that it helps with isolation. Running multiple benchmarks on the same process can interfere on some metrics like peak memory.
Within this class practitioners can report metrics and parameters with the methods `report_metrics` and `report_flags` respectively. This reported metrics together with commit/version information will then be saved as in the form of a JSON file like the following:
``` json
{
    "test_class": "MistralBenchmark",
    "timestamp": "2024-04-19_10-30-23",
    "head": "0534668a",
    "succeeded": true,
    "iter_time": 93333096.0,
    "max_memory_allocated": 5.098717696,
    "input_len": 4096,
    "batch_size": 1,
    "max_iters": 100,
    "warmup_iters": 20,
    "compile": "eager"
}
```
(example from `mistral.py` ran with `python mistral.py --compile=eager --input_len=4096 --batch_size=1`)

### Benchmark automation
The `Benchmarking` class in `benchmark_scripts.py` file provides with a way to automate and parametrize the previously described scripts. In particular, practitioners can register an parametrize a script by adding a method to this class that starts with `test_`:
``` python 
    @parameterized.product(
        compile=(
            "eager",
            "inductor",
            "thunder",
        ),
        input_len=(4_096,),
        batch_size=(1,),
    )
    def test_my_script(self, **kwargs):
        self.run_standalone_script("my_benchmark.py", kwargs)
```
It will pass the parameters as arguments when calling `my_benchmark.py` file. 

## Design decisions
In both cases I've used abseil built in argument parser for convenience.