### PR TITLE
Add support for `scatter_add` gradient

### DIFF
--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -833,6 +833,21 @@ register_grad(pids.GATHER, _gather_prim_grad)
 
 
 @torchctx
+def _scatter_add_prim_grad(a: TensorProxy, /, index: TensorProxy, value: TensorProxy, dim: int) -> TensorProxy:
+    fwd = prims.scatter_add(a, index, value, dim)
+
+    g = get_grad(fwd)
+    # NOTE The value gradient is only valid when src.shape == index.shape.
+    value_grad = prims.gather(g, index, dim)
+    put_grads((a, value), (g, value_grad))
+
+    return fwd
+
+
+register_grad(pids.SCATTER_ADD, _scatter_add_prim_grad)
+
+
+@torchctx
 def _take_along_axis_prim_grad(a: TensorProxy, index: TensorProxy, dim: int) -> TensorProxy:
     fwd = prims.take_along_axis(a, index, dim)
 

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -1973,6 +1973,11 @@ def gather(a: TensorLike, /, dim: int, index: TensorLike) -> TensorLike:
 # NOTE PyTorch's scatter_add has a parameter named 'src', not 'source'
 @torchsymbol(torch.scatter_add)
 def scatter_add(a: TensorLike, /, dim: int, index: TensorLike, src: TensorLike) -> TensorLike:
+    utils.check(
+        not src._requires_grad or src.shape == index.shape,
+        lambda: f"The gradient for the src Tensor is implemented only when src.shape == index.shape. "
+        "src shape is {src.shape} while index shape is {index.shape}"
+    )
     return clang.scatter_add(a, indices=index, value=src, dim=dim)
 
 


### PR DESCRIPTION
This PR adds support for `scatter_add` gradient. 

**Note:** The value gradient is only defined when `value.shape == index.shape`.
See https://pytorch.org/docs/stable/generated/torch.Tensor.scatter_add_.html#torch.Tensor.scatter_add_
