### PR TITLE
Add activation checkpointing to the LitGPT benchmark

### DIFF
--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -159,6 +159,9 @@ class Benchmark_litGPT:
             assert (
                 self.global_batch_size % self.micro_batch_size * world_size == 0
             ), f"Global Batch Size {self.global_batch_size} should be a multiple Micro Batch Size {self.micro_batch_size} * World Size {world_size}."
+
+        if self.checkpoint_activations:
+            assert "thunder" not in self.compile, "Activations checkpointing is not supported for Thunder."
         self.skip_data_sync = skip_data_sync
 
         # Profiling Args

--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -7,6 +7,13 @@ import functools
 from torch.utils.data import DataLoader, IterableDataset
 import torch.distributed as torch_dist
 from torch.distributed.device_mesh import init_device_mesh
+import warnings
+
+from torch.distributed.algorithms._checkpoint.checkpoint_wrapper import (
+    apply_activation_checkpointing,
+    checkpoint_wrapper,
+    CheckpointWrapper,
+)
 
 import thunder
 from thunder.tests.litgpt_model import Config, GPT, Block
@@ -67,6 +74,7 @@ class Benchmark_litGPT:
         sharding_size: int | None = None,
         ddp_bucket_size: float = 256.0,
         fsdp_bucket_params: float | None = None,
+        checkpoint_activations: bool = False,
         n_layers: int | None = None,
         profiler_start: int = 15,
         profiler_stop: int = 15,
@@ -97,6 +105,7 @@ class Benchmark_litGPT:
         self.sharding_size = sharding_size
         self.ddp_bucket_size = ddp_bucket_size
         self.fsdp_bucket_params = fsdp_bucket_params
+        self.checkpoint_activations = checkpoint_activations
         self.micro_batch_size = micro_batch_size
 
         # Clarify benchmark assumptions
@@ -168,6 +177,10 @@ class Benchmark_litGPT:
 
         # Setup the distributed algorithm choices
         self.model = self.setup_distributed(self.model)
+
+        # Setup activations checkpointing
+        if self.checkpoint_activations:
+            self.setup_activation_checkpointing()
 
         # Initialize the optimizer after the model is sharded if using FSDP
         self.optimizer = configure_optimizers(
@@ -272,6 +285,17 @@ class Benchmark_litGPT:
                     device_mesh=mesh,
                 )
         return model
+
+    def setup_activation_checkpointing(self):
+        if any(isinstance(mod, CheckpointWrapper) for mod in self.model.modules()):
+            warnings.warn(
+                "FSDP checkpointing is configured, but the model already contains checkpointed layers."
+                " Checkpointing will be ignored."
+            )
+            return
+
+        check_fn = lambda submodule: isinstance(submodule, Block)
+        apply_activation_checkpointing(self.model, checkpoint_wrapper_fn=checkpoint_wrapper, check_fn=check_fn)
 
     def setup_compile(self, model):
         if self.compile == "inductor":


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? 
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

It adds changes described [in this issue](https://github.com/Lightning-AI/lightning-thunder/issues/375).
This code works for eager and inductor compilation methods. Next step would be to make it work for Thunder. 

I can add test of this new flag in test_benchmark_litgpt.py however I was not able to run the tests there, so I'm not sure if this is good idea. 

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Yes 😀

Fixes https://github.com/Lightning-AI/lightning-thunder/issues/375
