### PR TITLE
Fix `unpack_trivial` usage in interpreter

### DIFF
--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -1500,12 +1500,12 @@ def process_recorded_modifications(ctx, epilogue_trace):
 
 def bind_inputs(name, trace, input_vars, input_proxies):
     # Unpacks inputs into the computation trace
-    # TODO This currently does the unpacks at the end of he trace, then moves them to the beginning, there's
+    # TODO This currently does the unpacks at the end of the trace, then moves them to the beginning, there's
     #   almost certainly a more elegant way to do this
     with tracectx(trace):
         p: Proxy
         for p in input_proxies:
-            prims.unpack_trivial(p)
+            prims.unpack_trivial(p, name=p.name)
 
     bsyms = trace.bound_symbols
     trace.bound_symbols = bsyms[-len(input_proxies) :] + bsyms[: -len(input_proxies)]

--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -634,6 +634,7 @@ def unpack_trivial_impl(x: Any, /, *, name: str | None = None) -> Any:
 
 
 def unpack_trivial_meta(x: Any, /, *, name: str | None = None) -> Any:
+    utils.check(name is not None, lambda: "Expected name argmument to not be None")
     return _collectify(x, name=name)
 
 

--- a/thunder/functional.py
+++ b/thunder/functional.py
@@ -325,7 +325,7 @@ def _eager_unpacking_interpreter(
         for name, x in si.args:
             p: Proxy
             p, _ = _eager_unpack(x, name, co=co)
-            prims.unpack_trivial(p)
+            prims.unpack_trivial(p, name=name)
             cargs, iargs = _eager_validate(p, co=co)
             computation_args.extend(cargs)
 
@@ -339,7 +339,7 @@ def _eager_unpacking_interpreter(
 
             p: Proxy
             p, _ = _eager_unpack(x, name, co=co)
-            prims.unpack_trivial(p)
+            prims.unpack_trivial(p, name=name)
             cargs, iargs = _eager_validate(p, co=co)
             computation_args.extend(cargs)
 
@@ -351,7 +351,7 @@ def _eager_unpacking_interpreter(
         for name, x in si.kwargs.items():
             p: Proxy
             p, _ = _eager_unpack(x, name, co=co)
-            prims.unpack_trivial(p)
+            prims.unpack_trivial(p, name=name)
             cargs, iargs = _eager_validate(p, co=co)
             computation_args.extend(cargs)
 
@@ -364,7 +364,7 @@ def _eager_unpacking_interpreter(
 
             p: Proxy
             p, _ = _eager_unpack(x, name, co=co)
-            prims.unpack_trivial(p)
+            prims.unpack_trivial(p, name=name)
             cargs, iargs = _eager_validate(p, co=co)
             computation_args.extend(cargs)
 
@@ -382,7 +382,7 @@ def _eager_unpacking_interpreter(
     with tracectx(computation_trc):
         p: Proxy
         for p in computation_args:
-            prims.unpack_trivial(p)
+            prims.unpack_trivial(p, name=p.name)
             csi.args.append((p.name, None))
             computation_trc.add_name(p.name)
 


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?
</details>

## What does this PR do?

This PR adds the name argument when using `prims.unpack_trivial` as it is key for the later CSE pass to understand unique inputs.

## PR review

This is linked to #543 and the other CSE issue #397.
