### PR TITLE
fsdp_v2: use correct variable

### DIFF
--- a/thunder/distributed/__init__.py
+++ b/thunder/distributed/__init__.py
@@ -431,7 +431,7 @@ def fsdp_transform_module(
                     thunder_model._overrides[n] = torch.nn.Parameter(p.to(device=device), requires_grad=p.requires_grad)
                     device_adjustments[n] = device
             for n, b in module_copy.named_buffers(recurse=False, prefix=module_name):
-                if p.device != device:
+                if b.device != device:
                     thunder_model._overrides[n] = b.to(device=device)
                     device_adjustments[n] = device
 


### PR DESCRIPTION
Following snippet fails

```python
import os
import torch
import torch.distributed as tdist
import thunder
import thunder.distributed
from thunder.tests.litgpt_model import GPT, Config

if __name__ == '__main__':

    tdist.init_process_group(backend="nccl")
    LOCAL_RANK = int(os.environ["LOCAL_RANK"])
    device = torch.device("cuda", LOCAL_RANK)
    torch.set_default_device(device)

    class Model(torch.nn.Module):
        def __init__(self, *args, **kwargs) -> None:
            super().__init__(*args, **kwargs)
            self.register_buffer("foo", torch.empty(4, 4))
            self.fc = torch.nn.Linear(4, 4)
        
        def forward(self, x):
            return self.fc(x)

    with device:
        model = Model()
        x = torch.randn(4, 4)

    model = thunder.jit(model, executors=["torch"])
    model = thunder.distributed.fsdp(model)
    model(x)
```

Cmd: 
```
CUDA_LAUNCH_BLOCKING=1 torchrun --nproc-per-node 2 --local-ranks-filter 0 test.py
```

Fails with
```
[rank0]:   File "lightning-thunder/thunder/distributed/__init__.py", line 434, in fsdp_transform_module
[rank0]:     if p.device != device:
[rank0]: UnboundLocalError: local variable 'p' referenced before assignment
```