### PR TITLE
ci: fix trigger event for docs' check

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -2,7 +2,9 @@ name: "Build (& deploy) Docs"
 on:
   push:
     branches: [main]
-  pull_request: {}
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, ready_for_review, synchronize]
   workflow_dispatch: {}
 
 concurrency:


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

a PR after turning ready fr review did not re-trigger docs build, only with new commit it was

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
