### PR TITLE
Add `_stacklevel` to `thunder.torch.softmax`'s kwarg

### DIFF
--- a/thunder/executors/torchex.py
+++ b/thunder/executors/torchex.py
@@ -1329,7 +1329,6 @@ max_pool3d_with_indices_backward = ex.register_operator(
 nll_loss = _register_torch_operation("nll_loss", module=torch.nn.functional)
 pad = _register_torch_operation("pad", module=torch.nn.functional)
 scaled_dot_product_attention = _register_torch_operation("scaled_dot_product_attention", module=torch.nn.functional)
-_softmax = _register_torch_operation("_softmax")
 softmax = _register_torch_operation("softmax", like=ltorch._softmax)
 
 

--- a/thunder/executors/torchex.py
+++ b/thunder/executors/torchex.py
@@ -1329,7 +1329,8 @@ max_pool3d_with_indices_backward = ex.register_operator(
 nll_loss = _register_torch_operation("nll_loss", module=torch.nn.functional)
 pad = _register_torch_operation("pad", module=torch.nn.functional)
 scaled_dot_product_attention = _register_torch_operation("scaled_dot_product_attention", module=torch.nn.functional)
-softmax = _register_torch_operation("softmax")
+_softmax = _register_torch_operation("_softmax")
+softmax = _register_torch_operation("softmax", like=ltorch._softmax)
 
 
 # NOTE This transform translates number proxies to boolean values
@@ -1632,7 +1633,7 @@ _register_implementation(ltorch.nll_loss_backward, nll_loss_backward, checker=_a
 _register_implementation(ltorch.pad, pad, checker=_always_executable)
 pad_prim_impl = ex.register_operator("torch_pad_prim_impl", meta=prims.pad.meta, fn=_pad_prim_impl)
 _register_implementation(prims.pad, pad_prim_impl, checker=_always_executable)
-_register_implementation(ltorch.softmax, checker=_always_executable, execution_transform=_softmax_transform)
+_register_implementation(ltorch._softmax, checker=_always_executable, execution_transform=_softmax_transform)
 _register_implementation(ltorch.scaled_dot_product_attention, scaled_dot_product_attention, checker=_always_executable)
 
 

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -4118,6 +4118,9 @@ def _softmax(
     return converted
 
 
+register_method("softmax", _softmax)
+
+
 # A wrapper to support `torch.nn.Softmax` whose `forward` passes the kwarg of `_stacklevel=5` to `torch.nn.functional.softmax`.
 # ref: https://github.com/pytorch/pytorch/blob/8d12ba9acfa20ed7df438a8892c9bf8e6bef5775/torch/nn/modules/activation.py#L1545
 def softmax(a: TensorLike, dim: int, dtype: None | dtypeLike = None, _stacklevel: int = 3) -> TensorLike:

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -4094,7 +4094,7 @@ def sigmoid(a: TensorLike, /) -> TensorLike:
 
 
 # CompositeImplicitAutograd - don't register decomp
-@torchsymbol(torch.softmax, torch.nn.functional.softmax, is_method=True, id="softmax")
+@torchsymbol(torch.softmax, torch.nn.functional.softmax, is_method=True, id="torch.softmax")
 def _softmax(
     a: TensorLike,
     /,

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -114,6 +114,8 @@ class torchsymbol:
                     exception_type=AssertionError,
                 )
         else:
+            if not self.id.startswith("torch"):
+                warnings.warn("Given {self.id=} does not start with the namespace of `torch`")
             id = self.id
 
         if self.is_prim:

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -4094,7 +4094,7 @@ def sigmoid(a: TensorLike, /) -> TensorLike:
 
 
 # CompositeImplicitAutograd - don't register decomp
-@torchsymbol(torch.softmax, torch.nn.functional.softmax, is_method=True)
+@torchsymbol(torch.softmax, torch.nn.functional.softmax, is_method=True, id="softmax")
 def _softmax(
     a: TensorLike,
     /,

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -4095,13 +4095,12 @@ def sigmoid(a: TensorLike, /) -> TensorLike:
 
 # CompositeImplicitAutograd - don't register decomp
 @torchsymbol(torch.softmax, torch.nn.functional.softmax, is_method=True)
-def softmax(
+def _softmax(
     a: TensorLike,
     /,
     dim: int,
     *,
     dtype: None | dtypeLike = None,
-    _stacklevel: int = 3,
 ) -> TensorLike:
     result_dtype: dtypeLike = dtype or a.dtype
     result_dtype: dtypes.dtype = to_dtype(result_dtype)
@@ -4117,6 +4116,12 @@ def softmax(
     result = a_exp / sum(a_exp, dim, keepdim=True)
     converted = result.to(result_dtype)
     return converted
+
+
+# A wrapper to support `torch.nn.Softmax` whose `forward` passes the kwarg of `_stacklevel=5` to `torch.nn.functional.softmax`.
+# ref: https://github.com/pytorch/pytorch/blob/8d12ba9acfa20ed7df438a8892c9bf8e6bef5775/torch/nn/modules/activation.py#L1545
+def softmax(a: TensorLike, dim: int, dtype: None | dtypeLike = None, _stacklevel: int = 3) -> TensorLike:
+    return _softmax(a, dim=dim, dtype=dtype)
 
 
 #

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -4095,7 +4095,14 @@ def sigmoid(a: TensorLike, /) -> TensorLike:
 
 # CompositeImplicitAutograd - don't register decomp
 @torchsymbol(torch.softmax, torch.nn.functional.softmax, is_method=True)
-def softmax(a: TensorLike, /, dim: int, *, dtype: None | dtypeLike = None) -> TensorLike:
+def softmax(
+    a: TensorLike,
+    /,
+    dim: int,
+    *,
+    dtype: None | dtypeLike = None,
+    _stacklevel: int = 3,
+) -> TensorLike:
     result_dtype: dtypeLike = dtype or a.dtype
     result_dtype: dtypes.dtype = to_dtype(result_dtype)
     computation_dtype = utils.get_computation_dtype(result_dtype)


### PR DESCRIPTION
## What does this PR do?

Fixes #258.

`torch.nn.Softmax`'s forward method calls `torch.nn.functional.softmax` with `_stacklevel` kwarg in https://github.com/pytorch/pytorch/blob/b2f521f3769a9545b7c9df57569b1cba6116745b/torch/nn/modules/activation.py#L1545
and it doesn't seem that we have a test case of this way of calling [`torch.nn.functional.softmax`](https://github.com/pytorch/pytorch/blob/b2f521f3769a9545b7c9df57569b1cba6116745b/torch/nn/functional.py#L1857)

cc @ptrblck @Fuzzkatt 