### PR TITLE
jit: add constraint for torch.device as input to jitted fn

### DIFF
--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -907,7 +907,7 @@ def recursively_proxy(*args, **kwargs):
             v.track_items()
             need_proxy = any(proxy_recursion(i) for i in v.item_wrappers)
         else:
-            need_proxy = isinstance(v.value, torch.Tensor) or isinstance(v.value, torch.device)
+            need_proxy = isinstance(v.value, torch.Tensor)
         if need_proxy:
             ctx: GeneralJitCtx = get_general_jit_ctx()
             ctx.proxify(v)
@@ -1117,7 +1117,7 @@ def _general_jit_wrap_callback(value):
         pass  # basic containers are OK, too, subclasses?
     elif isinstance(uvalue, Proxy):
         value.provenance.ext_flag |= EXT_FLAG_IS_PROXY_DERIVED
-    elif isinstance(uvalue, (float, int, complex, str)) and not isinstance(uvalue, Proxy):
+    elif isinstance(uvalue, (float, int, complex, str, torch.device)) and not isinstance(uvalue, Proxy):
         if value.provenance.ext_flag & EXT_FLAG_IS_PROXY_DERIVED:  # we already have seen this
             pass
         elif should_register_for_prologue(value.provenance):


### PR DESCRIPTION
Fixes: #555 

This PR adds constraints to the prologue trace to check the passed torch.device to jitted function matches the previously traced torch.device.

**NOTE**: We add this constraint even for `SYMBOLIC_VALUES` caching option, as the computation trace may have operations which are supported only on certain devices, so we shouldn't be reusing that trace.

Example:
```python
import thunder
import torch

def foo(x, device):
    return x.to(device)

jfoo = thunder.jit(foo)
x = torch.randn(3, 3)
print(jfoo(x, torch.device('cuda')).device)  # output : cuda:0
print("****")
print(thunder.last_prologue_traces(jfoo)[-1])
```

Prologue Trace (after the PR):
```python
# Constructed by Transform for execution (took 1 milliseconds)
import torch
from thunder.executors.torchex import no_autocast

@torch.no_grad()
@no_autocast
def prologue(*args, **kwargs):
  # args: "Any"
  check_len(args, 2)
    # prims.check_len(args, 2)
  # kwargs: "Any"
  check_len(kwargs, 0)
    # prims.check_len(kwargs, 0)
  x: "cpu f32[3, 3]" = args[0]
  check_tensor_metadata(x, (3, 3), 'cpu', torch.float32, False)
    # prims.check_tensor_metadata(x, (3, 3), 'cpu', torch.float32, False)

  # THIS CHECK IS ADDED BY THE PR
  p0: "<class 'torch.device'>" = args[1]
  check_literal_like(p0, torch.device("cuda"))
    # prims.check_literal_like(p0, torch.device("cuda"))

  cache_info: "Any" = thunder._get_cache_info()
  cache_info_is_autocast_enabled: "bool False" = cache_info['is_autocast_enabled']
  check_number_type_and_value(cache_info_is_autocast_enabled, False)
    # prims.check_number_type_and_value(cache_info_is_autocast_enabled, False)
  cache_info_no_grad_sync: "bool False" = cache_info['no_grad_sync']
  check_number_type_and_value(cache_info_no_grad_sync, False)
    # prims.check_number_type_and_value(cache_info_no_grad_sync, False)
  return (x,)
```