### PR TITLE
Update split QKV + RoPE benchmark

### DIFF
--- a/thunder/benchmarks/targets.py
+++ b/thunder/benchmarks/targets.py
@@ -909,6 +909,7 @@ def get_configs_for_qkv_split_rope():
     config_names = list(sorted(unique_config_names.values()))
     return config_names
 
+
 qkv_split_rope_executors = (
     (torch_executor, False),
     (torch_compile_executor, False),
@@ -925,6 +926,7 @@ qkv_split_rope_executors_ids = (
     "torch+apex",
     "torch.compile+apex",
 )
+
 
 # Sample command to run this benchmark:
 # pytest thunder/benchmarks/targets.py -k "test_litgpt_qkv_split_rope_train_forward" --benchmark-group-by='param:config,param:bs' --benchmark-columns='min,max,mean,stddev,median'
@@ -945,13 +947,7 @@ qkv_split_rope_executors_ids = (
     get_configs_for_qkv_split_rope(),
 )
 @pytest.mark.benchmark(group="forward")
-def test_litgpt_qkv_split_rope_train_forward(
-    benchmark,
-    executor: Callable,
-    use_apex: bool,
-    bs: int,
-    config: str
-):
+def test_litgpt_qkv_split_rope_train_forward(benchmark, executor: Callable, use_apex: bool, bs: int, config: str):
     from thunder.benchmarks import LlamaQKVSplitRopeBenchmark
 
     if use_apex and not APEX_FUSED_ROPE_AVAILABLE:
@@ -979,10 +975,7 @@ def backward_only(fn: Callable, jit_fn: Callable, fw_setup_fn: Callable):
     result = jfn(*args, **kwargs)
     result = thunder.core.utils.sequencify(result)
 
-    result_metadata = [
-        (r.dtype, r.device, r.shape)
-        for r in result
-    ]
+    result_metadata = [(r.dtype, r.device, r.shape) for r in result]
 
     def bw_setup():
         args = []
@@ -1018,13 +1011,7 @@ def backward_only(fn: Callable, jit_fn: Callable, fw_setup_fn: Callable):
     get_configs_for_qkv_split_rope(),
 )
 @pytest.mark.benchmark(group="backward")
-def test_litgpt_qkv_split_rope_train_backward(
-    benchmark,
-    executor: Callable,
-    use_apex: bool,
-    bs: int,
-    config: str
-):
+def test_litgpt_qkv_split_rope_train_backward(benchmark, executor: Callable, use_apex: bool, bs: int, config: str):
     from thunder.benchmarks import LlamaQKVSplitRopeBenchmark
 
     if use_apex and not APEX_FUSED_ROPE_AVAILABLE:
@@ -1044,6 +1031,7 @@ def test_litgpt_qkv_split_rope_train_backward(
     fn = wrap_for_benchmark(fn)
 
     benchmark.pedantic(fn, setup=bw_setup, rounds=40, warmup_rounds=1)
+
 
 #
 # interpreter benchmarks


### PR DESCRIPTION
This PR splits `test_llama2_qkv_split_rope_7b_train` into separate forward and backward benchmarks and adds a parametrization over litgpt configs with smaller batch size than before (it was 32, now it's 1, 2, ...).

I hope this will help simplify analysis for this portion of the network (ref https://github.com/Lightning-AI/lightning-thunder/issues/256).

Example runs for Llama 2 7B on DGX-H100:
```py
pytest thunder/benchmarks/targets.py -k "test_litgpt_qkv_split_rope_train_forward[Llama-2-7b-hf" --benchmark-group-by='param:config,param:bs' --benchmark-columns='min,max,mean,stddev,median'
------------------------------------------------------------------------ benchmark 'config=Llama-2-7b-hf bs=1': 6 tests -----------------------------------------------------------------------
Name (time in us)                                                                                  Min                 Max                Mean             StdDev              Median          
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_litgpt_qkv_split_rope_train_forward[Llama-2-7b-hf-bs1-torch.compile]                      93.1070 (1.0)      149.2300 (1.0)       97.1205 (1.0)       9.4027 (1.0)       94.9830 (1.0)    
test_litgpt_qkv_split_rope_train_forward[Llama-2-7b-hf-bs1-torch+apex]                        121.2551 (1.30)     400.8880 (2.69)     131.5780 (1.35)     44.6493 (4.75)     122.5070 (1.29)   
test_litgpt_qkv_split_rope_train_forward[Llama-2-7b-hf-bs1-thunder+nvfuser+torch.compile]     135.2079 (1.45)     298.7320 (2.00)     147.0512 (1.51)     26.1107 (2.78)     139.8915 (1.47)   
test_litgpt_qkv_split_rope_train_forward[Llama-2-7b-hf-bs1-torch.compile+apex]                176.3180 (1.89)     271.9470 (1.82)     186.1000 (1.92)     15.3009 (1.63)     182.9585 (1.93)   
test_litgpt_qkv_split_rope_train_forward[Llama-2-7b-hf-bs1-thunder]                           368.9330 (3.96)     782.9840 (5.25)     404.0743 (4.16)     68.9241 (7.33)     382.7575 (4.03)   
test_litgpt_qkv_split_rope_train_forward[Llama-2-7b-hf-bs1-torch]                             746.8500 (8.02)     806.0690 (5.40)     752.3981 (7.75)      9.6638 (1.03)     749.7925 (7.89)   
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

---------------------------------------------------------------------------- benchmark 'config=Llama-2-7b-hf bs=2': 6 tests ---------------------------------------------------------------------------
Name (time in us)                                                                                    Min                   Max                  Mean             StdDev                Median          
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_litgpt_qkv_split_rope_train_forward[Llama-2-7b-hf-bs2-torch.compile]                       139.6440 (1.0)        183.6730 (1.0)        142.9947 (1.0)       7.3855 (1.0)        140.9410 (1.0)    
test_litgpt_qkv_split_rope_train_forward[Llama-2-7b-hf-bs2-thunder+nvfuser+torch.compile]       179.7690 (1.29)       503.6511 (2.74)       201.9531 (1.41)     67.9426 (9.20)       184.1500 (1.31)   
test_litgpt_qkv_split_rope_train_forward[Llama-2-7b-hf-bs2-torch+apex]                          192.6100 (1.38)       418.6759 (2.28)       202.1950 (1.41)     36.6676 (4.96)       194.2225 (1.38)   
test_litgpt_qkv_split_rope_train_forward[Llama-2-7b-hf-bs2-torch.compile+apex]                  244.1310 (1.75)       314.1630 (1.71)       251.0559 (1.76)     10.9434 (1.48)       248.6064 (1.76)   
test_litgpt_qkv_split_rope_train_forward[Llama-2-7b-hf-bs2-thunder]                             576.0390 (4.13)       881.7980 (4.80)       597.9912 (4.18)     53.5302 (7.25)       584.5829 (4.15)   
test_litgpt_qkv_split_rope_train_forward[Llama-2-7b-hf-bs2-torch]                             1,437.3320 (10.29)    1,867.4340 (10.17)    1,456.1923 (10.18)    66.9990 (9.07)     1,444.6920 (10.25)  
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
```py
pytest thunder/benchmarks/targets.py -k "test_litgpt_qkv_split_rope_train_backward[Llama-2-7b-hf" --benchmark-group-by='param:config,param:bs' --benchmark-columns='min,max,mean,stddev,median'
---------------------------------------------------------------------------- benchmark 'config=Llama-2-7b-hf bs=1': 6 tests ----------------------------------------------------------------------------
Name (time in us)                                                                                     Min                   Max                  Mean             StdDev                Median          
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_litgpt_qkv_split_rope_train_backward[Llama-2-7b-hf-bs1-torch.compile+apex]                  317.1030 (1.0)        397.9061 (1.0)        320.7986 (1.0)      12.5539 (7.47)       318.8770 (1.0)    
test_litgpt_qkv_split_rope_train_backward[Llama-2-7b-hf-bs1-torch.compile]                       344.3230 (1.09)       489.4721 (1.23)       355.2051 (1.11)     22.4692 (13.37)      352.6175 (1.11)   
test_litgpt_qkv_split_rope_train_backward[Llama-2-7b-hf-bs1-thunder+nvfuser+torch.compile]       353.6000 (1.12)       745.0250 (1.87)       385.4599 (1.20)     62.8888 (37.42)      372.1565 (1.17)   
test_litgpt_qkv_split_rope_train_backward[Llama-2-7b-hf-bs1-torch+apex]                          519.6700 (1.64)       529.8480 (1.33)       521.2893 (1.62)      1.6805 (1.0)        521.0540 (1.63)   
test_litgpt_qkv_split_rope_train_backward[Llama-2-7b-hf-bs1-thunder]                             641.9370 (2.02)       989.5540 (2.49)       662.8183 (2.07)     53.6696 (31.94)      651.9795 (2.04)   
test_litgpt_qkv_split_rope_train_backward[Llama-2-7b-hf-bs1-torch]                             1,114.0959 (3.51)     1,281.0321 (3.22)     1,124.6536 (3.51)     26.2119 (15.60)    1,120.3341 (3.51)   
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

---------------------------------------------------------------------------- benchmark 'config=Llama-2-7b-hf bs=2': 6 tests ----------------------------------------------------------------------------
Name (time in us)                                                                                     Min                   Max                  Mean             StdDev                Median          
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_litgpt_qkv_split_rope_train_backward[Llama-2-7b-hf-bs2-torch.compile+apex]                  618.3760 (1.0)        641.0490 (1.0)        633.4444 (1.0)       3.0453 (2.13)       633.7005 (1.0)    
test_litgpt_qkv_split_rope_train_backward[Llama-2-7b-hf-bs2-thunder+nvfuser+torch.compile]       648.0020 (1.05)       770.2690 (1.20)       663.7784 (1.05)     17.6130 (12.35)      661.2550 (1.04)   
test_litgpt_qkv_split_rope_train_backward[Llama-2-7b-hf-bs2-torch.compile]                       668.1620 (1.08)       740.9060 (1.16)       678.2353 (1.07)     10.3458 (7.25)       676.9040 (1.07)   
test_litgpt_qkv_split_rope_train_backward[Llama-2-7b-hf-bs2-torch+apex]                        1,041.1850 (1.68)     1,048.7760 (1.64)     1,046.2538 (1.65)      1.4264 (1.0)      1,046.4430 (1.65)   
test_litgpt_qkv_split_rope_train_backward[Llama-2-7b-hf-bs2-thunder]                           1,321.8790 (2.14)     1,524.5760 (2.38)     1,334.8963 (2.11)     31.8932 (22.36)    1,328.0900 (2.10)   
test_litgpt_qkv_split_rope_train_backward[Llama-2-7b-hf-bs2-torch]                             2,169.7760 (3.51)     2,178.2031 (3.40)     2,174.8248 (3.43)      1.7552 (1.23)     2,175.0840 (3.43)   
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

cc: @parthmannan, @mpatel31415 

cc @crcrpar