### PR TITLE
fixing numberproxy trace mode check

### DIFF
--- a/thunder/core/baseutils.py
+++ b/thunder/core/baseutils.py
@@ -130,8 +130,7 @@ def check_valid_length(length: int):
 
     # maybe we should skip the check for IntegerProxy in general
     check_type(length, (int, NumberProxyInterface))
-    if isinstance(length, int):
-        check(length >= 0, lambda: f"Found invalid length {length}!")
+    check(length >= 0, lambda: f"Found invalid length {length}!")
 
 
 def check_valid_shape(shape: tuple[int, ...] | list[int]):

--- a/thunder/core/baseutils.py
+++ b/thunder/core/baseutils.py
@@ -130,7 +130,8 @@ def check_valid_length(length: int):
 
     # maybe we should skip the check for IntegerProxy in general
     check_type(length, (int, NumberProxyInterface))
-    check(length >= 0, lambda: f"Found invalid length {length}!")
+    if isinstance(length, int):
+        check(length >= 0, lambda: f"Found invalid length {length}!")
 
 
 def check_valid_shape(shape: tuple[int, ...] | list[int]):

--- a/thunder/core/proxies.py
+++ b/thunder/core/proxies.py
@@ -17,7 +17,7 @@ from thunder.core.interpreter import is_jitting
 from thunder.core.trace import VariableInterface, get_tracectx, TraceCtx
 from thunder.core.baseutils import ProxyInterface, NumberProxyInterface, TensorProxyInterface
 import thunder.core.baseutils as baseutils
-from thunder.core.langctxs import resolve_method
+from thunder.core.langctxs import resolve_method, get_langctx
 import thunder.core.devices as devices
 import thunder.core.dtypes as dtypes
 
@@ -593,10 +593,15 @@ class NumberProxy(Proxy, NumberProxyInterface):
     @staticmethod
     def _elementwise_unary_helper(a, name, fn, type_promotion_kind=None):
         trace: None | TraceCtx = get_tracectx()
+        lang: None | LangCtx = None
+        try:
+            lang = get_langctx()
+        except LookupError:
+            pass
 
         vala = pyval(a)
 
-        if trace is None:
+        if trace is None or lang is None:
             # Outside of a trace context, operations on NumberProxies are executed by the
             #   Python interpreter
             baseutils.check(
@@ -649,7 +654,12 @@ class NumberProxy(Proxy, NumberProxyInterface):
         valb = pyval(b) if isinstance(b, NumberProxy) else b
 
         trace: None | TraceCtx = get_tracectx()
-        if trace is None:
+        lang: None | LangCtx = None
+        try:
+            lang = get_langctx()
+        except LookupError:
+            pass
+        if trace is None or lang is None:
             # Outside of a trace or language context, binary operations on NumberProxies are
             #   executed by the Python interpreter
             baseutils.check(

--- a/thunder/core/proxies.py
+++ b/thunder/core/proxies.py
@@ -592,18 +592,18 @@ class NumberProxy(Proxy, NumberProxyInterface):
     # fn is the function to call if executing outside a language context
     @staticmethod
     def _elementwise_unary_helper(a, name, fn, type_promotion_kind=None):
+
+        vala = pyval(a)
+
         trace: None | TraceCtx = get_tracectx()
         lang: None | LangCtx = None
         try:
             lang = get_langctx()
         except LookupError:
             pass
-
-        vala = pyval(a)
-
         if trace is None or lang is None:
-            # Outside of a trace context, operations on NumberProxies are executed by the
-            #   Python interpreter
+            # Outside of a trace or language context, operations on NumberProxies are
+            #   executed by the Python interpreter
             baseutils.check(
                 vala is not None,
                 lambda: f"Trying to {name} a number with an unknown value",


### PR DESCRIPTION
trace & language context should both be present in order to trace operations on NumberProxy.