### PR TITLE
rename clear_collection to clear_mutable_collection

### DIFF
--- a/thunder/executors/passes.py
+++ b/thunder/executors/passes.py
@@ -18,7 +18,7 @@ from thunder.core.proxies import Proxy, variableify, unvariableify, Variable, Co
 import thunder.core.transforms as transforms
 from thunder.core.transform_common import dce
 from thunder.core.trace import get_tracectx
-from thunder.executors.pythonex import clear_collection
+from thunder.executors.pythonex import clear_mutable_collection
 
 from thunder.extend import Executor, get_always_executors, OperatorExecutor, FusionExecutor
 
@@ -229,13 +229,13 @@ def update_fusion_call_ctx(trace: TraceCtx) -> TraceCtx:
 
 
 # TODO Review deleting non-proxies
-def del_last_used(trace: TraceCtx, *, clear_collections=False) -> TraceCtx:
+def del_last_used(trace: TraceCtx, *, clear_mutable_collections=False) -> TraceCtx:
     """Mark last used intermediates to be deleted. This lets the Python garbage collector free
         unused tensor memory.
 
     Args:
         trace: trace to be transformed
-        clear_collections: whether to clear collections
+        clear_mutable_collections: whether to clear collections
     Returns:
         list: transformed trace
     """
@@ -268,7 +268,7 @@ def del_last_used(trace: TraceCtx, *, clear_collections=False) -> TraceCtx:
             to_del.append(x)
 
         to_clear_collections = []
-        if clear_collections:
+        if clear_mutable_collections:
             for x in to_del:
                 if isinstance(x, CollectionProxy):
                     to_clear_collections.append(x)
@@ -279,7 +279,7 @@ def del_last_used(trace: TraceCtx, *, clear_collections=False) -> TraceCtx:
             bsyms.appendleft(del_sym)
 
             for x in to_clear_collections:
-                bsyms.appendleft(clear_collection.bind(x, output=None))
+                bsyms.appendleft(clear_mutable_collection.bind(x, output=None))
 
         bsyms.appendleft(bsym)
 

--- a/thunder/executors/pythonex.py
+++ b/thunder/executors/pythonex.py
@@ -219,13 +219,13 @@ def _signbit_prim_impl(a: Number) -> bool:
     return a < 0
 
 
-def _clear_collection_meta(coll: CollectionProxy) -> None:
+def _clear_mutable_collection_meta(coll: CollectionProxy) -> None:
     baseutils.check_type(coll, CollectionProxy)
     baseutils.check_type(coll.coll, Sequence)
     return None
 
 
-def _clear_collection_prim_impl(a: Collection) -> None:
+def _clear_mutable_collection_prim_impl(a: Collection) -> None:
     if isinstance(a, (MutableSequence, MutableMapping, MutableSet)):
         a.clear()
 
@@ -241,7 +241,9 @@ tensor_abs = ex.register_operator("tensor_abs", like=prims.abs, fn=_tensor_abs_p
 neg = ex.register_operator("neg", like=prims.neg, module=operator)
 real = ex.register_operator("real", like=prims.real, fn=_real_prim_impl)
 signbit = ex.register_operator("signbit", like=prims.signbit, fn=_signbit_prim_impl)
-clear_collection = ex.register_operator("clear_collection", meta=_clear_collection_meta, fn=_clear_collection_prim_impl)
+clear_mutable_collection = ex.register_operator(
+    "clear_mutable_collection", meta=_clear_mutable_collection_meta, fn=_clear_mutable_collection_prim_impl
+)
 
 ex.register_implementation(prims.acos, acos, checker=_elementwise_unary_checker)
 ex.register_implementation(prims.acosh, acosh, checker=_elementwise_unary_checker)

--- a/thunder/executors/torch_autograd.py
+++ b/thunder/executors/torch_autograd.py
@@ -251,7 +251,7 @@ def split_forward_backward(computation_trc: TraceCtx, compile_data, compile_stat
     fw_extrace = del_last_used(fw_extrace)
     fw_traces.append(fw_extrace)
 
-    bw_extrace = del_last_used(bw_extrace, clear_collections=True)
+    bw_extrace = del_last_used(bw_extrace, clear_mutable_collections=True)
     bw_traces.append(bw_extrace)
 
     bw_trace = rename_bwd_trace_outputs(bw_extrace, fw_extrace)


### PR DESCRIPTION
> We should update the name clear_collection to clear_mutable_collection to make it clear that this won't do anything if tuple or other immutable collection is passed.

Related: https://github.com/Lightning-AI/lightning-thunder/issues/366#issuecomment-2095940166

This PR updates the name to reflect what this symbol does.