### PR TITLE
Added lookside for torch.compile

### DIFF
--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -774,6 +774,12 @@ def _general_jit_setattr_lookaside(obj: Any, name: str, value: Any):
         return res
     return res
 
+@general_jit_lookaside(torch.compile)
+def torch_compile_lookaside(*args, **kwargs):
+    return do_raise(NotImplementedError(
+        "Using torch.compile within a function to be JIT-compiled by Thunder is not supported. "
+        "Please remove the call to torch.compile or apply it outside the function."
+    ))
 
 # TODO Expand on this
 @interpreter_needs_wrap

--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -774,12 +774,16 @@ def _general_jit_setattr_lookaside(obj: Any, name: str, value: Any):
         return res
     return res
 
+
 @general_jit_lookaside(torch.compile)
 def torch_compile_lookaside(*args, **kwargs):
-    return do_raise(NotImplementedError(
-        "Using torch.compile within a function to be JIT-compiled by Thunder is not supported. "
-        "Please remove the call to torch.compile or apply it outside the function."
-    ))
+    return do_raise(
+        NotImplementedError(
+            "Using torch.compile within a function to be JIT-compiled by Thunder is not supported. "
+            "Please remove the call to torch.compile or apply it outside the function."
+        )
+    )
+
 
 # TODO Expand on this
 @interpreter_needs_wrap

--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -776,7 +776,7 @@ def _general_jit_setattr_lookaside(obj: Any, name: str, value: Any):
 
 
 @general_jit_lookaside(torch.compile)
-def torch_compile_lookaside(*args, **kwargs):
+def _jit_torch_compile_lookaside(*args, **kwargs):
     return do_raise(
         NotImplementedError(
             "Using torch.compile within a function to be JIT-compiled by Thunder is not supported. "

--- a/thunder/tests/test_jit_general.py
+++ b/thunder/tests/test_jit_general.py
@@ -342,6 +342,24 @@ def test_nn_module():
     actual = jfn2(a)
     assert_close(expected, actual)
 
+def test_compile_within_jit():
+    def model(a, b, c):
+        return a @ b + c
+
+    def jit_me(x):
+        cfn = torch.compile(model)
+        return cfn(x)
+
+    jcfn = thunder.jit(jit_me)
+
+    x = torch.randn(2, 2)
+    y = torch.randn(2, 2)
+    z = torch.randn(2, 2)
+
+    with pytest.raises(NotImplementedError) as exc_info:
+        jcfn(x, y, z)
+
+    assert "Using torch.compile within a function to be JIT-compiled by Thunder is not supported." in str(exc_info.value)
 
 def test_add_numbers():
     def foo(a, b):

--- a/thunder/tests/test_jit_general.py
+++ b/thunder/tests/test_jit_general.py
@@ -342,6 +342,7 @@ def test_nn_module():
     actual = jfn2(a)
     assert_close(expected, actual)
 
+
 def test_compile_within_jit():
     def model(a, b, c):
         return a @ b + c
@@ -359,7 +360,10 @@ def test_compile_within_jit():
     with pytest.raises(NotImplementedError) as exc_info:
         jcfn(x, y, z)
 
-    assert "Using torch.compile within a function to be JIT-compiled by Thunder is not supported." in str(exc_info.value)
+    assert "Using torch.compile within a function to be JIT-compiled by Thunder is not supported." in str(
+        exc_info.value
+    )
+
 
 def test_add_numbers():
     def foo(a, b):

--- a/thunder/tests/test_jit_general.py
+++ b/thunder/tests/test_jit_general.py
@@ -342,14 +342,13 @@ def test_nn_module():
     actual = jfn2(a)
     assert_close(expected, actual)
 
-
 def test_compile_within_jit():
     def model(a, b, c):
         return a @ b + c
 
-    def jit_me(x):
+    def jit_me(a, b, c):
         cfn = torch.compile(model)
-        return cfn(x)
+        return cfn(a, b, c)
 
     jcfn = thunder.jit(jit_me)
 
@@ -360,9 +359,7 @@ def test_compile_within_jit():
     with pytest.raises(NotImplementedError) as exc_info:
         jcfn(x, y, z)
 
-    assert "Using torch.compile within a function to be JIT-compiled by Thunder is not supported." in str(
-        exc_info.value
-    )
+    assert "Using torch.compile within a function to be JIT-compiled by Thunder is not supported." in str(exc_info.value)
 
 
 def test_add_numbers():

--- a/thunder/tests/test_jit_general.py
+++ b/thunder/tests/test_jit_general.py
@@ -342,6 +342,7 @@ def test_nn_module():
     actual = jfn2(a)
     assert_close(expected, actual)
 
+
 def test_compile_within_jit():
     def model(a, b, c):
         return a @ b + c
@@ -359,7 +360,9 @@ def test_compile_within_jit():
     with pytest.raises(NotImplementedError) as exc_info:
         jcfn(x, y, z)
 
-    assert "Using torch.compile within a function to be JIT-compiled by Thunder is not supported." in str(exc_info.value)
+    assert "Using torch.compile within a function to be JIT-compiled by Thunder is not supported." in str(
+        exc_info.value
+    )
 
 
 def test_add_numbers():


### PR DESCRIPTION
Added a lookaside function `torch_compile_lookaside` in `thunder/core/jit_ext.py` to handle cases where `torch.compile` is used within a function intended for JIT compilation.

<details>
  <summary><b>Before submitting</b></summary>

- [X] Was this discussed/approved via a Github issue? (no need for typos and docs improvements) - Yes
- [X] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section? - Yes
- [X] Did you make sure to update the docs? - No
- [X] Did you write any new necessary tests? - No

</details>

## What does this PR do?

Fixes #186 

- Added a lookaside function `torch_compile_lookaside` in `thunder/core/jit_ext.py` to handle cases where `torch.compile` is used within a function intended for JIT compilation.
- The lookaside raises a `NotImplementedError` with a clear message, guiding users to remove the `torch.compile` call or apply it outside the function.
- Ensured the function is decorated with `@general_jit_lookaside(torch.compile)` to integrate it properly with Thunder's JIT infrastructure.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Sure, did!
