### PR TITLE
pad: support alternate `value` types.

### DIFF
--- a/thunder/tests/test_elementwise.py
+++ b/thunder/tests/test_elementwise.py
@@ -139,35 +139,3 @@ def test_where(executor, device, dtype):
     # int64 x complex
     # int32 x complex64
     # predicate as number (True/False)
-
-def test_pad_cast_value_itof():
-    """
-    Pad should cast the given value to the type of tensor and pad that value.
-    """
-    def fqn():
-        x = torch.tensor([2,3], dtype=torch.int32)
-        y = torch.nn.functional.pad(x, pad=(1,2), value=6.4)
-        return y
-    th_fqn = thunder.jit(fqn)
-    v = th_fqn()
-    assert v[0] == 6
-    assert v[1] == 2
-    assert v[2] == 3
-    assert v[3] == 6
-    assert v[4] == 6
-
-def test_pad_cast_value_ftoi():
-    """
-    Pad should cast the given value to the type of tensor and pad that value.
-    """
-    def fqn():
-        x = torch.tensor([2.4, 3.8])
-        y = torch.nn.functional.pad(x, pad=(1,2), value=1)
-        return y
-    th_fqn = thunder.jit(fqn)
-    v = th_fqn()
-    assert v[0] == 1.0
-    assert v[1] == 2.4
-    assert v[2] == 3.8
-    assert v[3] == 1.0
-    assert v[4] == 1.0

--- a/thunder/tests/test_elementwise.py
+++ b/thunder/tests/test_elementwise.py
@@ -139,3 +139,35 @@ def test_where(executor, device, dtype):
     # int64 x complex
     # int32 x complex64
     # predicate as number (True/False)
+
+def test_pad_cast_value_itof():
+    """
+    Pad should cast the given value to the type of tensor and pad that value.
+    """
+    def fqn():
+        x = torch.tensor([2,3], dtype=torch.int32)
+        y = torch.nn.functional.pad(x, pad=(1,2), value=6.4)
+        return y
+    th_fqn = thunder.jit(fqn)
+    v = th_fqn()
+    assert v[0] == 6
+    assert v[1] == 2
+    assert v[2] == 3
+    assert v[3] == 6
+    assert v[4] == 6
+
+def test_pad_cast_value_ftoi():
+    """
+    Pad should cast the given value to the type of tensor and pad that value.
+    """
+    def fqn():
+        x = torch.tensor([2.4, 3.8])
+        y = torch.nn.functional.pad(x, pad=(1,2), value=1)
+        return y
+    th_fqn = thunder.jit(fqn)
+    v = th_fqn()
+    assert v[0] == 1.0
+    assert v[1] == 2.4
+    assert v[2] == 3.8
+    assert v[3] == 1.0
+    assert v[4] == 1.0

--- a/thunder/tests/test_shape_ops.py
+++ b/thunder/tests/test_shape_ops.py
@@ -1,4 +1,38 @@
+import thunder
+import torch
 from thunder.tests.framework import JAX_AVAILABLE
 
 if JAX_AVAILABLE:
     pass
+
+def test_pad_cast_value_itof():
+    """
+    Pad should cast the given value to the type of tensor and pad that value.
+    """
+    def fqn():
+        x = torch.tensor([2,3], dtype=torch.int32)
+        y = torch.nn.functional.pad(x, pad=(1,2), value=6.4)
+        return y
+    th_fqn = thunder.jit(fqn)
+    v = th_fqn()
+    assert v[0] == 6
+    assert v[1] == 2
+    assert v[2] == 3
+    assert v[3] == 6
+    assert v[4] == 6
+
+def test_pad_cast_value_ftoi():
+    """
+    Pad should cast the given value to the type of tensor and pad that value.
+    """
+    def fqn():
+        x = torch.tensor([2.4, 3.8])
+        y = torch.nn.functional.pad(x, pad=(1,2), value=1)
+        return y
+    th_fqn = thunder.jit(fqn)
+    v = th_fqn()
+    assert v[0] == 1.0
+    assert v[1] == 2.4
+    assert v[2] == 3.8
+    assert v[3] == 1.0
+    assert v[4] == 1.0

--- a/thunder/tests/test_shape_ops.py
+++ b/thunder/tests/test_shape_ops.py
@@ -5,14 +5,17 @@ from thunder.tests.framework import JAX_AVAILABLE
 if JAX_AVAILABLE:
     pass
 
+
 def test_pad_cast_value_itof():
     """
     Pad should cast the given value to the type of tensor and pad that value.
     """
+
     def fqn():
-        x = torch.tensor([2,3], dtype=torch.int32)
-        y = torch.nn.functional.pad(x, pad=(1,2), value=6.4)
+        x = torch.tensor([2, 3], dtype=torch.int32)
+        y = torch.nn.functional.pad(x, pad=(1, 2), value=6.4)
         return y
+
     th_fqn = thunder.jit(fqn)
     v = th_fqn()
     assert v[0] == 6
@@ -21,14 +24,17 @@ def test_pad_cast_value_itof():
     assert v[3] == 6
     assert v[4] == 6
 
+
 def test_pad_cast_value_ftoi():
     """
     Pad should cast the given value to the type of tensor and pad that value.
     """
+
     def fqn():
         x = torch.tensor([2.4, 3.8])
-        y = torch.nn.functional.pad(x, pad=(1,2), value=1)
+        y = torch.nn.functional.pad(x, pad=(1, 2), value=1)
         return y
+
     th_fqn = thunder.jit(fqn)
     v = th_fqn()
     assert v[0] == 1.0

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -906,6 +906,12 @@ def pad(a: TensorProxy, /, pad: tuple[int, ...], mode: str | None = "constant", 
     if value is None:
         value = 0
     a_typ = to_dtype(a, true_dtype=True)
+    # Note that this can be unsafe. This can happen, for example, if `a` is an
+    # integer tensor and `value` is a float. It can also be more subtle, where
+    # `a` is a lower-precision float than `value`.
+    if a_typ is not to_dtype(value, true_dtype=True):
+      warnings.warn("`value` and Tensor input are of different types. This "
+                    "may create numeric issues.")
     v2 = clang.maybe_convert_to_dtype(value, a_typ)
 
     return clang.pad(a, v2, pad_config)

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -905,8 +905,10 @@ def pad(a: TensorProxy, /, pad: tuple[int, ...], mode: str | None = "constant", 
 
     if value is None:
         value = 0
+    a_typ = to_dtype(a, true_dtype=True)
+    v2 = clang.maybe_convert_to_dtype(value, a_typ)
 
-    return clang.pad(a, value, pad_config)
+    return clang.pad(a, v2, pad_config)
 
 
 @torchsymbol(torch.permute, is_method=True)

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -910,8 +910,7 @@ def pad(a: TensorProxy, /, pad: tuple[int, ...], mode: str | None = "constant", 
     # integer tensor and `value` is a float. It can also be more subtle, where
     # `a` is a lower-precision float than `value`.
     if a_typ is not to_dtype(value, true_dtype=True):
-      warnings.warn("`value` and Tensor input are of different types. This "
-                    "may create numeric issues.")
+        warnings.warn("`value` and Tensor input are of different types. This " "may create numeric issues.")
     v2 = clang.maybe_convert_to_dtype(value, a_typ)
 
     return clang.pad(a, v2, pad_config)


### PR DESCRIPTION
PyTorch actually allows the `value` argument to have a different type than the input type, as long as the type of `value` is convertible to the type of `input`. This contradicts [the documentation](https://pytorch.org/docs/stable/generated/torch.nn.functional.pad.html) which indicates that the padding value, if specified, must be a float. 🤷

Fixes #458.

cc @tfogal