### PR TITLE
Add max_allocated_memory to extra_info in output json file for benchmarks/targets.py

### DIFF
--- a/thunder/benchmarks/targets.py
+++ b/thunder/benchmarks/targets.py
@@ -72,7 +72,9 @@ parametrize_compute_type = pytest.mark.parametrize(
 
 
 import functools
-def timer_and_memory_stats(benchmark) ->float:
+
+
+def timer_and_memory_stats(benchmark) -> float:
     def deco(func):
         @functools.wraps(func)
         def wrapper():
@@ -80,11 +82,15 @@ def timer_and_memory_stats(benchmark) ->float:
             benchmark.extra_info["max_allocated_memory(MB)"] = torch.cuda.max_memory_allocated() / (1024 * 1024.0)
             torch.cuda.reset_peak_memory_stats()
             return ret
+
         return wrapper
+
     return deco
 
 
 from contextlib import contextmanager
+
+
 @contextmanager
 def record_peak_allocated_memory(benchmark):
     old_timer = benchmark._timer
@@ -92,7 +98,7 @@ def record_peak_allocated_memory(benchmark):
     try:
         yield
     finally:
-        benchmark._timer=old_timer
+        benchmark._timer = old_timer
 
 
 def benchmark_for_compute_type(compute_type: ComputeType, benchmark, fn: Callable, args, kwargs):

--- a/thunder/benchmarks/targets.py
+++ b/thunder/benchmarks/targets.py
@@ -71,14 +71,39 @@ parametrize_compute_type = pytest.mark.parametrize(
 )
 
 
+import functools
+def timer_and_memory_stats(benchmark) ->float:
+    def deco(func):
+        @functools.wraps(func)
+        def wrapper():
+            ret = func()
+            benchmark.extra_info["max_allocated_memory(MB)"] = torch.cuda.max_memory_allocated() / (1024 * 1024.0)
+            torch.cuda.reset_peak_memory_stats()
+            return ret
+        return wrapper
+    return deco
+
+
+from contextlib import contextmanager
+@contextmanager
+def record_peak_allocated_memory(benchmark):
+    old_timer = benchmark._timer
+    benchmark._timer = timer_and_memory_stats(benchmark)(benchmark._timer)
+    try:
+        yield
+    finally:
+        benchmark._timer=old_timer
+
+
 def benchmark_for_compute_type(compute_type: ComputeType, benchmark, fn: Callable, args, kwargs):
-    match compute_type:
-        case ComputeType.INFERENCE | ComputeType.TRAINING_FORWARD:
-            benchmark(fn, *args, **kwargs)
-        case ComputeType.TRAINING_BACKWARD:
-            backward_fn, backward_setup = backward_only(fn, *args, **kwargs)
-            backward_args = backward_setup()
-            benchmark(backward_fn, *backward_args)
+    with record_peak_allocated_memory(benchmark):
+        match compute_type:
+            case ComputeType.INFERENCE | ComputeType.TRAINING_FORWARD:
+                benchmark(fn, *args, **kwargs)
+            case ComputeType.TRAINING_BACKWARD:
+                backward_fn, backward_setup = backward_only(fn, *args, **kwargs)
+                backward_args = backward_setup()
+                benchmark(backward_fn, *backward_args)
 
 
 def interpreter_fwd(module: Callable):


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

This PR add `max_allocated_memory` to `extra_info` in output json file for `benchmarks/targets.py`


when run with `pytest thunder/benchmarks/targets.py -k nanogpt_block --benchmark-json='output.json'`
the peak allocated memory is added in `output.json`:
```
{
            "group": null,
            "name": "test_nanogpt_block[inference-thunder+nvfuser+torch.compile]",
            "fullname": "thunder/benchmarks/targets.py::test_nanogpt_block[inference-thunder+nvfuser+torch.compile]",
            "params": {
                "compute_type": "UNSERIALIZABLE[<ComputeType.INFERENCE: 1>]",
                "executor": "UNSERIALIZABLE[<function thunder_sdpa_torch_compile_nvfuser_executor at 0x7f24138ac310>]"
            },
            "param": "inference-thunder+nvfuser+torch.compile",
            "extra_info": {
                "max_allocated_memory(MB)": 259.6181640625
            },
            "options": {
                "disable_gc": false,
                "timer": "timer",
                "min_rounds": 5,
                "max_time": 1.0,
                "min_time": 5e-06,
                "warmup": 100000
            },
   ......
}
```



Testing result:
run `pytest thunder/benchmarks/targets.py -k nanogpt_block --benchmark-json='nanoblk' -vs` with the patch below, it outputs the same result as the PR:
```
wayan@3d0e6ea-lcedt:~/lightning-thunder$ cat nanoblk |grep max_allo
                "max_allocated_memory(MB)": 141.0654296875
                "max_allocated_memory(MB)": 127.69091796875
                "max_allocated_memory(MB)": 193.51416015625
                "max_allocated_memory(MB)": 259.6181640625
                "max_allocated_memory(MB)": 382.98046875
                "max_allocated_memory(MB)": 184.76904296875
                "max_allocated_memory(MB)": 262.5537109375
                "max_allocated_memory(MB)": 197.2998046875
                "max_allocated_memory(MB)": 476.755859375
                "max_allocated_memory(MB)": 416.44482421875
                "max_allocated_memory(MB)": 355.7607421875
                "max_allocated_memory(MB)": 493.7021484375
```
```
[2024-06-03 14:28:47] thunder/benchmarks/targets.py::test_nanogpt_block[inference-torch] **peak allocated: 141.0654296875
PASSED
[2024-06-03 14:28:52] thunder/benchmarks/targets.py::test_nanogpt_block[inference-torch.compile] **peak allocated: 127.69091796875
PASSED
[2024-06-03 14:28:58] thunder/benchmarks/targets.py::test_nanogpt_block[inference-thunder] **peak allocated: 193.51416015625
PASSED
[2024-06-03 14:29:05] thunder/benchmarks/targets.py::test_nanogpt_block[inference-thunder+nvfuser+torch.compile] **peak allocated: 259.6181640625
PASSED
[2024-06-03 14:29:10] thunder/benchmarks/targets.py::test_nanogpt_block[forward-torch] **peak allocated: 382.98046875
PASSED
[2024-06-03 14:29:15] thunder/benchmarks/targets.py::test_nanogpt_block[forward-torch.compile] **peak allocated: 184.76904296875
PASSED
[2024-06-03 14:29:21] thunder/benchmarks/targets.py::test_nanogpt_block[forward-thunder] **peak allocated: 262.5537109375
PASSED
[2024-06-03 14:29:27] thunder/benchmarks/targets.py::test_nanogpt_block[forward-thunder+nvfuser+torch.compile] **peak allocated: 197.2998046875
PASSED
[2024-06-03 14:29:34] thunder/benchmarks/targets.py::test_nanogpt_block[backward-torch] **peak allocated: 476.755859375
PASSED
[2024-06-03 14:29:39] thunder/benchmarks/targets.py::test_nanogpt_block[backward-torch.compile] **peak allocated: 416.44482421875
PASSED
[2024-06-03 14:29:45] thunder/benchmarks/targets.py::test_nanogpt_block[backward-thunder] **peak allocated: 355.7607421875
PASSED
[2024-06-03 14:29:53] thunder/benchmarks/targets.py::test_nanogpt_block[backward-thunder+nvfuser+torch.compile] **peak allocated: 493.7021484375
PASSED

```

<details>
  <summary>patch</summary>

```
diff --git a/thunder/benchmarks/targets.py b/thunder/benchmarks/targets.py
index 1edf843d..15a0e6e1 100644
--- a/thunder/benchmarks/targets.py
+++ b/thunder/benchmarks/targets.py
@@ -94,16 +94,29 @@ def record_peak_allocated_memory(benchmark):
     finally:
         benchmark._timer=old_timer

+@contextmanager
+def runtime_allocated_memory(dev):
+    torch.cuda.reset_peak_memory_stats(dev)
+    try:
+        yield
+    finally:
+        memory_states = torch.cuda.memory_stats(dev)
+        alloc = memory_states["allocated_bytes.all.peak"]
+        print(f"**peak allocated: {alloc/1024/1024.}")

 def benchmark_for_compute_type(compute_type: ComputeType, benchmark, fn: Callable, args, kwargs):
     with record_peak_allocated_memory(benchmark):
         match compute_type:
             case ComputeType.INFERENCE | ComputeType.TRAINING_FORWARD:
                 benchmark(fn, *args, **kwargs)
+                with runtime_allocated_memory("cuda"):
+                    fn(*args, **kwargs)
             case ComputeType.TRAINING_BACKWARD:
                 backward_fn, backward_setup = backward_only(fn, *args, **kwargs)
                 backward_args = backward_setup()
                 benchmark(backward_fn, *backward_args)
+                with runtime_allocated_memory("cuda"):
+                    backward_fn(*backward_args)


 def interpreter_fwd(module: Callable):
```

</details>
