### PR TITLE
remove duplicate assert

### DIFF
--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -1401,13 +1401,6 @@ def unpack_inputs(ctx, prologue_trace, pro_to_comp_inps, pro_to_epi_inps, args, 
 
         already_unpacked[id(p)] = p
 
-        # Adds cache constraints
-        # TODO Consider refactoring these contraints
-        # TODO Constrain on rank, device, and dtype
-        if isinstance(p, TensorProxy):
-            with tracectx(prologue_trace):
-                prims.assert_tensor_metadata(p, p.shape, p.device, p.dtype, p.requires_grad)
-
         return p
 
     with tracectx(prologue_trace):


### PR DESCRIPTION
Turns out we had two checks for the tensor metadata (using different primitives(?)...),  so this removes one.

Fixes: #528 

Before:
```
def prologue(*args, **kwargs):
  # args: "Any"
  prims.check_len(args, 1)
  # kwargs: "Any"
  prims.check_len(kwargs, 0)
  x: "cuda:0 f32[4, 128]" = args[0]
  prims.assert_tensor_metadata_impl(x, (4, 128), devices.Device("cuda:0"), dtypes.float32, False)
  prims.check_tensor_metadata(x, (4, 128), 'cuda:0', torch.float32, False)
  cache_info: "Any" = thunder._get_cache_info()
  cache_info_is_autocast_enabled: "bool False" = cache_info['is_autocast_enabled']
  prims.check_number_type_and_value(cache_info_is_autocast_enabled, False)
  cache_info_no_grad_sync: "bool False" = cache_info['no_grad_sync']
  prims.check_number_type_and_value(cache_info_no_grad_sync, False)
  return (x,)
```

After:
```
...
def prologue(*args, **kwargs):
  # args: "Any"
  prims.check_len(args, 1)
  # kwargs: "Any"
  prims.check_len(kwargs, 0)
  x: "cuda:0 f32[4, 128]" = args[0]
  prims.check_tensor_metadata(x, (4, 128), 'cuda:0', torch.float32, False)
  cache_info: "Any" = thunder._get_cache_info()
  cache_info_is_autocast_enabled: "bool False" = cache_info['is_autocast_enabled']
  prims.check_number_type_and_value(cache_info_is_autocast_enabled, False)
  cache_info_no_grad_sync: "bool False" = cache_info['no_grad_sync']
  prims.check_number_type_and_value(cache_info_no_grad_sync, False)
  return (x,)
```