### PR TITLE
thunder.jit - fix ignoring compile options

### DIFF
--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -407,11 +407,7 @@ def jit(
     )
     # TODO: rewrite the code below once options are finalized
     # NOTE: the following options might be absorbed by `compile_options`
-    absorbed_options = {
-        "use_cudagraphs",
-        "use_torch_compile",
-        "use_rematerialization"
-    }
+    absorbed_options = {"use_cudagraphs", "use_torch_compile", "use_rematerialization"}
     assert len(compile_data_params.keys() & absorbed_options) == len(absorbed_options)
     compile_data_params |= {opt_name: opt for opt_name, opt in compile_options.items() if opt_name in absorbed_options}
 

--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -389,7 +389,7 @@ def jit(
     assert type(record_history) is bool
 
     # TODO RC1 Refine the compile data option to remove unused options
-    cd = CompileData(
+    compile_data_params = dict(
         fn=fn,
         langctx=langctx,
         executors_list=executors,
@@ -402,9 +402,20 @@ def jit(
         use_rematerialization=False,
         only_execute_prims=False,
         disable_preprocessing=True,
-        compile_options=compile_options,
         executor_lookasides=executor_lookasides,
+        compile_options=compile_options,
     )
+    # TODO: rewrite the code below once options are finalized
+    # NOTE: the following options might be absorbed by `compile_options`
+    absorbed_options = {
+        "use_cudagraphs",
+        "use_torch_compile",
+        "use_rematerialization"
+    }
+    assert len(compile_data_params.keys() & absorbed_options) == len(absorbed_options)
+    compile_data_params |= {opt_name: opt for opt_name, opt in compile_options.items() if opt_name in absorbed_options}
+
+    cd = CompileData(**compile_data_params)
     cs = CompileStats()
 
     @_with_cache_info_ctx


### PR DESCRIPTION
As per title. This enables using `use_cudagraphs` and other options that were previously ignored.
Fixes https://github.com/Lightning-AI/lightning-thunder/issues/347