### PR TITLE
TE: update in module structure

### DIFF
--- a/thunder/executors/transformer_engineex.py
+++ b/thunder/executors/transformer_engineex.py
@@ -49,7 +49,6 @@ if TE_AVAILABLE:
         from transformer_engine.pytorch.fp8 import FP8GlobalStateManager
         from transformer_engine.pytorch.utils import check_dim_for_fp8_exec
         from transformer_engine.pytorch.cpu_offload import CPUOffloadEnabled
-        import transformer_engine_extensions as tex
     except Exception as ex:
         warnings.warn(f"transformer_engine failed to import with exception {ex}")
         TE_AVAILABLE = False
@@ -61,6 +60,9 @@ if TE_AVAILABLE:
             f"Installed version of transformer_engine {version('transformer_engine')} is not supported, please upgrade. `transformer_engine_ex` will not be used."
         )
         TE_AVAILABLE = False
+
+    if TE_VERSION_1_8_PLUS:
+        import transformer_engine_torch as tex
 
 if not TE_AVAILABLE:
     TransformerEngineBaseModule = object


### PR DESCRIPTION
PR - https://github.com/NVIDIA/TransformerEngine/pull/877 updated the names of the the extension modules `transformer_engine_extensions` -> `transformer_engine_{torch| jax | paddle}` .

In this PR, we optionally import `transformer_engine_torch` if TE v1.8 or more as we require this module only to support the code path required for v1.8 .

Patch tested with TE v1.6, v1.7 and main (v1.8) with `test_transformer_engine_executor.py` and `thunder/tests/distributed/test_ddp.py -k transformer -v`
