### PR TITLE
[benchmark] call `distributed_c10d.destroy_process_group` in benchmark_litgpt

### DIFF
--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -510,3 +510,7 @@ if __name__ == "__main__":
     from jsonargparse import CLI
 
     CLI(benchmark_main)
+
+    # ref: https://github.com/pytorch/pytorch/blame/3af12447f85dfede191a113c052e58fa7b21a8b3/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp#L1110-L1116
+    if world_size > 1:
+        torch_dist.destroy_process_group()

--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -511,6 +511,6 @@ if __name__ == "__main__":
 
     CLI(benchmark_main)
 
-    # ref: https://github.com/pytorch/pytorch/blame/3af12447f85dfede191a113c052e58fa7b21a8b3/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp#L1110-L1116
+    # ref: https://github.com/pytorch/pytorch/blob/3af12447/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp#L1110-L1116
     if world_size > 1:
         torch_dist.destroy_process_group()


### PR DESCRIPTION
as per title.

cc @crcrpar @carmocca @awaelchli