### PR TITLE
[Benchmak][LitGPT] Relocate profiler_start

### DIFF
--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -387,15 +387,15 @@ class Benchmark_litGPT:
             if i == self.warmup_iter:  # warmup
                 t0 = iter_t0
 
+            if self.nsys_enabled and i == self.profiler_start and global_rank in [0, None]:
+                print("=====Start NSYS Profiling======")
+                torch.cuda.cudart().cudaProfilerStart()
+
             with data_sync_ctx():
                 for step_idx in range(self.gradient_accumulation_steps - 1):
                     input_ids, targets = next(self.train_data_iter)
                     input_ids = input_ids.to(device=self.device)
                     targets = targets.to(device=self.device)
-
-                    if self.nsys_enabled and i == self.profiler_start and global_rank in [0, None] and step_idx == 0:
-                        print("=====Start NSYS Profiling======")
-                        torch.cuda.cudart().cudaProfilerStart()
 
                     loss = run_fwd_bwd_one_microbatch(self.model, input_ids, targets, self.gradient_accumulation_steps)
 


### PR DESCRIPTION
I had an experience when `cudaProfilerStart()` was never called, ending up with no profile generated. I propose to call `cudaProfilerStart()` a bit earlier.

cc @crcrpar 