### PR TITLE
Minimize weight range for `cross_entropy` opinfo test

### DIFF
--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -7782,7 +7782,7 @@ def cross_entropy_sample_generator(op, device, dtype, requires_grad, **kwargs):
                 if not probability_target
                 else make(shape[1], low=0.0, high=1.0, requires_grad=True)
             ),
-            weight=make(C, requires_grad=False) if weight_flag else None,
+            weight=make(C, low=1.0, high=2.0, requires_grad=False) if weight_flag else None,
             ignore_index=ignore_index,
             reduction=reduction_str,
             label_smoothing=label_smoothing,


### PR DESCRIPTION
This PR limits the range for the `cross_entropy` weight argument for test stability. The range is inherited from `nll_loss` opinfo test.