### PR TITLE
Add  input information to fusion definitions for trace inspection and debugging

### DIFF
--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -441,7 +441,6 @@ class FusionDefinitionWrapper:
         return msg
 
 
-
 # Group bookend meta operations into separate regions
 # This function returns a List[Region] which changes the executor of meta regions to torchex
 #

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -396,10 +396,12 @@ class FusionDefinitionWrapper:
     cache_info: None | Callable = None
     cache_clear: None | Callable = None
     last_used: None | FusionDefinition = None
+    last_inputs_meta: None | Sequence[tuple] = None
 
     def __call__(self, *args):
         fd = self.get_fd(to_descriptors(args))
         self.last_used = fd
+        self.last_inputs_meta = [(i.size(), i.stride(), i.dtype, i.device) for i in args if isinstance(i, torch.Tensor)]
 
         # Set device if set in one of the "factory" methods like full, iota, or uniform
         kwargs = (
@@ -412,6 +414,32 @@ class FusionDefinitionWrapper:
 
     def __repr__(self):
         return f"FusionDefinitionWrapper({self.name})"
+
+    def last_inputs(self) -> str:
+        msg = "inputs = [\n"
+        for size, stride, dtype, device in self.last_inputs_meta:
+            # max linear index determines number of elements to generate
+            sz = 1
+            for szi, stri in zip(size, stride):
+                if szi == 0:
+                    sz = 0
+                    break
+                sz += (szi - 1) * stri
+            if dtype.is_floating_point:
+                msg += (
+                    f"    torch.randn(({sz},), dtype={dtype}, device='{device}')"
+                    f".as_strided({tuple(size)}, {tuple(stride)}),\n"
+                )
+            else:
+                upper_bound = 2 if dtype == torch.bool else 10
+                msg += (
+                    f"    torch.randint(0, {upper_bound}, ({sz},), dtype={dtype}, device='{device}')"
+                    f".as_strided({tuple(size())}, {tuple(stride())}),\n"
+                )
+        msg += "]"
+
+        return msg
+
 
 
 # Group bookend meta operations into separate regions


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes #387.
This PR adds information about the inputs for a fusion definition such that it can be retrieved by inspecting the trace. A tutorial on how to read this information will be published as part of #205.

Also this PR is in preparation for #205

Quickly, from a trace:
``` python
trace = thunder.last_traces(fn)[-1]
trace_ctx = trace.python_ctx()
print(trace_ctx['nvFusion0'].last_inputs())
```

will print something like:
``` shell
inputs = [
    torch.randn((2048,), dtype=torch.float32, device='cuda:0').as_strided((1, 2048), (2048, 1)),
    torch.randn((4096,), dtype=torch.bfloat16, device='cuda:0').as_strided((1, 2048, 4096), (4096, 0, 1))
]
```

I'm open to change the `str` output to returning a list of tensors, however for debugging it's usually enough to have a string. 
