### PR TITLE
clear_collection: also clear other mutable collections besides list

### DIFF
--- a/thunder/executors/pythonex.py
+++ b/thunder/executors/pythonex.py
@@ -226,7 +226,7 @@ def _clear_collection_meta(coll: CollectionProxy) -> None:
 
 
 def _clear_collection_prim_impl(a: Sequence) -> None:
-    if isinstance(a, list):
+    if isinstance(a, (list, dict)):
         a.clear()
 
 

--- a/thunder/executors/pythonex.py
+++ b/thunder/executors/pythonex.py
@@ -1,7 +1,7 @@
 from typing import List, Any, Dict, Tuple, Union, Type
 from collections.abc import Callable
 from collections.abc import Hashable
-from collections.abc import Sequence
+from collections.abc import Sequence, Collection, MutableSet, MutableMapping, MutableSequence
 from numbers import Number
 import math
 import operator
@@ -225,8 +225,8 @@ def _clear_collection_meta(coll: CollectionProxy) -> None:
     return None
 
 
-def _clear_collection_prim_impl(a: Sequence) -> None:
-    if isinstance(a, (list, dict)):
+def _clear_collection_prim_impl(a: Collection) -> None:
+    if isinstance(a, (MutableSequence, MutableMapping, MutableSet)):
         a.clear()
 
 


### PR DESCRIPTION
Fixes: #366 

Tested with `thunder/tests/test_transformer_engine.py` and `thunder/tests/distributed/test_ddp.py -k transformer`.

Benchmark with `test_benchmark_litgpt` for `open_llama_3b` - FSDP Zero3 - Microbatch Size 1

thunder : Memory used: 25.07 GB
(Before PR) thunder + transformerengine : Memory used: 44.41 GB
(After PR) thunder + transformerengine : Memory used: 33.97 GB