### PR TITLE
use transform_trace(s) on Transform classes instead of __call__

### DIFF
--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -606,7 +606,7 @@ def jit(
                 computation_trc = transform.transform_trace(computation_trc, executors_list=cd.executors_list)
                 extraces.append(computation_trc)
                 if backward_trc is not None:
-                    backward_trc = transform(backward_trc, executors_list=cd.executors_list)
+                    backward_trc = transform.transform_trace(backward_trc, executors_list=cd.executors_list)
                     backward_traces.append(backward_trc)
 
             comp = computation_trc.python_callable()

--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -517,7 +517,7 @@ def jit(
             transform: Callable
             for transform in early_transforms:
                 thunder.core.utils.check_type(transform, EarlyTransform)
-                prologue_trc, computation_trc, epilogue_trc = transform(
+                prologue_trc, computation_trc, epilogue_trc = transform.transform_traces(
                     prologue_trc, computation_trc, epilogue_trc, executors_list=cd.executors_list
                 )
                 prologue_traces.append(prologue_trc)
@@ -586,7 +586,7 @@ def jit(
                 cs.last_computation_transformation_start = time.time_ns()
                 for transform in additional_transforms:
                     thunder.core.utils.check_type(transform, AdditionalTransform)
-                    computation_trc = transform(computation_trc, executors_list=cd.executors_list)
+                    computation_trc = transform.transform_trace(computation_trc, executors_list=cd.executors_list)
                     computation_traces.append(computation_trc)
                 cs.last_computation_transformation_stop = time.time_ns()
 
@@ -603,7 +603,7 @@ def jit(
             for transform in post_optimization_transforms:
                 # NOTE: `backward_trc` could be None.
                 thunder.core.utils.check_type(transform, PostOptimizationTransform)
-                computation_trc = transform(computation_trc, executors_list=cd.executors_list)
+                computation_trc = transform.transform_trace(computation_trc, executors_list=cd.executors_list)
                 extraces.append(computation_trc)
                 if backward_trc is not None:
                     backward_trc = transform(backward_trc, executors_list=cd.executors_list)

--- a/thunder/common.py
+++ b/thunder/common.py
@@ -673,7 +673,7 @@ def _execute_trace(
 
     # Applies post-optimization transforms
     for transform in post_optimization_transforms:
-        extrace = transform(extrace)
+        extrace = transform.transform_trace(extrace)
         extraces.append(extrace)
 
     # Constructs the Python callable
@@ -825,7 +825,7 @@ def _create_callable(
 
             # Applies transforms
             for transform in transforms:
-                trc = transform(trc, executors_list=cd.executors_list)
+                trc = transform.transform_trace(trc, executors_list=cd.executors_list)
                 traces.append(trc)
 
             #

--- a/thunder/core/transform_common.py
+++ b/thunder/core/transform_common.py
@@ -335,7 +335,7 @@ class EarlyTransform(Transform, ABC):
     """
 
     @abstractmethod
-    def __call__(self, prologue_trace: Trace, computation_trace: Trace, epilogue_trace: Trace | None, **kwargs):
+    def transform_traces(self, prologue_trace: Trace, computation_trace: Trace, epilogue_trace: Trace | None, **kwargs):
         pass
 
 
@@ -346,7 +346,7 @@ class AdditionalTransform(Transform, ABC):
     """
 
     @abstractmethod
-    def __call__(self, computation_trace: Trace, **kwargs):
+    def transform_trace(self, computation_trace: Trace, **kwargs):
         pass
 
 
@@ -357,5 +357,5 @@ class PostOptimizationTransform(Transform, ABC):
     """
 
     @abstractmethod
-    def __call__(self, computation_trace: Trace, **kwargs):
+    def transform_trace(self, computation_trace: Trace, **kwargs):
         pass

--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -508,7 +508,7 @@ def add_post_optimization_transform(cfn: Callable, transform: PostOptimizationTr
 
 # The no-op transform. A trivial composable transform, only useful as an example.
 class _NoopTransform(AdditionalTransform):
-    def __call__(self, trace: Trace, **kwargs) -> Trace:
+    def transform_trace(self, trace: Trace, **kwargs) -> Trace:
         start_time_ns = time.time_ns()
         noop_trace = from_trace(trace)
 
@@ -1395,7 +1395,7 @@ def grad(
         return grad_func
 
     class _GradTransform(AdditionalTransform):
-        def __call__(self, trc: Trace, *, executors_list: Sequence[Any]) -> Trace:
+        def transform_trace(self, trc: Trace, *, executors_list: Sequence[Any]) -> Trace:
             # Using trc.python_callable() makes it impossible to retrace the
             # function because the python_callable uses python_ctx which replaces
             # symbol occurrences with its symbol._call_ctx function

--- a/thunder/distributed/tensor_parallel/common.py
+++ b/thunder/distributed/tensor_parallel/common.py
@@ -175,7 +175,7 @@ class TransformForTensorParallel(EarlyTransform):
     @abstractmethod
     def distparallel_type(self) -> DistParallelType: ...
 
-    def __call__(
+    def transform_traces(
         self,
         prologue_trace: TraceCtx,
         computation_trace: TraceCtx,

--- a/thunder/distributed/transforms/fsdp_v2.py
+++ b/thunder/distributed/transforms/fsdp_v2.py
@@ -28,7 +28,7 @@ class FSDPTraceTransform(EarlyTransform):
     sharded_params: dict[str, Any]
     process_group: ProcessGroup
 
-    def __call__(self, prologue_trace, computation_trace, epilogue_trace, **kwargs):
+    def transform_traces(self, prologue_trace, computation_trace, epilogue_trace, **kwargs):
         from thunder.distributed import prims as dist_prims
 
         prologue_producers, prologue_consumers = utils.producers_and_consumers(prologue_trace)

--- a/thunder/tests/test_jit_general.py
+++ b/thunder/tests/test_jit_general.py
@@ -820,7 +820,7 @@ def test_post_optimization_transform():
         return a * a + b * c
 
     class MyTransform(PostOptimizationTransform):
-        def __call__(self, trace, executors_list=None):
+        def transform_trace(self, trace, executors_list=None):
             # Transform that adds a comment before any `add` BoundSymbol.
             commented_trace = thunder.core.trace.from_trace(trace)
 


### PR DESCRIPTION
building on @kshitij12345 's #542 

The next step is to include the transformation of the module as a method on the transform. 