### PR TITLE
add program coverage as an extra category

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,9 +2,9 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: bug
 assignees: ''
 ---
+*Note*: If you have a model or program that is not supported yet but should be, please use the program coverage template.
 
 ## 🐛 Bug
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,6 +4,7 @@ about: Create a report to help us improve
 title: ''
 assignees: ''
 ---
+
 *Note*: If you have a model or program that is not supported yet but should be, please use the program coverage template.
 
 ## 🐛 Bug

--- a/.github/ISSUE_TEMPLATE/program_coverage.md
+++ b/.github/ISSUE_TEMPLATE/program_coverage.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: program-coverage
+assignees: ''
+---
+
+## 🚀 Model / language coverage
+
+<!-- A clear and concise description of the code construct you want to support -->
+
+### Pitch
+
+<!-- A clear and concise description of the impact (what models are enabled etc.) to help us prioritize coverage. -->
+
+### Alternatives / Potential work-arounds
+
+<!-- If you have thoughts on working around the issue or alternative functionality to achieve your goal, we would be keen to hear them.  >
+
+### Minimal Repro
+
+<!-- A minimal reproduction to demonstrate the current error message. -->


### PR DESCRIPTION
Currently, expanding model coverage is reported as "bug", but actually, it woudl be useful to have it as an additional category (similar to enhancement, but more specific).
This PR adds this.
It also removes adding the "bug" label to everything. Issues seem to be bugs by default.