### PR TITLE
Remove `TraceCtx.names.update` from fsdp bucketing

### DIFF
--- a/thunder/distributed/transforms/fsdp.py
+++ b/thunder/distributed/transforms/fsdp.py
@@ -500,15 +500,6 @@ class FSDPCommBucketing:
                         index_to_fqn[index] = rev_fqn_to_proxy_name[tmp_name]
             self.index_to_fqn = index_to_fqn
 
-    def update_name_set(self, backward_trace: TraceCtx) -> TraceCtx:
-        if not self.apply_bucketing:
-            return
-        utils.check(
-            hasattr(self, "fsdp_fwd_trace"),
-            lambda: "This method must be called after :func:`FSDPCommsOptimizer.apply_bucketing_to_forward_trace`",
-        )
-        backward_trace.names.update(self.fsdp_fwd_trace.names)
-
     def _collect_sharded_parameters(self, fwd_trace: TraceCtx) -> list[TensorProxy]:
         fwd_trace_flat_args, _ = tree_flatten((fwd_trace.args, fwd_trace.kwargs))
         return fwd_trace_flat_args
@@ -539,7 +530,6 @@ class FSDPCommBucketing:
             return fwd_trace
         fsdp_fwd_trace = from_trace(fwd_trace)
         fsdp_fwd_trace.bound_symbols = fwd_trace.bound_symbols
-        fsdp_fwd_trace.names.update(bwd_trace_names)
         trace_flat_args = self._collect_sharded_parameters(fsdp_fwd_trace)
         arg_to_index_in_flat_args = utils.ProxyDict()
         index_in_flat_args_to_param_and_bucket: dict[int, tuple[TensorProxy, Bucket]] = {}

--- a/thunder/executors/torch_autograd.py
+++ b/thunder/executors/torch_autograd.py
@@ -159,7 +159,6 @@ def split_forward_backward(computation_trc: TraceCtx, compile_data, compile_stat
     if getattr(compile_data.fn, "use_fsdp", False):
         _fsdp_comm_bucketing = FSDPCommBucketing(compile_data, computation_trc)
         fw_trace = _fsdp_comm_bucketing.apply_bucketing_to_forward_trace(fw_trace, bw_trace.names)
-        _fsdp_comm_bucketing.update_name_set(bw_trace)
 
     # Now we can run the optimization passes on the forward trace
     # TODO Restore request for no rematerialization


### PR DESCRIPTION
when I was implementing communication bucketing for FSDP, I encountered a name collision w/o `TraceCtx.names.update`.

If things work w/o it, I'd find it better.

cc @carmocca @awaelchli @crcrpar