### PR TITLE
Drop unused arg for nvFusion

### DIFF
--- a/thunder/core/transform_common.py
+++ b/thunder/core/transform_common.py
@@ -86,13 +86,16 @@ def _inplace_copy_sanity_check(extrace: Trace):
 #   that only produce non-proxy objects
 # NOTE needed_proxies is an in/out argument, it takes an initial set of Variables you want to keep, and return
 #   all the needed proxies of the input trace
-def dce(trace: Trace, needed_proxies: set[Variable] = set()) -> Trace:
+def dce(trace: Trace, needed_proxies=None) -> Trace:
     start_time_ns = time.time_ns()
 
     producer_map: ProxyDict = producers(trace)
 
     flat_trace_outputs, _ = tree_flatten(trace.output)
-    needed_proxies.update(tuple(variableify(x) for x in flat_trace_outputs if isinstance(x, Proxy)))
+    if needed_proxies is None:
+        needed_proxies: set[Variable] = set(tuple(variableify(x) for x in flat_trace_outputs if isinstance(x, Proxy)))
+    else:
+        needed_proxies.update(tuple(variableify(x) for x in flat_trace_outputs if isinstance(x, Proxy)))
     dced = []
 
     bsym: BoundSymbol

--- a/thunder/core/transform_common.py
+++ b/thunder/core/transform_common.py
@@ -84,13 +84,15 @@ def _inplace_copy_sanity_check(extrace: Trace):
 # Runs a Dead Code Elimination (DCE) pass
 # NOTE Today we are only interested in computations that produce proxies, so this will eliminate operations
 #   that only produce non-proxy objects
-def dce(trace: Trace) -> Trace:
+# NOTE needed_proxies is an in/out argument, it takes an initial set of Variables you want to keep, and return
+#   all the needed proxies of the input trace
+def dce(trace: Trace, needed_proxies: set[Variable] = set()) -> Trace:
     start_time_ns = time.time_ns()
 
     producer_map: ProxyDict = producers(trace)
 
     flat_trace_outputs, _ = tree_flatten(trace.output)
-    needed_proxies: set[Variable] = set(tuple(variableify(x) for x in flat_trace_outputs if isinstance(x, Proxy)))
+    needed_proxies.update(tuple(variableify(x) for x in flat_trace_outputs if isinstance(x, Proxy)))
     dced = []
 
     bsym: BoundSymbol

--- a/thunder/core/transform_common.py
+++ b/thunder/core/transform_common.py
@@ -86,7 +86,7 @@ def _inplace_copy_sanity_check(extrace: Trace):
 #   that only produce non-proxy objects
 # NOTE needed_proxies is an in/out argument, it takes an initial set of Variables you want to keep, and return
 #   all the needed proxies of the input trace
-def dce(trace: Trace, needed_proxies=None) -> Trace:
+def dce(trace: Trace, needed_proxies: None | set[Variable] =None) -> Trace:
     start_time_ns = time.time_ns()
 
     producer_map: ProxyDict = producers(trace)

--- a/thunder/core/transform_common.py
+++ b/thunder/core/transform_common.py
@@ -86,7 +86,7 @@ def _inplace_copy_sanity_check(extrace: Trace):
 #   that only produce non-proxy objects
 # NOTE needed_proxies is an in/out argument, it takes an initial set of Variables you want to keep, and return
 #   all the needed proxies of the input trace
-def dce(trace: Trace, needed_proxies: None | set[Variable] =None) -> Trace:
+def dce(trace: Trace, needed_proxies: None | set[Variable] = None) -> Trace:
     start_time_ns = time.time_ns()
 
     producer_map: ProxyDict = producers(trace)

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -639,6 +639,7 @@ class nvFuserExecutor(FusionExecutor):
         flattened_bsyms: list[BoundSymbol] = []
         for bsym in region.bound_symbols:
             flattened_bsyms.extend(self.flatten(bsym))
+
         flattened_bsyms = self._dce_bsyms(sorted_unique_inputs, sorted_unique_outputs, flattened_bsyms)
 
         fusion_name = f"nvFusion{fusion_counter}"


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes #531 .
Fixes #482.

This PR removes the unused inputs for nvFusion during the fusion pass according to the needed_proxies dce returned 