### PR TITLE
Modify subsymbols in cse_single_bsym; unblocks phi-2 with inductor_cat+nvfuser executors

### DIFF
--- a/thunder/core/transform_common.py
+++ b/thunder/core/transform_common.py
@@ -218,7 +218,6 @@ def cse_single_bsym(
         swap_map=redundant_map,
         skip_inputs=False,
         skip_output=True,
-        skip_subsymbols=True,
     )
 
     # Skip appending this bsym to the new bound symbols due to its rhs being a common subexpression.

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -397,7 +397,6 @@ class FusionDefinitionWrapper:
     cache_info: None | Callable = None
     cache_clear: None | Callable = None
     last_used: None | FusionDefinition = None
-    bound_symbols: None | list[BoundSymbol] = None
 
     def __call__(self, *args):
         fd = self.get_fd(to_descriptors(args))
@@ -512,7 +511,7 @@ def create_fusion_definition_wrapper(
         # A closure over local trace and region
         return create_fd(bsyms, input_descriptors, sorted_unique_inputs, sorted_unique_outputs)
 
-    fdw = FusionDefinitionWrapper(get_fd, name, get_fd.cache_info, get_fd.cache_clear, bsyms)
+    fdw = FusionDefinitionWrapper(get_fd, name, get_fd.cache_info, get_fd.cache_clear)
     return fdw
 
 

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -397,6 +397,7 @@ class FusionDefinitionWrapper:
     cache_info: None | Callable = None
     cache_clear: None | Callable = None
     last_used: None | FusionDefinition = None
+    bound_symbols: None | list[BoundSymbol] = None
 
     def __call__(self, *args):
         fd = self.get_fd(to_descriptors(args))
@@ -511,7 +512,7 @@ def create_fusion_definition_wrapper(
         # A closure over local trace and region
         return create_fd(bsyms, input_descriptors, sorted_unique_inputs, sorted_unique_outputs)
 
-    fdw = FusionDefinitionWrapper(get_fd, name, get_fd.cache_info, get_fd.cache_clear)
+    fdw = FusionDefinitionWrapper(get_fd, name, get_fd.cache_info, get_fd.cache_clear, bsyms)
     return fdw
 
 

--- a/thunder/tests/test_torch_compile_executor.py
+++ b/thunder/tests/test_torch_compile_executor.py
@@ -3,9 +3,11 @@ import torch
 from torch._dynamo import is_inductor_supported
 
 import thunder
-from thunder.executors.torch_compile import supported_ops, torch_compile_ex
+from thunder.executors.torch_compile import supported_ops, torch_compile_ex, torch_compile_cat_ex
 from thunder.executors.torchex import ex as pytorch_ex
-from thunder.tests.litgpt_model import GPT
+from thunder.executors.nvfuserex import nvfuserex
+from thunder.tests.litgpt_model import GPT, Config
+from thunder.tests .framework import requiresCUDA
 
 
 def test_supported_ops_are_in_pytorch_executor():
@@ -23,3 +25,19 @@ def test_torch_compile_litgpt():
     # a single torch.compile region. normally you would want to enable sdpa too
     assert "TorchCompile0" in forward_trace
     assert "TorchCompile1" not in forward_trace
+
+# Testing the following issue:
+# https://github.com/Lightning-AI/lightning-thunder/issues/292 The issue was
+# that the CSE pass was not being run correctly on the TorchCompile region.
+# Here we test that everything works as expected.
+@pytest.mark.skipif(not is_inductor_supported(), reason="inductor unsupported")
+@requiresCUDA
+def test_torch_compile_cat_nvfuser_phi2_tanh():
+    device = torch.device("cuda")
+    config = Config.from_name("phi-2", n_layer=1, gelu_approximate="tanh")
+    with device:
+        model = GPT(config).to(torch.bfloat16)
+    x = torch.randint(model.max_seq_length, (5, 5), device=device)
+    cmodel = thunder.jit(model, executors=[torch_compile_cat_ex, nvfuserex])
+    logits = cmodel(x)
+    logits.sum().backward()

--- a/thunder/tests/test_torch_compile_executor.py
+++ b/thunder/tests/test_torch_compile_executor.py
@@ -7,7 +7,7 @@ from thunder.executors.torch_compile import supported_ops, torch_compile_ex, tor
 from thunder.executors.torchex import ex as pytorch_ex
 from thunder.executors.nvfuserex import nvfuserex
 from thunder.tests.litgpt_model import GPT, Config
-from thunder.tests .framework import requiresCUDA
+from thunder.tests.framework import requiresCUDA
 
 
 def test_supported_ops_are_in_pytorch_executor():
@@ -25,6 +25,7 @@ def test_torch_compile_litgpt():
     # a single torch.compile region. normally you would want to enable sdpa too
     assert "TorchCompile0" in forward_trace
     assert "TorchCompile1" not in forward_trace
+
 
 # Testing the following issue:
 # https://github.com/Lightning-AI/lightning-thunder/issues/292 The issue was


### PR DESCRIPTION
There was an unfortunate interaction between the CSE pass and the "flattening" of symbols which is done in nvFuser fusion pass. CSE pass was changing only the highest level of the symbol information leaving its subsymbols untouched, nvFuser fusion pass then extracted the subsymbols that were not correct anymore and tried converting to FusionDefinition leading to an error reported in #292.

Fixes https://github.com/Lightning-AI/lightning-thunder/issues/292, fixes https://github.com/Lightning-AI/lightning-thunder/issues/551.

cc @apaz-cli