### PR TITLE
add size fix

### DIFF
--- a/thunder/core/proxies.py
+++ b/thunder/core/proxies.py
@@ -1128,11 +1128,6 @@ class FutureTensorProxy(Proxy, TensorProxyInterface):
     def type_string(self):
         return f"FUTURE {self.device} {self.dtype.shortname()}{list(self.shape)}"
 
-    @property
-    def size(self, /) -> Any:
-        fn = resolve_method("size", self)
-        return fn(self)
-
     def wait(self) -> TensorProxy:
         from thunder.distributed.prims import wait
 
@@ -1205,11 +1200,6 @@ class TensorProxy(Proxy, TensorProxyInterface):
     @property
     def ddp_type(self):
         return self._ddp_type
-
-    @property
-    def size(self, /) -> Any:
-        fn = resolve_method("size", self)
-        return fn(self)
 
     # We need to implement `__len__` as
     # > In addition to bypassing any instance attributes in the

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -170,21 +170,16 @@ def is_floating_point(a: TensorLike, /) -> bool:
 
 
 # Handles the size method
-def size(a):
-    def fn_(idx: int | None = None):
-        if idx is None:
-            return a.shape
-        return a.shape[idx]
-
-    return fn_
+@torchsymbol(torch.Tensor.size, is_method=True, id="torch.Tensor.size")
+def size(a: TensorLike, dim: None | int = None) -> int | TensorLike:
+    if dim:
+        return a.shape[dim]
+    return a.shape
 
 
 @torchsymbol(torch.Tensor.is_cuda, is_property=True, id="torch.is_cuda")
 def is_cuda(a: TensorLike, /) -> bool:
     return a.device.devicetype is devices.DeviceType.CUDA
-
-
-register_method("size", size)
 
 
 #


### PR DESCRIPTION
Fixes https://github.com/Lightning-AI/lightning-thunder/issues/349 and by extension https://github.com/Lightning-AI/lightning-thunder/issues/289 which is blocked by it. Rewrites size in a way that is consistent with the other ops and removes the special logic around it that previously existed.
