### PR TITLE
TE: Disable support for version less than v1.6

### DIFF
--- a/thunder/executors/transformer_engineex.py
+++ b/thunder/executors/transformer_engineex.py
@@ -385,6 +385,9 @@ def _linear_checker(
     w: TensorProxy,
     bias: None | TensorProxy,
 ) -> bool:
+    # Make sure that we don't claim an operator
+    # if `TransformerEngine` is not available (not installed or version requirements not met)
+    # and it is passed as an executor to `thunder.jit()`
     if not TE_AVAILABLE:
         return False
 

--- a/thunder/executors/transformer_engineex.py
+++ b/thunder/executors/transformer_engineex.py
@@ -385,6 +385,9 @@ def _linear_checker(
     w: TensorProxy,
     bias: None | TensorProxy,
 ) -> bool:
+    if not TE_AVAILABLE:
+        return False
+
     def is_cuda(t):
         return t.device.devicetype == devices.DeviceType.CUDA
 

--- a/thunder/tests/distributed/test_ddp.py
+++ b/thunder/tests/distributed/test_ddp.py
@@ -33,7 +33,6 @@ from thunder.tests.framework import instantiate
 from thunder.executors.transformer_engineex import (
     transformer_engine_ex,
     TE_AVAILABLE,
-    TE_VERSION_1_6_PLUS,
     te_sync_fp8_meta_bwd,
 )
 
@@ -1552,31 +1551,13 @@ def _test_ddp_transformer_engine_llama_sanity(input_data):
         fwd_exec_trace = thunder.last_traces(jit_model)[-1]
         bwd_exec_trace = thunder.last_backward_traces(jit_model)[-1]
 
-        if TE_VERSION_1_6_PLUS:
-            # Verify that the symbol to sync backward
-            # fp8 metadata is present in backward trace.
-            for bsym in reversed(bwd_exec_trace.bound_symbols):
-                if bsym.sym.id == te_sync_fp8_meta_bwd.id:
-                    break
-            else:
-                raise RuntimeError("Backward sync symbol not found.")
-
+        # Verify that the symbol to sync backward
+        # fp8 metadata is present in backward trace.
+        for bsym in reversed(bwd_exec_trace.bound_symbols):
+            if bsym.sym.id == te_sync_fp8_meta_bwd.id:
+                break
         else:
-            # Verify that the first te_linear in fwd_exec_trace is the
-            # last one in bwd_exec_tarce.
-            # We verify that by managing the `ctx` (CollectionProxy) output by `te_linear` which is
-            # passed to backward.
-            # As CollectionProxy don't implement __eq__, we verify them by name.
-            first_ctx_name = None
-            for bsym in fwd_exec_trace.bound_symbols:
-                if bsym.sym.name.startswith("te_linear"):
-                    first_ctx_name = bsym.output[1].name
-                    break
-
-            for bsym in reversed(bwd_exec_trace.bound_symbols):
-                if bsym.sym.name.startswith("te_functional"):
-                    assert first_ctx_name == bsym.args[-1].name, (first_ctx_name, bsym.args[-1].name)
-                    break
+            raise RuntimeError("Backward sync symbol not found.")
     except Exception as e:
         sanity_exceptions.append(e)
 


### PR DESCRIPTION
Currently there are conditional branches based on versions for supporting various TE versions. This PR drops support for TE versions < v1.6 (current stable) to simplify the implementation (for upcoming changes for v1.8 support). [v1.6](https://github.com/NVIDIA/TransformerEngine/releases/tag/v1.6) is the current stable and it was released on May 13th 2024. 

With this PR, we support TE v1.6 and upcoming v1.7 (verified with existing tests - `test_transformer_engine_ex and test_ddp.py -k transformer`).

Post this, will address the issue https://github.com/Lightning-AI/lightning-thunder/issues/499 for fixing the incompatibility with TE main (v1.8).