### PR TITLE
Update test_linear_nvfuser

### DIFF
--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -2209,6 +2209,12 @@ def _linear_check(a: TensorProxy, b: TensorProxy, bias: TensorProxy | None) -> b
     if bias is not None and not is_supported_tensor(bias):
         return False
 
+    # nvFuser supports only fp16 and bf16 inputs. Only checking the first tensor
+    # dtype, as all tensors should have the same dtype which is checked by
+    # linear_meta.
+    if a.dtype not in (dtypes.float16, dtypes.bfloat16):
+        return False
+
     # nvFuser only supports 2D inputs in v0.2.3.
     if not a.ndim == 2:
         return False

--- a/thunder/tests/test_nvfuser.py
+++ b/thunder/tests/test_nvfuser.py
@@ -854,7 +854,12 @@ def test_optimization_fuel(executor, device, _):
 
 
 @instantiate(
-    dtypes=(thunder.float16, thunder.bfloat16), devicetypes=(devices.DeviceType.CUDA,), executors=(nvFuserExecutor,)
+    dtypes=(thunder.float16, thunder.bfloat16),
+    devicetypes=(devices.DeviceType.CUDA,),
+    executors=(nvFuserExecutor,),
+    decorators=(
+        pytest.mark.skipif(nvfuser_version() < LooseVersion("0.2.3"), reason="Requires nvFuser version 0.2.3 or later"),
+    ),
 )
 def test_linear(executor, device: str, dtype: dtypes.dtype):
 
@@ -877,9 +882,8 @@ def test_linear(executor, device: str, dtype: dtypes.dtype):
         out = compiled_func(a, b, bias)
         traces = thunder.last_traces(compiled_func)
         fusions = examine.get_fusions(traces[-1])
-        nv_version = nvfuser_version()
 
-        expected_fusions = 1 if nv_version >= LooseVersion("0.2.3") else 0
+        expected_fusions = 1
 
         assert len(fusions) == expected_fusions
         torch.testing.assert_close(out, torch.nn.functional.linear(a, b, bias))


### PR DESCRIPTION
Thunder's nvFuser executor got support for `prims.linear` in https://github.com/Lightning-AI/lightning-thunder/pull/318. This PR updates the test
* to use the sample generator from OpInfos
* to reject linear execution if inputs are not bf16, fp16
* to skip the test if the nvFuser version is not new enough

