### PR TITLE
test_ddp: don't use clear=True for patching os.environ

### DIFF
--- a/thunder/tests/distributed/test_ddp.py
+++ b/thunder/tests/distributed/test_ddp.py
@@ -1502,7 +1502,9 @@ def test_native_fsdp(executor, devices, dtype, bucket_size_in_mb):
         # when running the tests.
         # With the setting below, we use `torch.jit` for this test suite
         # See: https://github.com/NVIDIA/TransformerEngine/blob/a38b291b0d1b04847e8ab1df8550df642a03a27d/transformer_engine/pytorch/jit.py#L11-L19
-        unittest.mock.patch.dict(os.environ, {"NVTE_TORCH_COMPILE": "0"}, clear=True),
+        # NOTE: We don't pass `clear=True` to `unittest.mock.patch.dict` as that may clear paths
+        # from environment leading to picking up of incorrect dependencies in the spawned process.
+        unittest.mock.patch.dict(os.environ, {"NVTE_TORCH_COMPILE": "0"}),
     ),
 )
 @ddp_wrapper("test_ddp_transformer_engine", _test_ddp_transformer_engine)
@@ -1519,7 +1521,9 @@ def test_ddp_transformer_engine(executor, devices, dtype):
         pytest.mark.skipif(not TE_AVAILABLE, reason="TransformerEngine is not installed."),
         pytest.mark.skipif(not is_fp8_supported, reason=fp8_support_reason),
         # See NOTE: Setting `NVTE_TORCH_COMPILE`
-        unittest.mock.patch.dict(os.environ, {"NVTE_TORCH_COMPILE": "0"}, clear=True),
+        # NOTE: We don't pass `clear=True` to `unittest.mock.patch.dict` as that may clear paths
+        # from environment leading to picking up of incorrect dependencies in the spawned process.
+        unittest.mock.patch.dict(os.environ, {"NVTE_TORCH_COMPILE": "0"}),
     ),
 )
 @ddp_wrapper("test_ddp_transformer_engine_llama_sanity", _test_ddp_transformer_engine_llama_sanity)


### PR DESCRIPTION
We shouldn't pass `clear=True` to `unittest.mock.patch.dict` as that may clear paths from environment leading to picking up of incorrect dependencies in the spawned process.

Script below shows difference between setting clear=True and (default) clear=False

```python
import unittest.mock
my_dict = {"a": 1}

print(my_dict)  # {'a': 1}

with unittest.mock.patch.dict(my_dict, {"b": 2}, clear=True):
    print(my_dict)  # {'b': 2}

print(my_dict)  # {'a': 1}

with unittest.mock.patch.dict(my_dict, {"b": 2}):
    print(my_dict)  # {'a': 1, 'b': 2}

print(my_dict)  # {'a': 1}

```