### PR TITLE
python executor should be able to handle NumberProxy

### DIFF
--- a/thunder/clang/__init__.py
+++ b/thunder/clang/__init__.py
@@ -19,7 +19,17 @@ from thunder.core.langctxs import langctx, Languages
 import thunder.core.dtypes as dtypes
 from thunder.core import utils
 import thunder.core.prims as prims
-from thunder.core.proxies import IntegerProxy, NumberProxy, NumberLike, TensorProxy, pyval, pytype, proxy, AnyProxy, Proxy
+from thunder.core.proxies import (
+    IntegerProxy,
+    NumberProxy,
+    NumberLike,
+    TensorProxy,
+    pyval,
+    pytype,
+    proxy,
+    AnyProxy,
+    Proxy,
+)
 import thunder.core.devices as devices
 
 # This file defines the operations in thunder.jit's "core" language.

--- a/thunder/clang/__init__.py
+++ b/thunder/clang/__init__.py
@@ -19,7 +19,7 @@ from thunder.core.langctxs import langctx, Languages
 import thunder.core.dtypes as dtypes
 from thunder.core import utils
 import thunder.core.prims as prims
-from thunder.core.proxies import IntegerProxy, NumberProxy, TensorProxy, pyval, pytype, proxy, AnyProxy, Proxy
+from thunder.core.proxies import IntegerProxy, NumberProxy, NumberLike, TensorProxy, pyval, pytype, proxy, AnyProxy, Proxy
 import thunder.core.devices as devices
 
 # This file defines the operations in thunder.jit's "core" language.
@@ -29,7 +29,6 @@ import thunder.core.devices as devices
 
 __all__ = []
 
-NumberLike = Number | NumberProxy
 TensorLike = TensorProxy
 DeviceLike = Union[str, devices.Device]
 

--- a/thunder/core/proxies.py
+++ b/thunder/core/proxies.py
@@ -898,6 +898,9 @@ class NumberProxy(Proxy, NumberProxyInterface):
         return NotImplemented
 
 
+NumberLike = Number | NumberProxy
+
+
 def pyval(x: Number | str | AnyProxy) -> Number | str | any:
     baseutils.check_type(x, (NumberProxy, Number, str, AnyProxy))
 

--- a/thunder/executors/pythonex.py
+++ b/thunder/executors/pythonex.py
@@ -14,7 +14,7 @@ import torch
 
 import thunder.core.prims as prims
 from thunder.core.prims import PrimIDs
-from thunder.core.proxies import NumberProxy, TensorProxy, CollectionProxy
+from thunder.core.proxies import NumberProxy, NumberLike, TensorProxy, CollectionProxy
 from thunder.core.symbol import Symbol, BoundSymbol
 from thunder.core import baseutils
 import thunder.core.dtypes as dtypes
@@ -174,8 +174,8 @@ ex.register_implementation(prims.construct_tuple, construct_tuple, checker=_alwa
 #
 
 
-def _convert_element_type_prim_checker(a: Number | TensorProxy, /, dtype: type | dtypes.dtype) -> bool:
-    return isinstance(a, Number) and dtype in (bool, int, float, complex)
+def _convert_element_type_prim_checker(a: NumberLike | TensorProxy, /, dtype: type | dtypes.dtype) -> bool:
+    return isinstance(a, (Number, NumberProxy)) and dtype in (bool, int, float, complex)
 
 
 def _convert_element_type_prim_impl(a: Number, dtype: type) -> Number:
@@ -198,8 +198,8 @@ ex.register_implementation(prims.convert_element_type, convert_element_type, che
 # TODO Review differences in type promotion (for example round(2.3))
 
 
-def _elementwise_unary_checker(x: Number | TensorProxy) -> bool:
-    return isinstance(x, Number)
+def _elementwise_unary_checker(x: NumberLike | TensorProxy) -> bool:
+    return isinstance(x, (Number, NumberProxy))
 
 
 # NOTE Tensor abs is distinct from Python's builtin abs because it preserves the dtype of booleans
@@ -294,7 +294,7 @@ ex.register_implementation(prims.signbit, signbit, checker=_elementwise_unary_ch
 #
 
 
-def _elementwise_binary_checker(a: Number | TensorProxy, b: Number | TensorProxy) -> bool:
+def _elementwise_binary_checker(a: NumberLike | TensorProxy, b: NumberLike | TensorProxy) -> bool:
     return isinstance(a, (Number, NumberProxy)) and isinstance(b, (Number, NumberProxy))
 
 

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -24,7 +24,7 @@ import thunder.core.prims as prims
 import thunder.core.utils as utils
 import thunder.distributed.prims as dist_prims
 from thunder.core.langctxs import langctx, Languages
-from thunder.core.proxies import FloatProxy, IntegerProxy, NumberProxy, TensorProxy, FutureTensorProxy, pyval
+from thunder.core.proxies import FloatProxy, IntegerProxy, NumberProxy, NumberLike, TensorProxy, FutureTensorProxy, pyval
 from thunder.core.pytree import tree_map
 from thunder.core.symbol import Symbol
 from thunder.core.transforms import register_grad, put_grads
@@ -42,7 +42,6 @@ import torch.distributed as tdist
 import warnings
 
 # Type annotation helpers
-NumberLike = Number | NumberProxy
 TensorLike = TensorProxy
 FutureTensorLike = FutureTensorProxy
 DeviceLike = str | devices.Device | torch.device

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -24,7 +24,15 @@ import thunder.core.prims as prims
 import thunder.core.utils as utils
 import thunder.distributed.prims as dist_prims
 from thunder.core.langctxs import langctx, Languages
-from thunder.core.proxies import FloatProxy, IntegerProxy, NumberProxy, NumberLike, TensorProxy, FutureTensorProxy, pyval
+from thunder.core.proxies import (
+    FloatProxy,
+    IntegerProxy,
+    NumberProxy,
+    NumberLike,
+    TensorProxy,
+    FutureTensorProxy,
+    pyval,
+)
 from thunder.core.pytree import tree_map
 from thunder.core.symbol import Symbol
 from thunder.core.transforms import register_grad, put_grads


### PR DESCRIPTION
extend the support from binary op to unary/cast

cherry-picked small fixes from #250 