### PR TITLE
split parameter and buffer overrides, override named_parameters / named_buffers for ThunderModule

### DIFF
--- a/thunder/core/module.py
+++ b/thunder/core/module.py
@@ -70,7 +70,7 @@ class ThunderModule(pytorch.nn.Module):
                     continue
                 seen_ids.add(id_v)
 
-            mod, _, prefix = k.rpartition(k)
+            mod, _, prefix = k.rpartition(".")
             if recurse or not mod:
                 if k not in seen_names:
                     seen_names.add(k)

--- a/thunder/core/module.py
+++ b/thunder/core/module.py
@@ -70,7 +70,7 @@ class ThunderModule(pytorch.nn.Module):
                     continue
                 seen_ids.add(id_v)
 
-            mod, _, prefix = k.rpartition(".")
+            mod, _, base_param = k.rpartition(".")
             if recurse or not mod:
                 if k not in seen_names:
                     seen_names.add(k)

--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -437,7 +437,8 @@ def add_transform(
         from thunder import ThunderModule
 
         if isinstance(jfn, ThunderModule):
-            jfn._overrides = cfn._overrides
+            jfn._overrides_parameters = cfn._overrides_parameters
+            jfn._overrides_buffers = cfn._overrides_buffers
         return jfn
 
     cs = getattr(cfn, "_lc_cs", None)

--- a/thunder/distributed/__init__.py
+++ b/thunder/distributed/__init__.py
@@ -418,21 +418,23 @@ def fsdp_transform_module(
             # TODO: we could also support calling a "param_init_fn" argument like PyTorch
             _materialize(module_copy, device)
             for n, p in module_copy.named_parameters(recurse=False, prefix=module_name):
-                thunder_model._overrides[n] = p
+                thunder_model._overrides_parameters[n] = p
                 device_adjustments[n] = device
             for n, b in module_copy.named_buffers(recurse=False, prefix=module_name):
-                thunder_model._overrides[n] = b
+                thunder_model._overrides_buffers[n] = b
                 device_adjustments[n] = device
         else:
             # Move leftover params and buffers to device. This is at least required to broadcast.
             # Cannot `submodule.to(device)` because we don't want it to recurse
             for n, p in module_copy.named_parameters(recurse=False, prefix=module_name):
                 if p.device != device:
-                    thunder_model._overrides[n] = torch.nn.Parameter(p.to(device=device), requires_grad=p.requires_grad)
+                    thunder_model._overrides_parameters[n] = torch.nn.Parameter(
+                        p.to(device=device), requires_grad=p.requires_grad
+                    )
                     device_adjustments[n] = device
             for n, b in module_copy.named_buffers(recurse=False, prefix=module_name):
                 if b.device != device:
-                    thunder_model._overrides[n] = b.to(device=device)
+                    thunder_model._overrides_buffers[n] = b.to(device=device)
                     device_adjustments[n] = device
 
         # Broadcast parameters if requested
@@ -446,13 +448,15 @@ def fsdp_transform_module(
 
         for pn, p in submodule.named_parameters(recurse=False, prefix=module_name):
             # if we don't have an override or it is just the original, do create a copy
-            if thunder_model._overrides.get(pn, p) is p:
-                thunder_model._overrides[pn] = copy.copy(p)
+            if thunder_model._overrides_parameters.get(pn, p) is p:
+                thunder_model._overrides_parameters[pn] = copy.copy(p)
             # we collect shapes and devices because we do not know if other transforms also change it...
-            old_shape = thunder_model._overrides[pn].shape
-            _shard_param(thunder_model._overrides[pn], global_rank, world_size, pn, allow_padding_for_fsdp=True)
-            new_shape = thunder_model._overrides[pn].shape
-            sharded_params[pn] = (old_shape, new_shape, thunder_model._overrides[pn].device)
+            old_shape = thunder_model._overrides_parameters[pn].shape
+            _shard_param(
+                thunder_model._overrides_parameters[pn], global_rank, world_size, pn, allow_padding_for_fsdp=True
+            )
+            new_shape = thunder_model._overrides_parameters[pn].shape
+            sharded_params[pn] = (old_shape, new_shape, thunder_model._overrides_parameters[pn].device)
 
     early_transform_from_trace_to_fsdp_trace = FSDPTraceTransform(
         sharded_params=sharded_params,

--- a/thunder/tests/test_jit_general.py
+++ b/thunder/tests/test_jit_general.py
@@ -723,3 +723,60 @@ def test_litgpt_variants_kvcache(name, device):
 
     assert_close(logits_1, thunder_logits_1)
     assert_close(logits_2[:, -1:], thunder_logits_2)
+
+
+@pytest.mark.parametrize(
+    "device",
+    ("cpu", "cuda"),
+)
+def test_tom_overrides_proxy(device):
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+    device = torch.device(device)
+
+    x = torch.randint(0, 200, (5, 5), device=device)
+    config = litgpt_model.Config.from_name("llama2-like")
+
+    with device:
+        reference = litgpt_model.GPT(config)
+    expected_logits = reference(x)
+
+    expected_logits.sum().backward()
+
+    with device:
+        model = litgpt_model.GPT(config)
+    model.load_state_dict(reference.state_dict())
+    tom = thunder.jit(model, executors=nvfuserex if device.type == "cuda" else torchex)
+
+    # we manually replace tensors here, early transforms (like distributed) will do this
+    for k, v in tom._overrides_parameters.items():
+        tom._overrides_parameters[k] = torch.nn.Parameter(v.detach().clone())
+
+    actual_logits = tom(x)
+    assert_close(actual_logits, expected_logits)
+
+    actual_logits.sum().backward()
+
+    grads_expected = {k: t.grad for k, t in reference.named_parameters()}
+    grads_actual = {k: t.grad for k, t in tom.named_parameters()}
+
+    # on the original model, we have no grads
+    for param in model.parameters():
+        assert param.grad is None
+
+    assert len(grads_expected) == len(grads_actual)
+
+    for k, v in grads_expected.items():
+        torch.testing.assert_close(v, grads_actual[k], rtol=1e-2, atol=1e-2)
+
+    # deleten overrides, we expect the tom to have the same named params as the original model
+    tom._overrides_parameters.clear()
+
+    params_expected = {k: t.grad for k, t in model.named_parameters()}
+    params_actual = {k: t.grad for k, t in tom.named_parameters()}
+
+    assert len(params_expected) == len(params_actual)
+
+    for k, v in params_expected.items():
+        assert v is params_actual[k]

--- a/thunder/tests/test_jit_general.py
+++ b/thunder/tests/test_jit_general.py
@@ -770,7 +770,7 @@ def test_tom_overrides_proxy(device):
     for k, v in grads_expected.items():
         torch.testing.assert_close(v, grads_actual[k], rtol=1e-2, atol=1e-2)
 
-    # deleten overrides, we expect the tom to have the same named params as the original model
+    # after deleting overrides, we expect the tom to have the same named params as the original model
     tom._overrides_parameters.clear()
 
     params_expected = {k: t.grad for k, t in model.named_parameters()}


### PR DESCRIPTION
(`parameters()`, `buffers()` will automatically work as they use their named variants under the hood)

Fixes: #453