### PR TITLE
Simplify `BoundSymbolRHS` and enforce immutability

### DIFF
--- a/thunder/core/symbol.py
+++ b/thunder/core/symbol.py
@@ -7,7 +7,6 @@ from contextvars import ContextVar
 from contextlib import contextmanager
 from itertools import chain
 from types import ModuleType
-from typing import NamedTuple
 
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional, List, Type, Tuple, TYPE_CHECKING
@@ -526,9 +525,10 @@ class BoundSymbol(BoundSymbolInterface):
 
         return (self.sym, self._var_args, self._var_output) == (other.sym, other._var_args, other._var_output)
 
-    def rhs(self):
-        hashable_args = tuple(map(make_hashable, self._var_args))
-        return BoundSymbolRHS(self.sym, hashable_args, FrozenDict(self._var_kwargs))
+    def rhs(self) -> BoundSymbolRHS:
+        hashable_args = make_hashable(self._var_args)
+        hashable_kwargs = make_hashable(self._var_kwargs)
+        return BoundSymbolRHS(self.sym, hashable_args, hashable_kwargs)
 
     # TODO Document contexts
     def import_ctx(self):

--- a/thunder/core/symbol.py
+++ b/thunder/core/symbol.py
@@ -527,7 +527,9 @@ class BoundSymbol(BoundSymbolInterface):
         return (self.sym, self._var_args, self._var_output) == (other.sym, other._var_args, other._var_output)
 
     def rhs(self):
-        return BoundSymbolRHS(self.sym, tuple(tree_flatten(self._var_args)[0]), tuple(tree_flatten(self._var_kwargs)[0]))
+        return BoundSymbolRHS(
+            self.sym, tuple(tree_flatten(self._var_args)[0]), tuple(tree_flatten(self._var_kwargs)[0])
+        )
 
     # TODO Document contexts
     def import_ctx(self):

--- a/thunder/core/symbol.py
+++ b/thunder/core/symbol.py
@@ -18,7 +18,7 @@ import thunder.core.baseutils as baseutils
 import thunder.core.codeutils as codeutils
 from thunder.core.codeutils import Printable, Positions
 from thunder.core.baseutils import BoundSymbolInterface, ProxyInterface
-from thunder.core.utils import FrozenDict
+from thunder.core.utils import FrozenDict, make_hashable
 from thunder.core.pytree import tree_flatten, tree_unflatten, tree_map
 import thunder.core.dtypes as dtypes
 import thunder.core.devices as devices
@@ -527,17 +527,7 @@ class BoundSymbol(BoundSymbolInterface):
         return (self.sym, self._var_args, self._var_output) == (other.sym, other._var_args, other._var_output)
 
     def rhs(self):
-        def make_hashable(x: Any) -> tuple | FrozenDict:
-            if isinstance(x, dict):
-                return FrozenDict(x)
-            if isinstance(x, (list, tuple)):
-                return tuple(map(make_hashable, x))
-            if isinstance(x, slice):
-                return id(x)
-            return x
-
         hashable_args = tuple(map(make_hashable, self._var_args))
-
         return BoundSymbolRHS(self.sym, hashable_args, FrozenDict(self._var_kwargs))
 
     # TODO Document contexts

--- a/thunder/core/symbol.py
+++ b/thunder/core/symbol.py
@@ -530,8 +530,10 @@ class BoundSymbol(BoundSymbolInterface):
         def make_hashable(x: Any) -> tuple | FrozenDict:
             if isinstance(x, dict):
                 return FrozenDict(x)
-            if isinstance(x, list):
-                return tuple(x)
+            if isinstance(x, (list, tuple)):
+                return tuple(map(make_hashable, x))
+            if isinstance(x, slice):
+                return id(x)
             return x
 
         hashable_args = tuple(map(make_hashable, self._var_args))

--- a/thunder/core/symbol.py
+++ b/thunder/core/symbol.py
@@ -655,5 +655,5 @@ def has_tags(bsym: BoundSymbol, tags: set[OpTags]) -> bool:
 @dataclass(**baseutils.default_dataclass_params)
 class BoundSymbolRHS:
     sym: Symbol
-    args: tuple[Any]
+    args: tuple[typing.Hashable]
     kwargs: FrozenDict

--- a/thunder/core/symbol.py
+++ b/thunder/core/symbol.py
@@ -525,6 +525,7 @@ class BoundSymbol(BoundSymbolInterface):
 
         return (self.sym, self._var_args, self._var_output) == (other.sym, other._var_args, other._var_output)
 
+    @functools.cached_property
     def rhs(self) -> BoundSymbolRHS:
         hashable_args = make_hashable(self._var_args)
         hashable_kwargs = make_hashable(self._var_kwargs)

--- a/thunder/core/symbol.py
+++ b/thunder/core/symbol.py
@@ -10,7 +10,7 @@ from types import ModuleType
 
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional, List, Type, Tuple, TYPE_CHECKING
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Hashable, Iterable
 from collections.abc import Sequence
 
 import thunder.core.baseutils as baseutils
@@ -655,5 +655,5 @@ def has_tags(bsym: BoundSymbol, tags: set[OpTags]) -> bool:
 @dataclass(**baseutils.default_dataclass_params)
 class BoundSymbolRHS:
     sym: Symbol
-    args: tuple[typing.Hashable]
+    args: tuple[Hashable]
     kwargs: FrozenDict

--- a/thunder/core/transform_common.py
+++ b/thunder/core/transform_common.py
@@ -226,7 +226,7 @@ def cse_single_bsym(
     )
 
     # Skip appending this bsym to the new bound symbols due to its rhs being a common subexpression.
-    rhs = new_bsym.rhs()
+    rhs = new_bsym.rhs
     if (prior_bsym := rhs_to_bsym_map.get(rhs)) is not None and bsym._executor is prior_bsym._executor:
         for src, dst in zip(bsym.flat_outs, prior_bsym.flat_outs):
             # Detects (and avoids) aliasing

--- a/thunder/core/utils.py
+++ b/thunder/core/utils.py
@@ -772,7 +772,14 @@ class FrozenDict(_UserDictT[T, T1], Mapping[T, T1]):
         return f"{self.__class__.__name__}({{{body}}})"
 
     def __hash__(self) -> int:
-        return hash(frozenset(self.items()))
+        def make_hashable(item) -> tuple:
+            k, v = item
+            if isinstance(v, list):
+                return (k, tuple(v))
+            return item
+
+        hashable_items = map(make_hashable, self.items())
+        return hash(frozenset(hashable_items))
 
 
 #

--- a/thunder/tests/test_core.py
+++ b/thunder/tests/test_core.py
@@ -1300,7 +1300,7 @@ def test_boundsymbol_hash_eq_examples(executor, device, dtype: dtypes.dtype):
     def extract_bsyms(fn, args, ops):
         return [b for b in compile_bsyms(fn, args) if b.sym.name in ops]
 
-    # We want .rhs() for a * b and torch.mul() to hash and compare
+    # We want .rhs for a * b and torch.mul() to hash and compare
     # the same for writing the CSE pass.
     def mul_rhs(a, b):
         c = a + b
@@ -1309,8 +1309,8 @@ def test_boundsymbol_hash_eq_examples(executor, device, dtype: dtypes.dtype):
         return c, d, e
 
     bsyms = extract_bsyms(mul_rhs, (a, b), ("mul",))
-    all_eq([hash(b.rhs()) for b in bsyms])
-    all_eq([b.rhs() for b in bsyms])
+    all_eq([hash(b.rhs) for b in bsyms])
+    all_eq([b.rhs for b in bsyms])
 
     # The current way BoundSymbols are compared treats args and kwargs the same,
     # so the same semantic call can be considered 'equal' if the arguments are
@@ -1321,8 +1321,8 @@ def test_boundsymbol_hash_eq_examples(executor, device, dtype: dtypes.dtype):
         return c, d
 
     bsyms = extract_bsyms(mul_rhs_kwargs, (a, b), ("mul",))
-    all_eq([hash(b.rhs()) for b in bsyms])
-    all_eq([b.rhs() for b in bsyms])
+    all_eq([hash(b.rhs) for b in bsyms])
+    all_eq([b.rhs for b in bsyms])
 
     # Also make sure the symbols are the same.
     all_eq([b.sym for b in bsyms])
@@ -1335,8 +1335,8 @@ def test_boundsymbol_hash_eq_examples(executor, device, dtype: dtypes.dtype):
         return a + b
 
     bsyms = extract_bsyms(same_kwargs, (device, dtype), ("full",))
-    all_eq([hash(b.rhs()) for b in bsyms])
-    all_eq([b.rhs() for b in bsyms])
+    all_eq([hash(b.rhs) for b in bsyms])
+    all_eq([b.rhs for b in bsyms])
 
     # The symbols should be the same.
     all_eq([b.sym for b in bsyms])
@@ -1350,8 +1350,8 @@ def test_boundsymbol_hash_eq_examples(executor, device, dtype: dtypes.dtype):
         return a, b, c
 
     bsyms = extract_bsyms(diff_kwargs, (device, dtype), ("full",))
-    all_neq([hash(b.rhs()) for b in bsyms])
-    all_neq([b.rhs() for b in bsyms])
+    all_neq([hash(b.rhs) for b in bsyms])
+    all_neq([b.rhs for b in bsyms])
 
     # Assert that boundsymbols for different ops hash/compare differently.
     def different_ops(a, b):
@@ -1362,10 +1362,10 @@ def test_boundsymbol_hash_eq_examples(executor, device, dtype: dtypes.dtype):
     c, d = extract_bsyms(different_ops, (a, b), ("add", "sub"))
     assert hash(c.sym) != hash(d.sym)
     assert hash(c) != hash(d)
-    assert hash(c.rhs()) != hash(d.rhs())
+    assert hash(c.rhs) != hash(d.rhs)
     assert c.sym != d.sym
     assert c != d
-    assert c.rhs() != d.rhs()
+    assert c.rhs != d.rhs
 
 
 # @instantiate(dtypes=NOTHING)

--- a/thunder/tests/test_examine_memory.py
+++ b/thunder/tests/test_examine_memory.py
@@ -71,7 +71,7 @@ def test_view_ops(executor, device: str, dtype: dtypes.dtype):
     bw_traces = thunder.last_backward_traces(cbar)
     bw_extrace = bw_traces[-1]
     max_mem_bw = get_alloc_memory(bw_extrace)
-    assert max_mem_bw[0] == 144
+    assert max_mem_bw[0] == 128
     assert sum(max_mem_bw[1].values()) == get_return_memory(bw_extrace.bound_symbols[-1])  # 32
 
     def bar1(a, b, c):  # [4], [1,4,4], [4,1,4]

--- a/thunder/tests/test_examine_memory.py
+++ b/thunder/tests/test_examine_memory.py
@@ -73,14 +73,14 @@ def test_view_ops(executor, device: str, dtype: dtypes.dtype):
     max_mem_bw = get_alloc_memory(bw_extrace)
 
     # NOTE: nvFuser is able to avoid the allocation of result2 and produce it as alias to result1.
-    if executor.name == 'nvfuser':
+    if executor.name == "nvfuser":
         assert max_mem_bw[0] == 128
     else:
         assert max_mem_bw[0] == 144
 
     # NOTE: The get_return_memory method cannot distinguish wether the returned values come from an alias op.
     # In this case, since nvFuser returns one tensor and it's reshaped alias it only allocates once (32/2).
-    if executor.name == 'nvfuser':
+    if executor.name == "nvfuser":
         assert sum(max_mem_bw[1].values()) == 16
     else:
         assert sum(max_mem_bw[1].values()) == get_return_memory(bw_extrace.bound_symbols[-1])  # 32

--- a/thunder/tests/test_examine_memory.py
+++ b/thunder/tests/test_examine_memory.py
@@ -71,8 +71,19 @@ def test_view_ops(executor, device: str, dtype: dtypes.dtype):
     bw_traces = thunder.last_backward_traces(cbar)
     bw_extrace = bw_traces[-1]
     max_mem_bw = get_alloc_memory(bw_extrace)
-    assert max_mem_bw[0] == 128
-    assert sum(max_mem_bw[1].values()) == get_return_memory(bw_extrace.bound_symbols[-1])  # 32
+
+    # NOTE: nvFuser is able to avoid the allocation of result2 and produce it as alias to result1.
+    if executor.name == 'nvfuser':
+        assert max_mem_bw[0] == 128
+    else:
+        assert max_mem_bw[0] == 144
+
+    # NOTE: The get_return_memory method cannot distinguish wether the returned values come from an alias op.
+    # In this case, since nvFuser returns one tensor and it's reshaped alias it only allocates once (32/2).
+    if executor.name == 'nvfuser':
+        assert sum(max_mem_bw[1].values()) == 16
+    else:
+        assert sum(max_mem_bw[1].values()) == get_return_memory(bw_extrace.bound_symbols[-1])  # 32
 
     def bar1(a, b, c):  # [4], [1,4,4], [4,1,4]
         a_1 = torch.unsqueeze(a, 0)  # [1,4]


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?
</details>

## What does this PR do?
Simplifies on #397 and PR #538. In reply to [this comment](https://github.com/Lightning-AI/lightning-thunder/pull/538#issuecomment-2150837852), there is the need to enforce immutability to the `BoundSymbolRHS` object. To do so there are two alternatives, one is by freezing the dataclass and another is to create a `BoundSymbolRHS` as a NamedTuple which is sintax sugar for [namedtuple](https://docs.python.org/3/library/collections.html#collections.namedtuple). I decided to go for the latter as it greatly simplifies the code and takes care of hash and eq operator automatically. To do so however there is the need to transform the args and kwargs into tuples which is carried out by using the very fast tree_flatten from optree. 

Furthermore, once the issue with `unpack_trivial` is resolved, those methods can be removed and we will have a nice and tidy namedtuple.

The reasoning behind this change is the enforcement of immutability.

## PR review
cc. @IvanYashchuk