### PR TITLE
fix benchmark script with TE and also remove te_ctx as we automatically wrap the trace with te_ctx.

### DIFF
--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -1,6 +1,7 @@
 import os
 import time
 from typing import Any
+from contextlib import nullcontext
 
 import torch
 import functools
@@ -356,8 +357,6 @@ class Benchmark_litGPT:
 
             te_ctx = te.fp8_autocast
         else:
-            from contextlib import nullcontext
-
             te_ctx = nullcontext
 
         if self.skip_data_sync:


### PR DESCRIPTION
Fixes: #369 

For case where, `transformerengine` is in `self.compile` and `self.skip_data_sync=False`, `nullcontext` is undefined.

https://github.com/Lightning-AI/lightning-thunder/blob/40e9c3ec7530cfc109a86301cb58ea62309da28b/thunder/benchmarks/benchmark_litgpt.py#L354-L367

Also, we remove `te_ctx` as it is not required since https://github.com/Lightning-AI/lightning-thunder/pull/48