### PR TITLE
Caches expensive cudnn graph validation

### DIFF
--- a/thunder/executors/cudnnex.py
+++ b/thunder/executors/cudnnex.py
@@ -163,17 +163,10 @@ def _make_cudnn_sdpa_forward_graph(query, key, value, attn_mask, dropout_p, is_c
 
     softmax_stats.set_output(True).set_data_type(torch_to_cudnn_dtype(torch.float32))
 
-    # Validate the graph before querying the cache key
-    # Validation makes sure all missing properties are inferred and filled, as they affect cache key.
-    graph.validate()
     cache_key = graph.key()
-
     # If a built graph does not exist in cache already, make one and place it in
     if cache_key not in _cudnnex_cache:
-        graph.build_operation_graph()
-        graph.create_execution_plans([cudnn.heur_mode.A])
-        graph.check_support()
-        graph.build_plans(cudnn.build_plan_policy.HEURISTICS_CHOICE)
+        graph.build([cudnn.heur_mode.A])
 
         _cudnnex_cache[cache_key] = (
             Q,
@@ -464,17 +457,10 @@ def _make_cudnn_sdpa_backward_graph(
         torch_to_cudnn_dtype(value.dtype)
     )
 
-    # Validate the graph before querying the cache key
-    # Validation makes sure all missing properties are inferred and filled, as they affect cache key.
-    graph.validate()
     cache_key = graph.key()
-
     # If a built graph does not exist in cache already, make one and place it in
     if cache_key not in _cudnnex_cache:
-        graph.build_operation_graph()
-        graph.create_execution_plans([cudnn.heur_mode.A])
-        graph.check_support()
-        graph.build_plans(cudnn.build_plan_policy.HEURISTICS_CHOICE)
+        graph.build([cudnn.heur_mode.A])
 
         _cudnnex_cache[cache_key] = (
             Q,


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

## What does this PR do?
- cudnn kernels have a large launch latency due to cpu overhead
- This becomes a bottleneck in fsdp setting as described in issue #241. 
- It also causes smaller models/configs to not show speedup with cudnn
- The main culprit is cudnn graph validation
- Earlier:
    - graph validation was not cached
    - This is because it used to fill out various missing attributes that helps in making more complete caching key
    - Takes ~1.5 ms
- Now:
    - graph validation is cached
    - There is no need right now to fill all attributes before querying cache key
    - Same set of inputs to thunder cudnnex will lead to same final missing attributes.
- Future:
    - cudnn will further optimize cache key API
    - It currently takes 70 us.
 
cuda API kernel launch overhead:

Before:
2.5 ms of cpu overhead
![Screenshot 2024-04-24 at 2 00 19 PM](https://github.com/Lightning-AI/lightning-thunder/assets/142048820/6f999f4d-79df-4e9f-bfc9-91b8a5607527)


After:
1 ms of cpu overhead
![Screenshot 2024-04-24 at 2 04 17 PM](https://github.com/Lightning-AI/lightning-thunder/assets/142048820/eaf0e53a-aaf7-4865-aec9-548000c53ecf)


Fixes #241 .

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.