### PR TITLE
add `numel` method with default attribute

### DIFF
--- a/thunder/core/langctxs.py
+++ b/thunder/core/langctxs.py
@@ -64,9 +64,13 @@ def reset_langctx(token: Any, /) -> None:
 
 # A helper for acquiring a method
 def resolve_method(id: Any, *args, **kwargs) -> Callable:
-    ctx: LanguageContext = get_langctx()
-    method: Callable = ctx.get_method(id, *args, **kwargs)
-    return method
+    try:
+        ctx: LanguageContext = get_langctx()
+    except:
+        return None
+    finally:
+        method: Callable = ctx.get_method(id, *args, **kwargs)
+        return method
 
 
 _langctx_registry: dict[Any, LanguageContext] = {}

--- a/thunder/core/langctxs.py
+++ b/thunder/core/langctxs.py
@@ -53,7 +53,10 @@ def set_langctx(ctx: LanguageContext, /) -> Any:
 
 def get_langctx() -> LanguageContext:
     """Gets the current language context"""
-    t = _langctx.get()
+    try:
+        t = _langctx.get()
+    except LookupError:
+        return None
     return t
 
 
@@ -64,13 +67,14 @@ def reset_langctx(token: Any, /) -> None:
 
 # A helper for acquiring a method
 def resolve_method(id: Any, *args, **kwargs) -> Callable:
+    ctx: LanguageContext = get_langctx()
+    # is ctx ever None?
+    # it falls to Prim context
     try:
-        ctx: LanguageContext = get_langctx()
-    except:
-        return None
-    finally:
         method: Callable = ctx.get_method(id, *args, **kwargs)
-        return method
+    except (AttributeError, ValueError) as e:
+        return None
+    return method
 
 
 _langctx_registry: dict[Any, LanguageContext] = {}

--- a/thunder/core/langctxs.py
+++ b/thunder/core/langctxs.py
@@ -53,10 +53,7 @@ def set_langctx(ctx: LanguageContext, /) -> Any:
 
 def get_langctx() -> LanguageContext:
     """Gets the current language context"""
-    try:
-        t = _langctx.get()
-    except LookupError:
-        return None
+    t = _langctx.get()
     return t
 
 
@@ -67,10 +64,14 @@ def reset_langctx(token: Any, /) -> None:
 
 # A helper for acquiring a method
 def resolve_method(id: Any, *args, **kwargs) -> Callable:
-    ctx: LanguageContext = get_langctx()
-    # is ctx ever None?
-    # it falls to Prim context
+    # I could combine the try/except statements but intentionally separated them for clarity
     try:
+        ctx: None | LanguageContext = get_langctx()
+    except LookupError:
+        return None
+    try:
+        # AttributeError occurs when there is language context is None or when that context does not have the attribute
+        # ValueError occurs when it access prims context
         method: Callable = ctx.get_method(id, *args, **kwargs)
     except (AttributeError, ValueError) as e:
         return None

--- a/thunder/core/langctxs.py
+++ b/thunder/core/langctxs.py
@@ -63,15 +63,14 @@ def reset_langctx(token: Any, /) -> None:
 
 
 # A helper for acquiring a method
-def resolve_method(id: Any, *args, **kwargs) -> Callable:
-    # I could combine the try/except statements but intentionally separated them for clarity
+def resolve_method(id: Any, *args, **kwargs) -> None | Callable:
     try:
         ctx: None | LanguageContext = get_langctx()
     except LookupError:
         return None
     try:
-        # AttributeError occurs when there is language context is None or when that context does not have the attribute
-        # ValueError occurs when it access prims context
+        # ctx.get_method throws an AttributeError when the context does not have the requested attribute, except
+        # for the prims language context, which always throws a ValueError
         method: Callable = ctx.get_method(id, *args, **kwargs)
     except (AttributeError, ValueError) as e:
         return None

--- a/thunder/core/proxies.py
+++ b/thunder/core/proxies.py
@@ -1179,10 +1179,6 @@ class TensorProxy(Proxy, TensorProxyInterface):
         return self._shape
 
     @property
-    def numel(self):
-        return self._numel
-
-    @property
     def ndim(self):
         return self._ndim
 
@@ -1232,12 +1228,22 @@ class TensorProxy(Proxy, TensorProxyInterface):
     # NOTE __getattr__ is overridden to support language-specific methods
     def __getattr__(self, attr: str, /):
         method_or_value: None | Callable | Any = resolve_method(attr, self)
+        if method_or_value is None:
+            method_or_value = self.get_default_attr(attr)
         baseutils.check(method_or_value is not None, lambda: f"Unknown attribute {attr}", exception_type=AttributeError)
 
         if callable(method_or_value):
             return partial(method_or_value, self)
 
         return method_or_value
+
+    #
+    # Default attribute
+    #
+    def get_default_attr(self, attr: str, /) -> None | Any:
+        if attr == "numel":
+            return self._numel
+        return None
 
     #
     # Datatype conversion shorthands

--- a/thunder/core/proxies.py
+++ b/thunder/core/proxies.py
@@ -1225,8 +1225,6 @@ class TensorProxy(Proxy, TensorProxyInterface):
     def type_string(self):
         return f"{self.device} {self.dtype.shortname()}{list(self.shape)}"
 
-
-
     # NOTE __getattr__ is overridden to support language-specific methods
     def __getattr__(self, attr: str, /):
         method_or_value: None | Callable | Any = resolve_method(attr, self)
@@ -1246,6 +1244,7 @@ class TensorProxy(Proxy, TensorProxyInterface):
         if attr == "numel":
             return self._numel
         return None
+
     #
     # Datatype conversion shorthands
     #

--- a/thunder/core/proxies.py
+++ b/thunder/core/proxies.py
@@ -1225,6 +1225,8 @@ class TensorProxy(Proxy, TensorProxyInterface):
     def type_string(self):
         return f"{self.device} {self.dtype.shortname()}{list(self.shape)}"
 
+
+
     # NOTE __getattr__ is overridden to support language-specific methods
     def __getattr__(self, attr: str, /):
         method_or_value: None | Callable | Any = resolve_method(attr, self)
@@ -1244,7 +1246,6 @@ class TensorProxy(Proxy, TensorProxyInterface):
         if attr == "numel":
             return self._numel
         return None
-
     #
     # Datatype conversion shorthands
     #

--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -1159,7 +1159,7 @@ def _var_mean_prim_grad(a: TensorProxy, /, dims: Sequence[int], *, correction: N
     gv = get_grad(v)
     gm = get_grad(m)
 
-    n_elem_reduced = a.numel // m.numel if a.numel != 0 else 1
+    n_elem_reduced = a.numel() // m.numel() if a.numel() != 0 else 1
 
     # Computes mean bwd
     mean_scale = 1.0 / n_elem_reduced
@@ -2636,7 +2636,7 @@ def var_aug_fwd(a, dim, *, correction):
 # TODO: fix grad when correction > n_elem_reduced.
 @register_backward(prims.PrimIDs.VAR)
 def var_backward(a, dim, correction, v, g):
-    n_elem_reduced = a.numel // v.numel if a.numel != 0 else 1
+    n_elem_reduced = a.numel() // v.numel() if a.numel() != 0 else 1
     normalization_scalar = n_elem_reduced - correction
     g = restore_reduced_dims(g, dim, a.shape)
     if a.dtype != v.dtype:
@@ -3125,7 +3125,7 @@ def cumsum_aug_fwd(a: Proxy, dim: int, *, dtype: None | dtypes.dtype = None) -> 
 @register_backward("torch.cumsum")
 def cumsum_backward(a_dtype, dim, g):
     g = g.to(a_dtype)
-    if g.numel <= 1 or g.shape[dim] == 1:
+    if g.numel() <= 1 or g.shape[dim] == 1:
         return g
     return g.flip(dim).cumsum(dim).flip(dim)
 

--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -4561,6 +4561,28 @@ opinfos.extend(shape_ops)
 reduction_ops = []
 
 
+def numel_sample_generator(op, device, dtype, requires_grad, **kwargs):
+    make = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)
+
+    cases = (
+        (0,),
+        (4, 2, 0),
+        (2, 2),
+    )
+
+    for shape in cases:
+        yield SampleInput(make(shape))
+
+
+numel_opinfo = OpInfo(
+    ltorch.numel,
+    dtypes=(datatypes.floating,),
+    sample_input_generator=numel_sample_generator,
+    torch_reference=torch.numel,
+)
+reduction_ops.append(numel_opinfo)
+
+
 # TODO: increase reduction samples and refacort amax and sum generators
 def amax_amin_sample_generator(op, device, dtype, requires_grad, **kwargs):
     # For grad test stability it's better to use wider range of values

--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -561,6 +561,28 @@ is_cuda_opinfo = OpInfo(
 
 tensor_properties.append(is_cuda_opinfo)
 
+
+def numel_sample_generator(op, device, dtype, requires_grad, **kwargs):
+    make = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)
+
+    cases = (
+        (0,),
+        (4, 2, 0),
+        (2, 2),
+    )
+
+    for shape in cases:
+        yield SampleInput(make(shape))
+
+
+numel_opinfo = OpInfo(
+    ltorch.numel,
+    dtypes=(datatypes.floating,),
+    sample_input_generator=numel_sample_generator,
+    torch_reference=torch.numel,
+)
+tensor_properties.append(numel_opinfo)
+
 opinfos.extend(tensor_properties)
 
 
@@ -4559,28 +4581,6 @@ opinfos.extend(shape_ops)
 # Reduction OpInfos
 #
 reduction_ops = []
-
-
-def numel_sample_generator(op, device, dtype, requires_grad, **kwargs):
-    make = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)
-
-    cases = (
-        (0,),
-        (4, 2, 0),
-        (2, 2),
-    )
-
-    for shape in cases:
-        yield SampleInput(make(shape))
-
-
-numel_opinfo = OpInfo(
-    ltorch.numel,
-    dtypes=(datatypes.floating,),
-    sample_input_generator=numel_sample_generator,
-    torch_reference=torch.numel,
-)
-reduction_ops.append(numel_opinfo)
 
 
 # TODO: increase reduction samples and refacort amax and sum generators

--- a/thunder/tests/test_core.py
+++ b/thunder/tests/test_core.py
@@ -646,6 +646,27 @@ def test_int_to_float_type_promotion(executor, device, _):
 #
 # Caching tests
 #
+@instantiate(dtypes=(thunder.float32, ))
+def test_fallback_method(executor, device: str, dtype: dtypes.dtype):
+    from thunder.core.trace import detached_trace
+    from thunder.core.proxies import TensorProxy    
+
+    torch_dtype = ltorch.to_torch_dtype(dtype)
+    a = make_tensor((2, 2), device=device, dtype=torch_dtype)
+    
+    with detached_trace():
+        b = TensorProxy(
+            name="__b",
+            shape=(2, 2),
+            device=thunder.core.devices.cpu,
+            dtype=thunder.core.dtypes.float32,
+            requires_grad=False,
+        )    
+    
+    # torch.numel(a) and a.numel() will run on PyTorch contenxt
+    # b.numel will fall back to the default implementation
+    assert torch.numel(a) == a.numel() == b.numel
+
 
 
 @instantiate(dtypes=(thunder.float32,))

--- a/thunder/tests/test_core.py
+++ b/thunder/tests/test_core.py
@@ -646,14 +646,14 @@ def test_int_to_float_type_promotion(executor, device, _):
 #
 # Caching tests
 #
-@instantiate(dtypes=(thunder.float32, ))
+@instantiate(dtypes=(thunder.float32,))
 def test_fallback_method(executor, device: str, dtype: dtypes.dtype):
     from thunder.core.trace import detached_trace
-    from thunder.core.proxies import TensorProxy    
+    from thunder.core.proxies import TensorProxy
 
     torch_dtype = ltorch.to_torch_dtype(dtype)
     a = make_tensor((2, 2), device=device, dtype=torch_dtype)
-    
+
     with detached_trace():
         b = TensorProxy(
             name="__b",
@@ -661,12 +661,11 @@ def test_fallback_method(executor, device: str, dtype: dtypes.dtype):
             device=thunder.core.devices.cpu,
             dtype=thunder.core.dtypes.float32,
             requires_grad=False,
-        )    
-    
+        )
+
     # torch.numel(a) and a.numel() will run on PyTorch contenxt
     # b.numel will fall back to the default implementation
     assert torch.numel(a) == a.numel() == b.numel
-
 
 
 @instantiate(dtypes=(thunder.float32,))

--- a/thunder/tests/test_core.py
+++ b/thunder/tests/test_core.py
@@ -646,26 +646,6 @@ def test_int_to_float_type_promotion(executor, device, _):
 #
 # Caching tests
 #
-@instantiate(dtypes=(thunder.float32,))
-def test_fallback_method(executor, device: str, dtype: dtypes.dtype):
-    from thunder.core.trace import detached_trace
-    from thunder.core.proxies import TensorProxy
-
-    torch_dtype = ltorch.to_torch_dtype(dtype)
-    a = make_tensor((2, 2), device=device, dtype=torch_dtype)
-
-    with detached_trace():
-        b = TensorProxy(
-            name="__b",
-            shape=(2, 2),
-            device=thunder.core.devices.cpu,
-            dtype=thunder.core.dtypes.float32,
-            requires_grad=False,
-        )
-
-    # torch.numel(a) and a.numel() will run on PyTorch contenxt
-    # b.numel will fall back to the default implementation
-    assert torch.numel(a) == a.numel() == b.numel
 
 
 @instantiate(dtypes=(thunder.float32,))
@@ -2331,6 +2311,29 @@ def test_preserve_weight_names(executor, device: str, dtype: dtypes.dtype):
     assert "t_fc1_weight" in sig.parameters
     assert "t_fc2_bias" in sig.parameters
     assert "t_fc2_weight" in sig.parameters
+
+
+@instantiate(dtypes=(thunder.float32,))
+def test_default_method(executor, device: str, dtype: dtypes.dtype):
+    # This test ensures that when no language context is given, it will fallback to the default implementation.
+    from thunder.core.trace import detached_trace
+    from thunder.core.proxies import TensorProxy
+
+    torch_dtype = ltorch.to_torch_dtype(dtype)
+    a = make_tensor((2, 2), device=device, dtype=torch_dtype)
+
+    with detached_trace():
+        b = TensorProxy(
+            name="__b",
+            shape=(2, 2),
+            device=thunder.core.devices.cpu,
+            dtype=thunder.core.dtypes.float32,
+            requires_grad=False,
+        )
+
+    # torch.numel(a) and a.numel() will run on PyTorch contenxt
+    # b.numel will fall back to the default implementation
+    assert torch.numel(a) == a.numel() == b.numel
 
 
 # @instantiate(

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -358,13 +358,13 @@ def type_as(a: TensorProxy, b: TensorProxy, /) -> TensorProxy:
 #
 
 
-# @torchsymbol(torch.numel, is_method=True)
-# def numel(a: TensorProxy, /) -> Number:
-#     size = a.size()
-#     out = 1
-#     for num in size:
-#         out *= num
-#     return out
+@torchsymbol(torch.numel, is_method=True)
+def numel(a: TensorProxy, /) -> Number:
+    size = a.size()
+    out = 1
+    for num in size:
+        out *= num
+    return out
 
 
 @torchsymbol(torch.arange)

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -187,6 +187,7 @@ def numel(a: TensorLike, /) -> Number:
         out *= num
     return out
 
+
 register_method("numel", numel)
 
 

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -179,14 +179,13 @@ def size(a):
     return fn_
 
 
-@torchsymbol(torch.Tensor.numel, is_method=True, id="torch.numel")
-def numel(a: TensorProxy, /):
+@torchsymbol(torch.Tensor.numel, is_method=True)
+def numel(a: TensorLike, /) -> Number:
     size = a.size()
     out = 1
     for num in size:
         out *= num
     return out
-
 
 register_method("numel", numel)
 
@@ -356,6 +355,15 @@ def type_as(a: TensorProxy, b: TensorProxy, /) -> TensorProxy:
 #
 # Tensor creation operations
 #
+
+
+# @torchsymbol(torch.numel, is_method=True)
+# def numel(a: TensorProxy, /) -> Number:
+#     size = a.size()
+#     out = 1
+#     for num in size:
+#         out *= num
+#     return out
 
 
 @torchsymbol(torch.arange)

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -180,12 +180,8 @@ def size(a):
 
 
 @torchsymbol(torch.numel, torch.Tensor.numel, is_method=True)
-def numel(a: TensorLike, /) -> Number:
-    size = a.size()
-    out = 1
-    for num in size:
-        out *= num
-    return out
+def numel(a: TensorLike, /) -> int:
+    return a._numel
 
 
 register_method("numel", numel)

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -179,6 +179,18 @@ def size(a):
     return fn_
 
 
+@torchsymbol(torch.Tensor.numel, is_method=True, id="torch.numel")
+def numel(a: TensorProxy, /):
+    size = a.size()
+    out = 1
+    for num in size:
+        out *= num
+    return out
+
+
+register_method("numel", numel)
+
+
 @torchsymbol(torch.Tensor.is_cuda, is_property=True, id="torch.is_cuda")
 def is_cuda(a: TensorLike, /) -> bool:
     return a.device.devicetype is devices.DeviceType.CUDA

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -179,7 +179,7 @@ def size(a):
     return fn_
 
 
-@torchsymbol(torch.Tensor.numel, is_method=True)
+@torchsymbol(torch.numel, torch.Tensor.numel, is_method=True)
 def numel(a: TensorLike, /) -> Number:
     size = a.size()
     out = 1
@@ -356,15 +356,6 @@ def type_as(a: TensorProxy, b: TensorProxy, /) -> TensorProxy:
 #
 # Tensor creation operations
 #
-
-
-@torchsymbol(torch.numel, is_method=True)
-def numel(a: TensorProxy, /) -> Number:
-    size = a.size()
-    out = 1
-    for num in size:
-        out *= num
-    return out
 
 
 @torchsymbol(torch.arange)
@@ -2681,7 +2672,7 @@ def _native_batch_norm(
                 new_running_mean = to(new_running_mean, running_mean.dtype)
             prims.copy_(new_running_mean, running_mean)
         if running_var is not None:
-            n = a.numel / a.shape[1]
+            n = a.numel() / a.shape[1]
             unbiased_var = biased_var * (n / (n - 1))
             new_running_var = (1 - momentum) * running_var + momentum * unbiased_var
             if not utils.are_same_dtypes(new_running_var, running_var):
@@ -3288,10 +3279,10 @@ def cross_entropy(
     C_dim = 1 if a.ndim >= 2 else 0
     N = a.shape[0] if a.ndim >= 2 else 1
     C = a.shape[C_dim]
-    feature_size = int(a.numel / N / C)
+    feature_size = int(a.numel() / N / C)
 
     # Short-circuits if a is empty
-    if a.numel == 0:
+    if a.numel() == 0:
         if reduction == "none":
             output_shape = list(a.shape)
             output_shape.pop(C_dim)
@@ -3307,7 +3298,7 @@ def cross_entropy(
 
     if weight is not None:
         utils.check(
-            weight.ndim == 1 and weight.numel == C,
+            weight.ndim == 1 and weight.numel() == C,
             lambda: f"Expected {weight.shape=} to have one dimension and {C} elements",
         )
         bcast_weight = reshape(weight, [C] + [1 for i in range(2, a.ndim)])
@@ -3473,18 +3464,18 @@ def cross_entropy(
                     output_dtype_kind=REDUCTION_OUTPUT_TYPE_KIND.SAME,
                 )
                 # NOTE: does the call numel here work with dynamic shape?!
-                out = reduced_sum / (target.numel - mask_sum)
+                out = reduced_sum / (target.numel() - mask_sum)
                 if label_smoothing > 0:
-                    ret = ret / (target.numel - mask_sum)
+                    ret = ret / (target.numel() - mask_sum)
                 elif target.ndim == 0:
                     # NOTE: this is pytorch implementation details.
                     # overwrite output to 0 when target hits ignore_index AND label_smoothing is missing.
                     # https://github.com/pytorch/pytorch/pull/64572
                     out = where((target == ignore_index), 0, out)
             else:
-                out = reduced_sum / target.numel
+                out = reduced_sum / target.numel()
                 if label_smoothing > 0:
-                    ret = ret / target.numel
+                    ret = ret / target.numel()
         else:
             raise ValueError(f"Reduction argument: {reduction} to cross_entropy is not supported")
 
@@ -3575,7 +3566,7 @@ def embedding(
         return clang.take(weight, a, 0)
 
     output_shape = list(a.shape) + list(weight.shape[1:])
-    flatten_indices = reshape(a, [a.numel])
+    flatten_indices = reshape(a, [a.numel()])
     flatten_output = clang.take(weight, flatten_indices, 0)
     return reshape(flatten_output, output_shape)
 
@@ -3623,11 +3614,11 @@ def group_norm(
         num_channels % num_groups == 0, lambda: f"group_norm: {num_channels=} should be divisible by {num_groups=}"
     )
     utils.check(
-        weight is None or (weight.ndim == 1 and weight.numel == num_channels),
+        weight is None or (weight.ndim == 1 and weight.numel() == num_channels),
         lambda: f"group_norm: {weight.ndim=} should be equal to 1 and {weight.numel=} to {num_channels=}",
     )
     utils.check(
-        bias is None or (bias.ndim == 1 and bias.numel == num_channels),
+        bias is None or (bias.ndim == 1 and bias.numel() == num_channels),
         lambda: f"group_norm: {bias.ndim=} should be equal to 1 and {bias.numel=} to {num_channels=}",
     )
 
@@ -3775,7 +3766,7 @@ def interpolate(
     )
 
     utils.check(a.ndim >= 3, lambda: f"Expected {a.ndim=} >= 3")
-    utils.check(a.numel > 0, lambda: f"Expected {a.numel=} to be greater than 0")
+    utils.check(a.numel() > 0, lambda: f"Expected {a.numel=} to be greater than 0")
 
     utils.check(
         (size is not None) ^ (scale_factor is not None),
@@ -3858,7 +3849,7 @@ def _nll_loss_helper(
     #   reduction = 'sum'  --- tensor(0.)
     #   reduction = 'mean' --- tensor(nan)
     # Mean reduction on empty tensors produces NaN.
-    if a.numel == 0 and target.numel == 0:
+    if a.numel() == 0 and target.numel() == 0:
         if reduction == "none":
             # Keep target shape if it is non-trivial
             result_shape = target.shape if target.shape != (0,) else []


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes #240. 

I have modified the use of `numel` in a torch context to `numel()`. Also, I have added a test case to compare the default `numel` attribute and torch version of `numel`. There is a operator test cas in `opinfos.py`.
Also, the test that is failing for this PR seems irrelevant to the PR (it occured once I merged the `main` branch to this branch and the error is related to `test_phantom_grad_vs_torch_consistency_getitem_`).

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Got to understand how language context is being interpreted and used! So much fun!
