### PR TITLE
Add SDPA benchmark for Llama 2 13B, Llama 2 70B, Llama 3 8B, Llama 3 70B

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -11,7 +11,7 @@ expecttest ==0.2.1  # for test_ddp.py
 hypothesis ==6.100.0  # for test_ddp.py
 numpy  # for test_ops.py
 einops  # for test_einops.py
-litgpt @ git+https://github.com/Lightning-AI/lit-gpt@940ffc96f7214bca24aa77479bc7c33900aaef28
+litgpt @ git+https://github.com/Lightning-AI/lit-gpt@54628ecbdf72b2ceb42bb0ef5f74f1a89ec13d2f
 absl-py # thunder/benchmarks/test_benchmark_litgpt.py
 pandas # thunder/benchmarks/test_benchmark_litgpt.py
 xlsxwriter # thunder/benchmarks/test_benchmark_litgpt.py

--- a/thunder/benchmarks/__init__.py
+++ b/thunder/benchmarks/__init__.py
@@ -737,6 +737,7 @@ from thunder.executors.cudnn_layernormex import cudnn_layernorm_ex
 
 thunder_cudnn_executor: None | Callable = None
 thunder_cudnn_nvfuser_executor: None | Callable = None
+thunder_cudnn_sdpa_torch_compile_nvfuser_executor: None | Callable = None
 thunder_cudnn_layer_norm_executor: None | Callable = None
 thunder_cudnn_layer_norm_nvfuser_executor: None | Callable = None
 if cudnn_available():
@@ -748,6 +749,10 @@ if cudnn_available():
     def thunder_cudnn_nvfuser_executor(fn: Callable) -> Callable:
         torch.backends.cuda.matmul.allow_tf32 = True
         return thunder.jit(fn, executors=[cudnn_ex, thunder.nvfuser_executor])
+
+    def thunder_cudnn_sdpa_torch_compile_nvfuser_executor(fn: Callable) -> Callable:
+        torch.backends.cuda.matmul.allow_tf32 = True
+        return thunder.jit(fn, executors=[cudnn_ex, sdpa_ex, torch_compile_ex, thunder.nvfuser_executor])
 
     def thunder_cudnn_layer_norm_executor(fn: Callable) -> Callable:
         torch.backends.cuda.matmul.allow_tf32 = True

--- a/thunder/benchmarks/__init__.py
+++ b/thunder/benchmarks/__init__.py
@@ -737,7 +737,6 @@ from thunder.executors.cudnn_layernormex import cudnn_layernorm_ex
 
 thunder_cudnn_executor: None | Callable = None
 thunder_cudnn_nvfuser_executor: None | Callable = None
-thunder_cudnn_sdpa_torch_compile_nvfuser_executor: None | Callable = None
 thunder_cudnn_layer_norm_executor: None | Callable = None
 thunder_cudnn_layer_norm_nvfuser_executor: None | Callable = None
 if cudnn_available():
@@ -749,10 +748,6 @@ if cudnn_available():
     def thunder_cudnn_nvfuser_executor(fn: Callable) -> Callable:
         torch.backends.cuda.matmul.allow_tf32 = True
         return thunder.jit(fn, executors=[cudnn_ex, thunder.nvfuser_executor])
-
-    def thunder_cudnn_sdpa_torch_compile_nvfuser_executor(fn: Callable) -> Callable:
-        torch.backends.cuda.matmul.allow_tf32 = True
-        return thunder.jit(fn, executors=[cudnn_ex, sdpa_ex, torch_compile_ex, thunder.nvfuser_executor])
 
     def thunder_cudnn_layer_norm_executor(fn: Callable) -> Callable:
         torch.backends.cuda.matmul.allow_tf32 = True

--- a/thunder/benchmarks/targets.py
+++ b/thunder/benchmarks/targets.py
@@ -33,7 +33,6 @@ from thunder.benchmarks import (
     thunder_apex_nvfuser_executor,
     thunder_cudnn_executor,
     thunder_cudnn_nvfuser_executor,
-    thunder_cudnn_sdpa_torch_compile_nvfuser_executor,
     thunder_cudnn_layer_norm_executor,
     thunder_cudnn_layer_norm_nvfuser_executor,
     thunder_sdpa_executor,
@@ -597,15 +596,9 @@ sdpa_executors = (
     torch_executor,
     torch_compile_executor,
     thunder_executor,
-    thunder_sdpa_torch_compile_nvfuser_executor,
     *(
         (thunder_cudnn_nvfuser_executor,)
         if thunder_cudnn_nvfuser_executor is not None
-        else ()
-    ),
-    *(
-        (thunder_cudnn_sdpa_torch_compile_nvfuser_executor,)
-        if thunder_cudnn_sdpa_torch_compile_nvfuser_executor is not None
         else ()
     ),
 )
@@ -613,9 +606,7 @@ sdpa_executors_ids = (
     "torch",
     "torch.compile",
     "thunder",
-    "thunder+inductor_concat",
     *(("thunder+cudnn",) if thunder_cudnn_nvfuser_executor is not None else ()),
-    *(("thunder+cudnn+inductor_concat",) if thunder_cudnn_sdpa_torch_compile_nvfuser_executor is not None else ()),
 )
 
 # Sample command to run this benchmark:

--- a/thunder/tests/test_jit_general.py
+++ b/thunder/tests/test_jit_general.py
@@ -621,6 +621,7 @@ def test_nanogpt():
         "falcon-7b-like",
         "falcon-40b-like",
         "codellama2-like",
+        "Llama-3-8B",
         pytest.param(
             "mixtral-like",
             marks=pytest.mark.xfail(raises=(NotImplementedError, TypeError), reason="topk and where", strict=True),
@@ -639,6 +640,7 @@ def test_litgpt_variants(name, device):
 
     x = torch.randint(0, 200, (5, 5), device=device)
     config = litgpt_model.Config.from_name(name)
+    config.n_layer = 1
 
     with device:
         reference = litgpt_model.GPT(config)


### PR DESCRIPTION
New parametrized microbenchmark to test the performance of several configurations of the scaled dot product attention call:
```
pytest thunder/benchmarks/targets.py -k "test_litgpt_sdpa_grad" --collect-only
<Module thunder/benchmarks/targets.py>
  <Function test_litgpt_sdpa_grad[Llama-2-7b-hf-torch]>
  <Function test_litgpt_sdpa_grad[Llama-2-7b-hf-torch.compile]>
  <Function test_litgpt_sdpa_grad[Llama-2-7b-hf-thunder]>
  <Function test_litgpt_sdpa_grad[Llama-2-7b-hf-thunder+cudnn]>
  <Function test_litgpt_sdpa_grad[Llama-2-13b-hf-torch]>
  <Function test_litgpt_sdpa_grad[Llama-2-13b-hf-torch.compile]>
  <Function test_litgpt_sdpa_grad[Llama-2-13b-hf-thunder]>
  <Function test_litgpt_sdpa_grad[Llama-2-13b-hf-thunder+cudnn]>
  <Function test_litgpt_sdpa_grad[Llama-2-70b-hf-torch]>
  <Function test_litgpt_sdpa_grad[Llama-2-70b-hf-torch.compile]>
  <Function test_litgpt_sdpa_grad[Llama-2-70b-hf-thunder]>
  <Function test_litgpt_sdpa_grad[Llama-2-70b-hf-thunder+cudnn]>
  <Function test_litgpt_sdpa_grad[Llama-3-8B-torch]>
  <Function test_litgpt_sdpa_grad[Llama-3-8B-torch.compile]>
  <Function test_litgpt_sdpa_grad[Llama-3-8B-thunder]>
  <Function test_litgpt_sdpa_grad[Llama-3-8B-thunder+cudnn]>
  <Function test_litgpt_sdpa_grad[Llama-3-70B-torch]>
  <Function test_litgpt_sdpa_grad[Llama-3-70B-torch.compile]>
  <Function test_litgpt_sdpa_grad[Llama-3-70B-thunder]>
  <Function test_litgpt_sdpa_grad[Llama-3-70B-thunder+cudnn]>
```

H100 results:
```py
TODO
```

I have updated the litgpt pin to include the Llama 3 config and added it to the general jit tests.