### PR TITLE
[fsdp] Add option of AllGather rate limiting (mainly for ZERO2)

### DIFF
--- a/thunder/executors/torch_autograd.py
+++ b/thunder/executors/torch_autograd.py
@@ -218,12 +218,14 @@ def split_forward_backward(computation_trc: TraceCtx, compile_data, compile_stat
     # communication ops as possible. But it causes the all_gather_prim_impl nodes gathered at the start of
     # backward trace and increases the peak allocated memory
     if getattr(compile_data.fn, "use_fsdp", False):
+        from thunder.distributed import FSDPBucketingStrategy
+        from thunder.distributed.utils import limit_in_flight_allgathers
+
         assert hasattr(compile_data.fn, "sharding_strategy")
         assert hasattr(compile_data.fn, "apply_rate_limiting")
         apply_rate_limiting = compile_data.fn.apply_rate_limiting
+        utils.check_type(apply_rate_limiting, bool)
         if getattr(compile_data.fn, "sharding_strategy") == FSDPType.ZERO3:
-            from thunder.distributed import FSDPBucketingStrategy
-            from thunder.distributed.utils import limit_in_flight_allgathers
 
             fw_extrace = sort_waits_for_zero3(fw_extrace)
             if apply_rate_limiting:


### PR DESCRIPTION
Adding the new argument of `apply_rate_limting` to `thunder.distributed.fsdp` so that we can try rate limiting of AllGather, for especially when ZERO2 is used.

The major changes this pr brings are options of (a) trying rate limiting with zero2 and (b) turning off it for zero3.

Previously I tried this with llama-2-7b-hf-ish models with zero2 but the perf gain wasn't seen.
I however think it might make sense to have an option to switch on/off it.