### PR TITLE
Change prologue details to prepare for fsdp as a transform

### DIFF
--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -113,6 +113,7 @@ from thunder.core.compile_data import compile_data_and_stats
 EXT_FLAG_IS_PROXY_DERIVED = 1
 EXT_FLAG_IS_TENSOR_PROXY = 2
 EXT_FLAG_IS_MODULE_MEMBER_DICT = 4
+EXT_FLAG_IS_MODULE = 8
 MODULE_MEMBER_DICT_ATTRS = {
     "_parameters",
     "_modules",
@@ -1051,7 +1052,9 @@ def _general_jit_wrap_callback(value):
     ctx: GeneralJitCtx = get_general_jit_ctx()
 
     uvalue = value.value
-    if isinstance(uvalue, torch.Tensor):
+    if isinstance(uvalue, torch.nn.Module):
+        value.provenance.ext_flag |= EXT_FLAG_IS_MODULE
+    elif isinstance(uvalue, torch.Tensor):
         # we always want to proxy torch.Tensor, even const
         p = ctx.proxify(value)
     elif value.provenance.inst is PseudoInst.CONSTANT:
@@ -1156,17 +1159,20 @@ def unpack_inputs(ctx, prologue_trace, pro_to_comp_inps, pro_to_epi_inps, args, 
         def from_input(provenance, *, new_output=False):
             assert new_output
             if provenance.inst == PseudoInst.INPUT_ARGS:
-                param_ordering[id(p)][1].insert(0, 0)
+                param_ordering[id(pro_args_proxy)] = (pro_args_proxy, [0])
                 return pro_args_proxy
             elif provenance.inst == PseudoInst.INPUT_KWARGS:
-                param_ordering[id(p)][1].insert(0, 1)
+                param_ordering[id(pro_kwargs_proxy)] = (pro_kwargs_proxy, [1])
                 is_pure = False
                 return pro_kwargs_proxy
             elif provenance.inst == PseudoInst.INPUT_FN:
-                param_ordering[id(p)][1].insert(0, 3)
                 is_pure = False
-                name = "fn"
+                if provenance.ext_flag & EXT_FLAG_IS_MODULE:
+                    name = "module"
+                else:
+                    name = "fn"
                 output = Proxy(name=name)
+                param_ordering[id(output)] = (output, [3])
                 provenance.proxy = output
                 bsym = prims.unpack_function_obj.bind(output, output=output)
                 prologue_trace.bound_symbols.append(bsym)
@@ -1180,7 +1186,7 @@ def unpack_inputs(ctx, prologue_trace, pro_to_comp_inps, pro_to_epi_inps, args, 
                 output = Proxy("obj")
             else:
                 output = p
-            param_ordering[id(p)][1][:0] = [math.inf, "." + str(inputs[1])]
+            param_ordering[id(output)] = (output, param_ordering[id(inputs[0])][1] + [math.inf, "." + str(inputs[1])])
             bsym = prims.unpack_attr.bind(inputs[0], inputs[1], output=output)
             prologue_trace.bound_symbols.append(bsym)
             return output
@@ -1191,7 +1197,64 @@ def unpack_inputs(ctx, prologue_trace, pro_to_comp_inps, pro_to_epi_inps, args, 
             else:
                 raise NotImplementedError(f"constant of type {type(provenance.value)} {provenance.value}")
 
+        def unpack_parameter_or_buffer(provenance, *, new_output=False):
+            assert provenance.inputs[0].inputs[0].inputs[0].ext_flag & EXT_FLAG_IS_MODULE
+            typ = provenance.inputs[0].inputs[1].value
+            name = [provenance.inputs[1].value]
+            mprovenance = provenance.inputs[0].inputs[0].inputs[0]
+
+            while (
+                mprovenance.inst is PseudoInst.BINARY_SUBSCR
+                and mprovenance.inputs[1].inst is PseudoInst.CONSTANT
+                and mprovenance.inputs[0].inst is PseudoInst.LOAD_ATTR
+                and mprovenance.inputs[0].inputs[0].ext_flag & EXT_FLAG_IS_MODULE
+            ):
+                assert (
+                    mprovenance.inputs[0].inputs[1].inst is PseudoInst.CONSTANT
+                    and mprovenance.inputs[0].inputs[1].value == "_modules"
+                )
+
+                name_component = mprovenance.inputs[1].value
+                name.insert(0, name_component)
+                mprovenance = mprovenance.inputs[0].inputs[0]
+
+            root_module = from_provenance(mprovenance, new_output=True)
+            if new_output:
+                output = Proxy("")  # name? collectify?
+            else:
+                output = p
+
+            param_ordering[id(output)] = (
+                output,
+                param_ordering[id(root_module)][1]
+                + [
+                    i
+                    for name_component in name
+                    for i in (
+                        [int(name_component)] if name_component.isnumeric() else [math.inf, ("." + name_component)]
+                    )
+                ],
+            )
+
+            name = ".".join(name)
+            if typ == "_parameters":
+                bsym = prims.unpack_parameter.bind(root_module, name, output=output)
+            else:
+                bsym = prims.unpack_buffer.bind(root_module, name, output=output)
+            prologue_trace.bound_symbols.append(bsym)
+
         def from_binary_subscr(provenance, *, new_output=False):
+            # special case tensors, todo: do this via pattern matching after unpacking?
+            if (
+                provenance.inst is PseudoInst.BINARY_SUBSCR
+                and provenance.inputs[0].inst is PseudoInst.BINARY_SUBSCR
+                and provenance.inputs[1].inst is PseudoInst.CONSTANT
+                and provenance.inputs[0].inputs[1].inst is PseudoInst.CONSTANT
+                and provenance.inputs[0].inputs[1].value in {"_parameters", "_buffers"}
+                and provenance.inputs[0].inputs[0].ext_flag & EXT_FLAG_IS_MODULE_MEMBER_DICT
+            ):
+                return unpack_parameter_or_buffer(provenance, new_output=new_output)
+
             inputs = [from_provenance(i, new_output=True) for i in provenance.inputs]
             obj, idx = inputs
             if new_output:
@@ -1203,7 +1266,7 @@ def unpack_inputs(ctx, prologue_trace, pro_to_comp_inps, pro_to_epi_inps, args, 
                     idx = int(idx)
                 elif isinstance(idx, str):
                     idx = str(idx)
-                param_ordering[id(p)][1][:0] = [math.inf, "[" + str(idx) + "]"]
+                param_ordering[id(output)] = (output, param_ordering[id(obj)][1] + [math.inf, "[" + str(idx) + "]"])
                 bsym = prims.unpack_getitem.bind(obj, idx, output=output)
                 prologue_trace.bound_symbols.append(bsym)
             else:
@@ -1266,7 +1329,6 @@ def unpack_inputs(ctx, prologue_trace, pro_to_comp_inps, pro_to_epi_inps, args, 
             return res
 
         assert isinstance(p.history, ProvenanceRecord), p.history
-        param_ordering[id(p)] = (p, [])
         with tracectx(prologue_trace):
             try:
                 from_provenance(p.history)
@@ -1439,7 +1501,6 @@ def thunder_general_jit(fn: Callable, args, kwargs, /, *, sharp_edges: SHARP_EDG
             result = jfn(*args, **kwargs)
             prims.python_return(result)
             process_recorded_modifications(ctx, epilogue_trace)
-
             last_interpreter_log = jfn._last_interpreter_log
 
     pro_to_comp, computation_intermediates = get_computation_inputs_and_intermediates(computation_trace)

--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -119,6 +119,8 @@ class PrimIDs(Enum):
     UNPACK_TUPLE = auto()
     UNPACK_LIST = auto()
     UNPACK_DICT_KEY = auto()
+    UNPACK_PARAMETER = auto()
+    UNPACK_BUFFER = auto()
     CONSTRUCT_TUPLE = auto()
     PACK_SETITEM = auto()
     # TODO: UNPACK_SET
@@ -945,6 +947,88 @@ unpack_attr = make_prim(
     meta=unpack_attr_meta,
     python_printer=unpack_attr_printer,
     python_impl=unpack_attr_impl,
+)
+
+
+# NOTE UNPACK_PARAMETER is intended only to be bound to directly, and not called
+def unpack_parameter_meta(o: Any, key: str) -> Any:
+    raise NotImplementedError
+
+
+def unpack_parameter_printer(
+    bsym: BoundSymbol, out_printables: Any, arg_printables: Sequence[Printable], kwarg_printables: dict[str, Printable]
+):
+    utils.check(
+        len(arg_printables) == 2,
+        lambda: f"Expected two arguments for unpack_attr but got {arg_printables}",
+        exception_type=AssertionError,
+    )
+    utils.check(
+        len(kwarg_printables) == 0,
+        lambda: f"Expected no kwargs for unpack_attr but got {kwarg_printables}",
+        exception_type=AssertionError,
+    )
+
+    # Converts printables to strings
+    origin, key = arg_printables
+    origin_str = codeutils.prettyprint(origin)
+    keystr = codeutils.prettyprint(key)
+    outstr = codeutils.prettyprint(out_printables, with_type=True, literals_as_underscores=True)
+
+    return f"{outstr} = {origin_str}.get_parameter({keystr})"
+
+
+def unpack_parameter_impl(o: Any, key: str) -> Any:
+    return o.get_parameter(key)
+
+
+unpack_parameter = make_prim(
+    PrimIDs.UNPACK_PARAMETER,
+    "unpack_parameter",
+    meta=unpack_parameter_meta,
+    python_printer=unpack_parameter_printer,
+    python_impl=unpack_parameter_impl,
+)
+
+
+# NOTE UNPACK_BUFFER is intended only to be bound to directly, and not called
+def unpack_buffer_meta(o: Any, key: str) -> Any:
+    raise NotImplementedError
+
+
+def unpack_buffer_printer(
+    bsym: BoundSymbol, out_printables: Any, arg_printables: Sequence[Printable], kwarg_printables: dict[str, Printable]
+):
+    utils.check(
+        len(arg_printables) == 2,
+        lambda: f"Expected two arguments for unpack_attr but got {arg_printables}",
+        exception_type=AssertionError,
+    )
+    utils.check(
+        len(kwarg_printables) == 0,
+        lambda: f"Expected no kwargs for unpack_attr but got {kwarg_printables}",
+        exception_type=AssertionError,
+    )
+
+    # Converts printables to strings
+    origin, key = arg_printables
+    origin_str = codeutils.prettyprint(origin)
+    keystr = codeutils.prettyprint(key)
+    outstr = codeutils.prettyprint(out_printables, with_type=True, literals_as_underscores=True)
+
+    return f"{outstr} = {origin_str}.get_buffer({keystr})"
+
+
+def unpack_buffer_impl(o: Any, key: str) -> Any:
+    return o.get_buffer(key)
+
+
+unpack_buffer = make_prim(
+    PrimIDs.UNPACK_BUFFER,
+    "unpack_buffer",
+    meta=unpack_buffer_meta,
+    python_printer=unpack_buffer_printer,
+    python_impl=unpack_buffer_impl,
 )
 
 

--- a/thunder/tests/distributed/test_ddp.py
+++ b/thunder/tests/distributed/test_ddp.py
@@ -505,7 +505,7 @@ class CompileDDPTest(DataParallelTestCase):
         #       in the original trace and are inputs to all_gather, the unshard are the outputs fo the corresponding wait
         #       If you fix this to be dynamically discerned, you'll be my hero.
         sharded_param_names = ("t_net1_weight", "t_net2_weight")
-        # t5 and t16 are all-gather'ed t_net1_weight and t_net2_weight, respectively.
+        # t3 and t16 are all-gather'ed t_net1_weight and t_net2_weight, respectively.
         unshard_param_names = ("t3", "t16")
         result_saved_for_bwd = [x.name for x in fwd_trc.bound_symbols[-1].args[1][0]]
         self.assertTrue(all(t not in sharded_param_names for t in result_saved_for_bwd))

--- a/thunder/tests/distributed/test_ddp.py
+++ b/thunder/tests/distributed/test_ddp.py
@@ -506,7 +506,7 @@ class CompileDDPTest(DataParallelTestCase):
         #       If you fix this to be dynamically discerned, you'll be my hero.
         sharded_param_names = ("t_net1_weight", "t_net2_weight")
         # t5 and t16 are all-gather'ed t_net1_weight and t_net2_weight, respectively.
-        unshard_param_names = ("t5", "t16")
+        unshard_param_names = ("t3", "t16")
         result_saved_for_bwd = [x.name for x in fwd_trc.bound_symbols[-1].args[1][0]]
         self.assertTrue(all(t not in sharded_param_names for t in result_saved_for_bwd))
         self.assertTrue(all(t in result_saved_for_bwd for t in unshard_param_names))

--- a/thunder/tests/test_jit_general.py
+++ b/thunder/tests/test_jit_general.py
@@ -629,7 +629,7 @@ def test_nanogpt():
 )
 @pytest.mark.parametrize(
     "device",
-    ("cpu", "cuda"),
+    ("cpu", "cuda", "meta"),
 )
 def test_litgpt_variants(name, device):
     if device == "cuda" and not torch.cuda.is_available():


### PR DESCRIPTION
- support tracing a model on meta device (to enable tracing before materializing / sharding)
- use model.get_parameter / model.get_buffer to acquire parameters and buffers to more easily divert these.