### PR TITLE
Add "important configs" to the benchmarks/targets.py as the default list for parametrized benchmarks

### DIFF
--- a/thunder/benchmarks/targets.py
+++ b/thunder/benchmarks/targets.py
@@ -560,13 +560,7 @@ sdpa_executors_ids = (
 )
 @pytest.mark.parametrize(
     "config,",
-    (
-        "Llama-2-7b-hf",
-        "Llama-2-13b-hf",
-        "Llama-2-70b-hf",
-        "Llama-3-8B",
-        "Llama-3-70B",
-    ),
+    IMPORTANT_CONFIGS,
 )
 def test_litgpt_sdpa_grad(benchmark, executor: Callable, bs, config):
     bench: Benchmark = LitGPTSDPABenchmark(

--- a/thunder/benchmarks/targets.py
+++ b/thunder/benchmarks/targets.py
@@ -59,6 +59,7 @@ IMPORTANT_CONFIGS = [
 ]
 RUN_ALL_CONFIGS = os.environ.get("THUNDER_BENCH_RUN_ALL_CONFIGS", "0") == "1"
 
+
 def make_setup(b: Benchmark):
     def setup():
         args_and_kwargs = b.make_batch()


### PR DESCRIPTION
This PR adds a new global variable in the script to define the set of important configs to track by default. Optionally it's possible to turn on all other configs with `THUNDER_BENCH_RUN_ALL_CONFIGS=1`.

This script is used in our nightly pipelines to track performance regressions. It takes about 12 minutes to run all benchmarks for all different models. It's probably not needed to run all of the configs nightly, only some of the most important ones.

A follow-up to https://github.com/Lightning-AI/lightning-thunder/pull/479.



cc @crcrpar