### PR TITLE
Adds optional scale and bias to cudnn's layernorm

### DIFF
--- a/thunder/executors/cudnn_layernormex.py
+++ b/thunder/executors/cudnn_layernormex.py
@@ -1,5 +1,6 @@
-from typing import Any
+from typing import Any, List
 
+from looseversion import LooseVersion
 import torch
 import numpy as np
 
@@ -18,25 +19,11 @@ from dataclasses import dataclass
 from functools import lru_cache
 from typing import Union, Dict
 
+from thunder.torch import TensorLike
 import thunder.core.dtypes as dtypes
 from thunder.core.proxies import TensorProxy
 
-from thunder.executors.cudnnex import CudnnTensorAttributes, torch_to_cudnn_dtype
-
-
-def make_cacheable_cudnn_graph_inputs(func):
-    def wrapper(*args, **kwargs):
-        cudnn_input_args = [
-            (
-                CudnnTensorAttributes(arg.size(), arg.stride(), arg.dtype, args.device_index)
-                if isinstance(arg, torch.Tensor)
-                else arg
-            )
-            for arg in args
-        ]
-        return func(*cudnn_input_args, **kwargs)
-
-    return wrapper
+from thunder.executors.cudnnex import CudnnTensorAttributes, torch_to_cudnn_dtype, CudnnexLRUCache, _get_cudnn_handle
 
 
 from thunder.extend import OperatorExecutor, register_executor
@@ -44,22 +31,28 @@ from thunder.extend import OperatorExecutor, register_executor
 cudnn_layernorm_ex: OperatorExecutor = OperatorExecutor("cudnn_layernorm", version=cudnn_backend_version)
 register_executor(cudnn_layernorm_ex)
 
+_cudnn_layernormex_cache = CudnnexLRUCache(maxlen=1024)
 
-@make_cacheable_cudnn_graph_inputs
-@lru_cache(maxsize=1024)
-def _make_cudnn_layer_norm_graph(a_4d, weight_4d, bias_4d):
-    graph = cudnn.pygraph(intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT)
+def _make_cudnn_layer_norm_graph(a, weight, bias):
+    graph = cudnn.pygraph(intermediate_data_type=cudnn.data_type.FLOAT, compute_data_type=cudnn.data_type.FLOAT, handle=_get_cudnn_handle(a.device_index))
 
-    input = graph.tensor(name="input", dim=a_4d.size, stride=a_4d.stride, data_type=torch_to_cudnn_dtype(a_4d.dtype))
-    scale = graph.tensor(
-        name="scale", dim=weight_4d.size, stride=weight_4d.stride, data_type=torch_to_cudnn_dtype(weight_4d.dtype)
-    )
-    bias = graph.tensor(
-        name="bias", dim=bias_4d.size, stride=bias_4d.stride, data_type=torch_to_cudnn_dtype(bias_4d.dtype)
-    )
+    input = graph.tensor(name="input", dim=a.size, stride=a.stride, data_type=torch_to_cudnn_dtype(a.dtype))
+    
+    scale = None
+    if weight is not None:
+        scale = graph.tensor(
+            name="scale", dim=weight.size, stride=weight.stride, data_type=torch_to_cudnn_dtype(weight.dtype)
+        )
+    
+    bias_cudnn = None
+    if bias is not None:
+        bias_cudnn = graph.tensor(
+            name="bias", dim=bias.size, stride=bias.stride, data_type=torch_to_cudnn_dtype(bias.dtype)
+        )
 
+    scalar_dim_stride = tuple([1] * len(a.size))
     epsilon = graph.tensor(
-        name="epsilon", dim=[1, 1, 1, 1], stride=[1, 1, 1, 1], data_type=cudnn.data_type.FLOAT, is_pass_by_value=True
+        name="epsilon", dim=scalar_dim_stride, stride=scalar_dim_stride, data_type=cudnn.data_type.FLOAT, is_pass_by_value=True
     )
 
     Y, _, _ = graph.layernorm(
@@ -67,54 +60,103 @@ def _make_cudnn_layer_norm_graph(a_4d, weight_4d, bias_4d):
         norm_forward_phase=cudnn.norm_forward_phase.INFERENCE,
         input=input,
         scale=scale,
-        bias=bias,
+        bias=bias_cudnn,
         epsilon=epsilon,
     )
 
-    Y.set_output(True).set_data_type(torch_to_cudnn_dtype(a_4d.dtype)).set_stride(a_4d.stride)
-
-    graph.build([cudnn.heur_mode.A])
-
-    return input, scale, bias, epsilon, Y, graph
+    Y.set_output(True).set_data_type(torch_to_cudnn_dtype(a.dtype)).set_stride(a.stride)
 
 
-# cudnn only supports following:
-# input tensor shape: N, C, (D), H, W
-# normalized shape:  (C, (D), H, W)
-# convert all tensor shapes to above format
+    # Validate the graph before querying the cache key
+    # Validation makes sure all missing properties are inferred and filled, as they affect cache key.
+    graph.validate()
+    cache_key = graph.key()
+
+    # If a built graph does not exist in cache already, make one and place it in
+    if cache_key not in _cudnn_layernormex_cache:
+        graph.build_operation_graph()
+        graph.create_execution_plans([cudnn.heur_mode.A])
+        graph.check_support()
+        graph.build_plans(cudnn.build_plan_policy.HEURISTICS_CHOICE)
+
+        _cudnn_layernormex_cache[cache_key] = (input, scale, bias_cudnn, epsilon, Y, graph)
+    return _cudnn_layernormex_cache[cache_key]
+
 def _transform_layer_norm_inputs(a, normalized_shape, weight, bias):
-    elements_to_normalize = np.prod(normalized_shape)
-    batch_size = np.prod(a.shape[: -len(normalized_shape)], dtype=int)
+    if LooseVersion(cudnn.backend_version_string()) >= "9.1":
+        def compute_contiguous_strides(shape):
+            strides = [1] * len(shape)
+            stride = 1
+            for i in reversed(range(len(shape))):
+                strides[i] = stride
+                stride *= shape[i]
+            return tuple(strides)
 
-    # Assume strides to be NCHW contiguous
-    assumed_stride = (elements_to_normalize, 1, 1, 1)
-    a_4d = CudnnTensorAttributes((batch_size, elements_to_normalize, 1, 1), assumed_stride, a.dtype, a.device.index)
-    weight_4d = CudnnTensorAttributes(
-        (1, elements_to_normalize, 1, 1), assumed_stride, weight.dtype, weight.device.index
-    )
-    bias_4d = CudnnTensorAttributes((1, elements_to_normalize, 1, 1), assumed_stride, bias.dtype, bias.device.index)
+        a_new = CudnnTensorAttributes(a.shape, compute_contiguous_strides(a.shape), a.dtype, a.device.index)
+        weight_new = None
+        if weight is not None:
+            # Make weight to be of the same dimensionality as other input tensors
+            weight_shape = (1,) * (a.ndim - weight.ndim) + weight.shape
+            weight_new = CudnnTensorAttributes(
+                weight_shape, compute_contiguous_strides(weight_shape), weight.dtype, weight.device.index
+            )
+        bias_new = None
+        if bias is not None:
+            # Make bias to be of the same dimensionality as other input tensors
+            bias_shape = (1,) * (a.ndim - bias.ndim) + bias.shape
+            bias_new = CudnnTensorAttributes(
+                bias_shape, compute_contiguous_strides(bias_shape), bias.dtype, bias.device.index
+            )
+        
+        return a_new, weight_new, bias_new
+    else:
+        # cudnn only supports following:
+        # input tensor shape: N, C, (D), H, W
+        # normalized shape:  (C, (D), H, W)
+        # convert all tensor shapes to above format
+        elements_to_normalize = np.prod(normalized_shape)
+        batch_size = np.prod(a.shape[: -len(normalized_shape)], dtype=int)
 
-    return a_4d, weight_4d, bias_4d
+        # Assume strides to be NCHW contiguous
+        assumed_stride = (elements_to_normalize, 1, 1, 1)
+        a_4d = CudnnTensorAttributes((batch_size, elements_to_normalize, 1, 1), assumed_stride, a.dtype, a.device.index)
+        weight_4d = CudnnTensorAttributes(
+            (1, elements_to_normalize, 1, 1), assumed_stride, weight.dtype, weight.device.index
+        )
+        bias_4d = CudnnTensorAttributes((1, elements_to_normalize, 1, 1), assumed_stride, bias.dtype, bias.device.index)
+
+        return a_4d, weight_4d, bias_4d
 
 
-def layer_norm_impl(a, normalized_shape, weight=None, bias=None, eps=1e-5):
+def _cudnn_layer_norm_fwd_impl(
+    a: torch.Tensor,
+    normalized_shape: List[int],
+    weight: torch.Tensor | None = None,
+    bias: torch.Tensor | None = None,
+    eps: float = 1e-5):
     a_4d, weight_4d, bias_4d = _transform_layer_norm_inputs(a, normalized_shape, weight, bias)
     input, scale, B, epsilon, Y, graph = _make_cudnn_layer_norm_graph(a_4d, weight_4d, bias_4d)
 
-    Y_actual = torch.zeros_like(a, device="cuda")
-
+    Y_actual = torch.empty_like(a)
     epsilon_cpu = torch.full((1, 1, 1, 1), eps, dtype=torch.float32, device="cpu")
-
-    workspace = torch.empty(graph.get_workspace_size(), device="cuda", dtype=torch.uint8)
+    workspace = torch.empty(graph.get_workspace_size(), device=a.device, dtype=torch.uint8)
 
     cudnn_to_torch_tensor = {input: a, scale: weight, B: bias, epsilon: epsilon_cpu, Y: Y_actual}
 
-    graph.execute(cudnn_to_torch_tensor, workspace)
+    # Even though the handle is created on a.device, cudnn still requires to set current device to a.device.
+    # This is most probably a bug and is being actively looked into.
+    with torch.cuda.device(a.device):
+        graph.execute(cudnn_to_torch_tensor, workspace)
 
     return Y_actual
 
 
-def layer_norm_checker(a, normalized_shape, weight=None, bias=None, eps=1e-5):
+def _cudnn_layer_norm_checker(
+    a: TensorLike,
+    normalized_shape: List[int],
+    weight: TensorLike | None = None,
+    bias: TensorLike | None = None,
+    eps: float = 1e-5):
     if cudnn is None:
         return False
 
@@ -122,13 +164,16 @@ def layer_norm_checker(a, normalized_shape, weight=None, bias=None, eps=1e-5):
 
     try:
         _make_cudnn_layer_norm_graph(a_4d, weight_4d, bias_4d)
-    except:
+    except cudnn.cudnnGraphNotSupportedError as ex:
         return False
-
+    except Exception as e:
+        raise 
+    
     return True
 
 
 import thunder.torch as ltorch
 
-layer_norm = cudnn_layernorm_ex.register_operator("cudnn_layernorm", like=ltorch.layer_norm, fn=layer_norm_impl)
-cudnn_layernorm_ex.register_implementation(ltorch.layer_norm, layer_norm, checker=layer_norm_checker)
+cudnn_layer_norm_fwd = cudnn_layernorm_ex.register_operator("cudnn_layernorm_fwd", like=ltorch.layer_norm, fn=_cudnn_layer_norm_fwd_impl)
+cudnn_layernorm_ex.register_implementation(ltorch.layer_norm, cudnn_layer_norm_fwd, checker=_cudnn_layer_norm_checker)
+

--- a/thunder/executors/cudnn_layernormex.py
+++ b/thunder/executors/cudnn_layernormex.py
@@ -1,4 +1,4 @@
-from typing import Any, List
+from typing import Any
 
 from looseversion import LooseVersion
 import torch

--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -6405,6 +6405,19 @@ def layer_norm_reference_generator(op, device, dtype, requires_grad, **kwargs):
 
         yield SampleInput(a, normalized_shape, weight, bias, 1e-03)
 
+    
+    # Test with/without weight/bias
+    batch, seq_len, embedding = cases[0]
+    a = make_arg(batch, seq_len, embedding)
+    normalized_shape = (embedding,)
+    weight = make_arg(normalized_shape)
+    bias = make_arg(normalized_shape)
+
+    yield SampleInput(a, normalized_shape, None, bias, 1e-03)
+    yield SampleInput(a, normalized_shape, weight, None, 1e-03)
+    yield SampleInput(a, normalized_shape, None, None, 1e-03)
+
+
 
 def layer_norm_sample_generator(op, device, dtype, requires_grad, **kwargs):
     # input_shape, normalized_shape, kwargs

--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -6405,7 +6405,6 @@ def layer_norm_reference_generator(op, device, dtype, requires_grad, **kwargs):
 
         yield SampleInput(a, normalized_shape, weight, bias, 1e-03)
 
-    
     # Test with/without weight/bias
     batch, seq_len, embedding = cases[0]
     a = make_arg(batch, seq_len, embedding)
@@ -6416,7 +6415,6 @@ def layer_norm_reference_generator(op, device, dtype, requires_grad, **kwargs):
     yield SampleInput(a, normalized_shape, None, bias, 1e-03)
     yield SampleInput(a, normalized_shape, weight, None, 1e-03)
     yield SampleInput(a, normalized_shape, None, None, 1e-03)
-
 
 
 def layer_norm_sample_generator(op, device, dtype, requires_grad, **kwargs):


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

## What does this PR do?
This PR adds more functionality to cudnn's layernorm
1. Adds optional bias and scale
2. Updates to cudnn 9.1 requirements
3. Removes older way of caching full graph making function

Future:
1. Add benchmarks for LN fwd with litgpt configs
2. Add LN bwd
3. Add RMSnorm 

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
