### PR TITLE
update bwd trace ouptut name to `grad_for_<some_param>`

### DIFF
--- a/thunder/executors/torch_autograd.py
+++ b/thunder/executors/torch_autograd.py
@@ -19,12 +19,12 @@ def rename_bwd_trace_outputs(bwd_trace: TraceCtx, fwd_trace: TraceCtx) -> TraceC
     trace_tok = set_tracectx(bwd_trace)
 
     swap_map: dict[VariableInterface, TensorProxy] = {}
-    bwd_outputs, _bwd_output_spec = tree_flatten(bwd_trace.output)
-    fwd_inputs, _fwd_input_spec = tree_flatten((fwd_trace.args, fwd_trace.kwargs))
+    bwd_outputs, _ = tree_flatten(bwd_trace.output)
+    fwd_inputs, _ = tree_flatten((fwd_trace.args, fwd_trace.kwargs))
 
     utils.check(len(bwd_outputs) == len(fwd_inputs), lambda: f"{len(bwd_outputs)=}, {len(fwd_inputs)=}")
 
-    for index, (fwd_arg, bwd_out) in enumerate(zip(fwd_inputs, bwd_outputs)):
+    for fwd_arg, bwd_out in zip(fwd_inputs, bwd_outputs):
         if isinstance(bwd_out, TensorProxy):
             swap_map[variableify(bwd_out)] = bwd_out.replace_name(f"grad_for_{fwd_arg.name}")
     reset_tracectx(trace_tok)

--- a/thunder/executors/torch_autograd.py
+++ b/thunder/executors/torch_autograd.py
@@ -16,6 +16,26 @@ if TYPE_CHECKING:
 
 
 def rename_bwd_trace_outputs(bwd_trace: TraceCtx, fwd_trace: TraceCtx) -> TraceCtx:
+    """Have backward trace output tensor proxy names follow `grad_for_<param>` format.
+
+    Since ``i``-th tensor proxy of backward trace's outputs is grad of ``i``-th tensor proxy of forward trace's inputs,
+    this method looks up to forward trace's inputs to get the param name for each grad.
+
+    Args:
+        bwd_trace:
+        fwd_trace:
+
+    Returns:
+        :class:`thunder.core.trace.TraceCtx`
+    """
+
+    # [note: why setting trace ctx?]
+    # [`TensorProxy.replace_name`](https://github.com/Lightning-AI/lightning-thunder/blob/561b699/thunder/core/proxies.py#L1221-L1223) calls
+    # [`tensorproxy`](https://github.com/Lightning-AI/lightning-thunder/blob/561b699/thunder/core/proxies.py#L1506-L1520)
+    # which then calls `TensorProxy.__init__`. `TensorProxy.__init__` of course calls
+    # [` Proxy.__init__`](https://github.com/Lightning-AI/lightning-thunder/blob/561b699/thunder/core/proxies.py#L81-L86).
+    # `Proxy`'s dunder init calls [`make_proxy_name`](https://github.com/Lightning-AI/lightning-thunder/blob/561b699/thunder/core/proxies.py#L81-L86)
+    # which depends on a tracectx.
     trace_tok = set_tracectx(bwd_trace)
 
     swap_map: dict[VariableInterface, TensorProxy] = {}

--- a/thunder/executors/torch_autograd.py
+++ b/thunder/executors/torch_autograd.py
@@ -134,7 +134,6 @@ def split_forward_backward(computation_trc: TraceCtx, compile_data, compile_stat
 
     # autograd.Function.backward expects a flat tuple of gradients
     bw_trace.bound_symbols[-1] = replace(bw_trace.bound_symbols[-1], args=(filtered_grads,))
-    bw_trace = rename_bwd_trace_outputs(bw_trace, fw_trace)
 
     _fsdp_comm_bucketing: FSDPCommBucketing | None = None
     if getattr(compile_data.fn, "use_fsdp", False):
@@ -235,6 +234,8 @@ def split_forward_backward(computation_trc: TraceCtx, compile_data, compile_stat
 
     bw_extrace = del_last_used(bw_extrace, clear_collections=True)
     bw_traces.append(bw_extrace)
+
+    bw_trace = rename_bwd_trace_outputs(bw_extrace, fw_extrace)
 
     if compile_stats is not None:
         compile_stats.last_traces += fw_traces


### PR DESCRIPTION
This would be helpful to make fsdp bucketing transform stateless.

As per title,

For the following model
```python
class M(nn.Module):
    def __init__(self):
        super().__init__()
        self.l1 = nn.Linear(12, 8)
        self.l2 = nn.Linear(8, 16)

    def forward(self, x):
        h = F.sigmoid(self.l1(x))
        return self.l2(h)
```

what's generated as the backward trace with this change is 

```python
def backward_fn(saved_for_backward, cotangents):
  # saved_for_backward: "Collection"
  # cotangents: "Collection"
  C0, _, = saved_for_backward
  clear_collection(saved_for_backward)
  del saved_for_backward
  t6, = cotangents
  clear_collection(cotangents)
  del cotangents
  t0, t4, t_l2_weight, x, = C0
  clear_collection(C0)
  del C0
  t15 = torch.reshape(t6, (-1, 16))  # t15: "cuda:0 f32[4, 16]"
  t18 = torch.permute(t15, (1, 0))  # t18: "cuda:0 f32[16, 4]"
  t19 = torch.reshape(t4, (-1, 8))  # t19: "cuda:0 f32[4, 8]"
  t31 = torch.reshape(x, (-1, 12))  # t31: "cuda:0 f32[4, 12]"
  del x
  [grad_for_t_l2_bias] = nvFusion0(t6)
  del t6
  t16 = torch.matmul(t15, t_l2_weight)  # t16: "cuda:0 f32[4, 8]"
  del t15, t_l2_weight
  grad_for_t_l2_weight = torch.matmul(t18, t19)  # grad_for_t_l2_weight: "cuda:0 f32[16, 8]"
  del t18, t19
  [grad_for_t_l1_bias, t26] = nvFusion1(t0, t16, t4)
  del t0, t16, t4
  t29 = torch.reshape(t26, (-1, 8))  # t29: "cuda:0 f32[4, 8]"
  del t26
  t30 = torch.permute(t29, (1, 0))  # t30: "cuda:0 f32[8, 4]"
  del t29
  grad_for_t_l1_weight = torch.matmul(t30, t31)  # grad_for_t_l1_weight: "cuda:0 f32[8, 12]"
  del t30, t31
  return (None, grad_for_t_l1_bias, grad_for_t_l1_weight, grad_for_t_l2_bias, grad_for_t_l2_weight)
```

while that of main branch is
```python
def backward_fn(saved_for_backward, cotangents):
  # saved_for_backward: "Collection"
  # cotangents: "Collection"
  C0, _, = saved_for_backward
  clear_collection(saved_for_backward)
  del saved_for_backward
  t6, = cotangents
  clear_collection(cotangents)
  del cotangents
  t0, t4, t_l2_weight, x, = C0
  clear_collection(C0)
  del C0
  t15 = torch.reshape(t6, (-1, 16))  # t15: "cuda:0 f32[4, 16]"
  t18 = torch.permute(t15, (1, 0))  # t18: "cuda:0 f32[16, 4]"
  t19 = torch.reshape(t4, (-1, 8))  # t19: "cuda:0 f32[4, 8]"
  t31 = torch.reshape(x, (-1, 12))  # t31: "cuda:0 f32[4, 12]"
  del x
  [t21] = nvFusion0(t6)
  del t6
  t16 = torch.matmul(t15, t_l2_weight)  # t16: "cuda:0 f32[4, 8]"
  del t15, t_l2_weight
  t20 = torch.matmul(t18, t19)  # t20: "cuda:0 f32[16, 8]"
  del t18, t19
  [t26, t33] = nvFusion1(t0, t16, t4)
  del t0, t16, t4
  t29 = torch.reshape(t26, (-1, 8))  # t29: "cuda:0 f32[4, 8]"
  del t26
  t30 = torch.permute(t29, (1, 0))  # t30: "cuda:0 f32[8, 4]"
  del t29
  t32 = torch.matmul(t30, t31)  # t32: "cuda:0 f32[8, 12]"
  del t30, t31
  return (None, t33, t32, t21, t20)
```

cc @borda @apaz-cli