### PR TITLE
Fix flaky test_prim_inplace_copy_fwd

### DIFF
--- a/thunder/tests/test_inplace_copy.py
+++ b/thunder/tests/test_inplace_copy.py
@@ -12,16 +12,12 @@ from thunder.tests.framework import instantiate
 @instantiate()
 def test_prim_inplace_copy_fwd(executor, device, dtype):
     def torch_foo(x, y):
-        z = x * y
-        z = z + z
-        z = x + z
+        z = x + y
         o = x.copy_(z)
         return o
 
     def foo(x, y):
-        z = x * y
-        z = z + z
-        z = x + z
+        z = x + y
         # NOTE: nvfuserex doesn't support `return z`, i.e. the copy_from argument
         o = thunder.core.prims.copy_(z, x)
         return o
@@ -36,14 +32,8 @@ def test_prim_inplace_copy_fwd(executor, device, dtype):
     thunder_result = traced_nvfuser_foo(a, b)
     torch_result = torch_foo(a1, b1)
 
-    # see https://github.com/Lightning-AI/lightning-thunder/issues/295
-    custom_comparator = (
-        partial(assert_close, atol=5e-2, rtol=5e-2)
-        if dtype in (datatypes.bfloat16, datatypes.float16)
-        else assert_close
-    )
-    custom_comparator(thunder_result, torch_result)
-    custom_comparator(a, a1)
+    assert_close(thunder_result, torch_result)
+    assert_close(a, a1)
 
 
 @instantiate(dtypes=(datatypes.floating,))


### PR DESCRIPTION
The problem with bf16 dtype inputs is that we were testing different functions as eager upcasts and downcasts around each arithmetic op while the nvFuser executor does upcasting and downcasting once and doesn't do it for intermediates. To test the behavior of `copy_` we don't need several arithmetic operations, so I reduced it to just one. On 1000 test runs there are now zero failures. 

Fixes #295 