### PR TITLE
Fix FSDP jit(fsdp(...)) when sharing weights.

### DIFF
--- a/thunder/distributed/__init__.py
+++ b/thunder/distributed/__init__.py
@@ -588,6 +588,7 @@ def _shard_params(
             if param in sharded_params:
                 continue
             _shard_param(param, global_rank, world_size, param_name, allow_padding_for_fsdp=allow_padding_for_fsdp)
+            # Mark the param as sharded so that we don't reshard it (in case model has shared parameters)
             sharded_params[param] = True
 
 

--- a/thunder/tests/distributed/test_ddp.py
+++ b/thunder/tests/distributed/test_ddp.py
@@ -1044,8 +1044,7 @@ class CompileDDPTest(DataParallelTestCase):
 
         model.fc1.weight = model.fc2.weight
 
-        model = thunder.distributed.fsdp(model)
-        model = thunder.jit(model, executors=["torch"])
+        model = thunder.jit(thunder.distributed.fsdp(model), executors=["torch"])
 
         x = torch.randn(4, 16)
         output = model(x)


### PR DESCRIPTION
This PR fixes first problem from the 2 mentioned in https://github.com/Lightning-AI/lightning-thunder/issues/257#issuecomment-2133070264

Will fix `fsdp(jit(...))` in a seperate PR.