### PR TITLE
Replacing uniform with uniform_philox , and incrementing PRNG state

### DIFF
--- a/thunder/core/rematerialization.py
+++ b/thunder/core/rematerialization.py
@@ -668,17 +668,13 @@ def replace_uniform(trace: TraceCtx) -> TraceCtx:
         if bsym.sym.id == prims.PrimIDs.UNIFORM:
             dev = bsym.kwargs["device"]
             if dev not in prev_state:
-                rng_state = prims.get_rng_state(None, dev)
-                prev_state[dev] = rng_state
+                seed, offset = prims.get_and_update_rng_state(None, None, dev)
             else:
-                rng_state = prims.get_rng_state(prev_state[dev], dev)
-            seed, offset = prims.unpack_rng_state(rng_state)
+                seed, offset = prims.get_and_update_rng_state(*prev_state[dev], dev)
             out = prims.uniform_philox(*bsym.args, **bsym.kwargs, seed=seed, offset=offset)
-            new_state = prims.update_rng_state(seed, offset)
-            new_state_1 = prims.set_rng_state(new_state, dev)
             new_vo = variableify(out)
             swapmap[new_vo] = bsym.output
-            prev_state[dev] = new_state_1
+            prev_state[dev] = [seed, offset]
             return VISIT_TYPE.REPLACE
         return VISIT_TYPE.NO_OP
 

--- a/thunder/core/rematerialization.py
+++ b/thunder/core/rematerialization.py
@@ -651,3 +651,52 @@ def rematerialize_forward_and_backward(fw_trace: TraceCtx, bw_trace: TraceCtx) -
     new_fw_trace = update_fusion_call_ctx(new_fw_trace)
     new_bw_trace = update_fusion_call_ctx(new_bw_trace)
     return new_fw_trace, new_bw_trace
+
+
+def replace_uniform(trace: TraceCtx) -> TraceCtx:
+    """For better rematerialization, replace the uniform operator with the stateless uniform_philox operator and manually update the RNG state."""
+    start_time_ns = time.time_ns()
+    from thunder.core.trace import VariableInterface
+    from thunder.core.proxies import Proxy
+    from thunder.core.devices import Device
+    from thunder.core.transforms import VISIT_TYPE, visitor_transform
+
+    swapmap: dict[VariableInterface, Proxy] = {}
+    prev_state: dict[Device, Proxy] = {}
+
+    def visit_(bsym: BoundSymbolInterface) -> VISIT_TYPE:
+        if bsym.sym.id == prims.PrimIDs.UNIFORM:
+            dev = bsym.kwargs["device"]
+            if dev not in prev_state:
+                rng_state = prims.get_rng_state(None, dev)
+                prev_state[dev] = rng_state
+            else:
+                rng_state = prims.get_rng_state(prev_state[dev], dev)
+            seed, offset = prims.unpack_rng_state(rng_state)
+            out = prims.uniform_philox(*bsym.args, **bsym.kwargs, seed=seed, offset=offset)
+            advance_offset = 4
+            new_offset = prims.add(offset, advance_offset)
+            new_state = prims.pack_rng_state(seed, new_offset)
+            new_state_1 = prims.set_rng_state(new_state, dev)
+            new_vo = variableify(out)
+            swapmap[new_vo] = bsym.output
+            prev_state[dev] = new_state_1
+            return VISIT_TYPE.REPLACE
+        return VISIT_TYPE.NO_OP
+
+    new_trace = visitor_transform(trace, visit_)
+
+    bound_symbols: list[BoundSymbolInterface] = []
+    for bsym in new_trace.bound_symbols:
+        nbsym: BoundSymbolInterface = bsym.from_bsym_swap_proxies(swapmap)
+        bound_symbols.append(nbsym)
+
+    new_trace.bound_symbols = bound_symbols
+
+    end_time_ns = time.time_ns()
+    elapsed_time_ns = end_time_ns - start_time_ns
+    elapsed_time_millis = elapsed_time_ns // 1000000
+    new_trace.set_provenance(
+        TraceProvenance(f"Transform for replace uniform (took {elapsed_time_millis} milliseconds)")
+    )
+    return new_trace

--- a/thunder/core/rematerialization.py
+++ b/thunder/core/rematerialization.py
@@ -674,9 +674,7 @@ def replace_uniform(trace: TraceCtx) -> TraceCtx:
                 rng_state = prims.get_rng_state(prev_state[dev], dev)
             seed, offset = prims.unpack_rng_state(rng_state)
             out = prims.uniform_philox(*bsym.args, **bsym.kwargs, seed=seed, offset=offset)
-            advance_offset = 4
-            new_offset = prims.add(offset, advance_offset)
-            new_state = prims.pack_rng_state(seed, new_offset)
+            new_state = prims.update_rng_state(seed, offset)
             new_state_1 = prims.set_rng_state(new_state, dev)
             new_vo = variableify(out)
             swapmap[new_vo] = bsym.output

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -748,7 +748,11 @@ class nvFuserExecutor(FusionExecutor):
     # TODO Restore fusion logic here -- this just replaces supported operations in isolation at the moment
     def fusion_pass(self, trace: TraceCtx) -> TraceCtx:
         start_time_ns: int = time.time_ns()
-
+        # Replace uniform with uniform_philox and rng state operators for better rematerialization
+        from thunder.core.rematerialization import replace_uniform
+        print(trace)
+        trace = replace_uniform(trace)
+        print(trace)
         fusedtrace: TraceCtx = from_trace(trace)
 
         producers, consumers = utils.producers_and_consumers(trace)

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -750,9 +750,9 @@ class nvFuserExecutor(FusionExecutor):
         start_time_ns: int = time.time_ns()
         # Replace uniform with uniform_philox and rng state operators for better rematerialization
         from thunder.core.rematerialization import replace_uniform
-        print(trace)
+
         trace = replace_uniform(trace)
-        print(trace)
+
         fusedtrace: TraceCtx = from_trace(trace)
 
         producers, consumers = utils.producers_and_consumers(trace)

--- a/thunder/executors/torch_autograd.py
+++ b/thunder/executors/torch_autograd.py
@@ -163,6 +163,11 @@ def split_forward_backward(computation_trc: TraceCtx, compile_data, compile_stat
         _fsdp_comm_bucketing = FSDPCommBucketing(compile_data, computation_trc)
         fw_trace = _fsdp_comm_bucketing.apply_bucketing_to_forward_trace(fw_trace)
 
+    # Replace uniform with uniform_philox and rng state operators for better rematerialization
+    from thunder.core.rematerialization import replace_uniform
+
+    fw_trace = replace_uniform(fw_trace)
+
     # Now we can run the optimization passes on the forward trace
     # TODO Restore request for no rematerialization
     fw_extrace = transform_for_execution(

--- a/thunder/executors/torch_autograd.py
+++ b/thunder/executors/torch_autograd.py
@@ -163,10 +163,6 @@ def split_forward_backward(computation_trc: TraceCtx, compile_data, compile_stat
         _fsdp_comm_bucketing = FSDPCommBucketing(compile_data, computation_trc)
         fw_trace = _fsdp_comm_bucketing.apply_bucketing_to_forward_trace(fw_trace)
 
-    # Replace uniform with uniform_philox and rng state operators for better rematerialization
-    from thunder.core.rematerialization import replace_uniform
-
-    fw_trace = replace_uniform(fw_trace)
 
     # Now we can run the optimization passes on the forward trace
     # TODO Restore request for no rematerialization

--- a/thunder/executors/torch_autograd.py
+++ b/thunder/executors/torch_autograd.py
@@ -163,7 +163,6 @@ def split_forward_backward(computation_trc: TraceCtx, compile_data, compile_stat
         _fsdp_comm_bucketing = FSDPCommBucketing(compile_data, computation_trc)
         fw_trace = _fsdp_comm_bucketing.apply_bucketing_to_forward_trace(fw_trace)
 
-
     # Now we can run the optimization passes on the forward trace
     # TODO Restore request for no rematerialization
     fw_extrace = transform_for_execution(

--- a/thunder/tests/test_randomness.py
+++ b/thunder/tests/test_randomness.py
@@ -169,9 +169,7 @@ def test_uniform_philox_vs_uniform(executor, device: str, dtype: dtypes.dtype):
             out.sum().backward()
             expects.append(out)
         assert cuda_generator.get_offset() == 12 * 4
-        rng_syms = (
-            "get_and_update_rng_state_impl",
-        )
+        rng_syms = ("get_and_update_rng_state_impl",)
         # check the transform has inserted the rng state operators
         assert any(t.sym.id in rng_syms for t in thunder.last_traces(jfunc)[-1].bound_symbols)
 

--- a/thunder/tests/test_randomness.py
+++ b/thunder/tests/test_randomness.py
@@ -159,7 +159,7 @@ def test_uniform_philox_vs_uniform(executor, device: str, dtype: dtypes.dtype):
 
     jfunc = thunder.jit(func, executors_list=executor.executors_list())
 
-    #TODO: Check the backward results when #231 is fixed
+    # TODO: Check the backward results when #231 is fixed
     with torch.random.fork_rng(devices=(dev,)):
         cuda_generator.manual_seed(20)
         expects = []
@@ -169,7 +169,12 @@ def test_uniform_philox_vs_uniform(executor, device: str, dtype: dtypes.dtype):
             out.sum().backward()
             expects.append(out)
         assert cuda_generator.get_offset() == 12 * 4
-        rng_syms = ('unpack_rng_state_prim_impl', 'get_rng_state_prim_impl', 'update_rng_state_prim_impl', 'set_rng_state_prim_impl')
+        rng_syms = (
+            "unpack_rng_state_prim_impl",
+            "get_rng_state_prim_impl",
+            "update_rng_state_prim_impl",
+            "set_rng_state_prim_impl",
+        )
         # check the transform has inserted the rng state operators
         assert any(t.sym.id in rng_syms for t in thunder.last_traces(jfunc)[-1].bound_symbols)
 
@@ -177,6 +182,7 @@ def test_uniform_philox_vs_uniform(executor, device: str, dtype: dtypes.dtype):
         results = []
         cuda_generator.manual_seed(20)
         from unittest.mock import patch, MagicMock
+
         # mock the replace_uniform transform to return the input trace
         replace_uniform_mock = MagicMock(side_effect=lambda trc: trc)
 

--- a/thunder/tests/test_randomness.py
+++ b/thunder/tests/test_randomness.py
@@ -170,10 +170,7 @@ def test_uniform_philox_vs_uniform(executor, device: str, dtype: dtypes.dtype):
             expects.append(out)
         assert cuda_generator.get_offset() == 12 * 4
         rng_syms = (
-            "unpack_rng_state_prim_impl",
-            "get_rng_state_prim_impl",
-            "update_rng_state_prim_impl",
-            "set_rng_state_prim_impl",
+            "get_and_update_rng_state_impl",
         )
         # check the transform has inserted the rng state operators
         assert any(t.sym.id in rng_syms for t in thunder.last_traces(jfunc)[-1].bound_symbols)

--- a/thunder/tests/test_randomness.py
+++ b/thunder/tests/test_randomness.py
@@ -112,7 +112,7 @@ def test_rng_state_uniform_philox_reproducibility(executor, device: str, dtype: 
     a1 = a.detach().clone()
     a1.requires_grad_()
 
-    jfunc = thunder.jit(func, executors_list=executor.executors_list())
+    jfunc = thunder.jit(func, executors=executor.executors_list())
 
     with torch.random.fork_rng(devices=(dev,)):
         torch.cuda.manual_seed(20)
@@ -157,7 +157,7 @@ def test_uniform_philox_vs_uniform(executor, device: str, dtype: dtypes.dtype):
     a = torch.randn(2, 2, device=dev, dtype=dtypes.to_torch_dtype(dtype), requires_grad=True)
     a1 = a.detach().clone().requires_grad_()
 
-    jfunc = thunder.jit(func, executors_list=executor.executors_list())
+    jfunc = thunder.jit(func, executors=executor.executors_list())
 
     # TODO: Check the backward results when #231 is fixed
     with torch.random.fork_rng(devices=(dev,)):
@@ -187,7 +187,7 @@ def test_uniform_philox_vs_uniform(executor, device: str, dtype: dtypes.dtype):
         replace_uniform_mock = MagicMock(side_effect=lambda trc: trc)
 
         with patch("thunder.core.rematerialization.replace_uniform", new=replace_uniform_mock):
-            jfunc = thunder.jit(func, executors_list=executor.executors_list())
+            jfunc = thunder.jit(func, executors=executor.executors_list())
             for _ in range(4):
                 out = jfunc(a1)
                 out.sum().backward()


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?
Same as https://github.com/Lightning-AI/lightning-thunder/pull/237/ (not merged into main)
Open this PR to re-target it to merge main

This PR is one step towards recomputing dropout in backward, the steps are:

- [x] Add the prim operators to query/update the default CUDA RNG state [PR](https://github.com/Lightning-AI/lightning-thunder/pull/264/)
- [ ] Fix #231 (required before merging this PR)
- [x] Add transformation to replacing uniform with uniform_philox (this PR)
- [ ] Make sure the rematerialization works properly for Dropout

Ref #114 

