### PR TITLE
Add inplace kwarg to `torch.nn.functional.silu`

### DIFF
--- a/thunder/executors/torchex.py
+++ b/thunder/executors/torchex.py
@@ -836,7 +836,7 @@ _register_elementwise_unary_implementation(ltorch.relu, relu, checker=_elementwi
 _register_elementwise_unary_implementation(ltorch.relu6, relu6, checker=_elementwise_unary_with_inplace_checker)
 _register_elementwise_unary_implementation(ltorch.hardswish, hardswish, checker=_elementwise_unary_with_inplace_checker)
 _register_elementwise_unary_implementation(ltorch.selu, selu, checker=_elementwise_unary_with_inplace_checker)
-_register_elementwise_unary_implementation(ltorch.silu, silu)
+_register_elementwise_unary_implementation(ltorch.silu, silu, checker=_always_executable)
 
 #
 # Elementwise binary operations

--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -1194,10 +1194,15 @@ rsqrt_opinfo = OpInfo(
 )
 elementwise_unary_ops.append(rsqrt_opinfo)
 
+def silu_error_generator(op, device, dtype=torch.float32, **kwargs):
+    a = make_tensor((), dtype=dtype, device=device)
+    yield (SampleInput(a, inplace=True), NotImplementedError, "silu only supports inplace=False")
+
 silu_opinfo = OpInfo(
-    clang.silu,
+    ltorch.silu,
     dtypes=(datatypes.floating,),
     sample_input_generator=partial(elementwise_unary_generator, supports_numbers=False),
+    error_input_generator=silu_error_generator,
     torch_reference=_elementwise_unary_torch(torch.nn.functional.silu),
     test_directives=(
         DecorateInfo(

--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -1194,38 +1194,6 @@ rsqrt_opinfo = OpInfo(
 )
 elementwise_unary_ops.append(rsqrt_opinfo)
 
-def silu_error_generator(op, device, dtype=torch.float32, **kwargs):
-    a = make_tensor((), dtype=dtype, device=device)
-    yield (SampleInput(a, inplace=True), NotImplementedError, "silu only supports inplace=False")
-
-silu_opinfo = OpInfo(
-    ltorch.silu,
-    dtypes=(datatypes.floating,),
-    sample_input_generator=partial(elementwise_unary_generator, supports_numbers=False),
-    error_input_generator=silu_error_generator,
-    torch_reference=_elementwise_unary_torch(torch.nn.functional.silu),
-    test_directives=(
-        DecorateInfo(
-            pytest.mark.xfail,
-            executors=("nvfuser",),
-            active_if=nvfuser_version < "0.0.3",
-        ),
-        # NOTE: Torch doesn't support CPU float16 silu
-        DecorateInfo(
-            pytest.mark.xfail,
-            "test_core_vs_torch_consistency",
-            dtypes=(datatypes.float16,),
-            devicetypes=(devices.DeviceType.CPU,),
-        ),
-        # test tols are too tight for these half precision tests
-        DecorateInfo(
-            pytest.mark.xfail,
-            "test_core_vs_torch_consistency",
-            dtypes=(datatypes.float16, datatypes.bfloat16),
-        ),
-    ),
-)
-elementwise_unary_ops.append(silu_opinfo)
 
 sigmoid_opinfo = OpInfo(
     clang.sigmoid,
@@ -1300,10 +1268,17 @@ signbit_opinfo = OpInfo(
 )
 elementwise_unary_ops.append(signbit_opinfo)
 
+
+def silu_error_generator(op, device, dtype=torch.float32, **kwargs):
+    a = make_tensor((), dtype=dtype, device=device)
+    yield (SampleInput(a, inplace=True), NotImplementedError, "Thunder only supports silu with inplace=False")
+
+
 silu_opinfo = OpInfo(
-    clang.silu,
+    ltorch.silu,
     dtypes=(datatypes.floating,),
     sample_input_generator=partial(elementwise_unary_generator, supports_numbers=False),
+    error_input_generator=silu_error_generator,
     torch_reference=_elementwise_unary_torch(torch.nn.functional.silu),
     test_directives=(
         DecorateInfo(

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -1486,8 +1486,10 @@ def selu(a: TensorProxy, /, inplace: bool = False) -> TensorLike:
 
 
 @torchsymbol(torch.nn.functional.silu)
-def silu(a: TensorLike, inplace: bool = False):
-    utils.check(not inplace, lambda: "silu only supports inplace=False", exception_type=NotImplementedError)
+def silu(a: TensorLike, /, *, inplace: bool = False):
+    utils.check(
+        not inplace, lambda: "Thunder only supports silu with inplace=False", exception_type=NotImplementedError
+    )
     return clang.silu(a)
 
 

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -1486,7 +1486,8 @@ def selu(a: TensorProxy, /, inplace: bool = False) -> TensorLike:
 
 
 @torchsymbol(torch.nn.functional.silu)
-def silu(a, /):
+def silu(a: TensorLike, inplace: bool = False):
+    utils.check(not inplace, lambda: "silu only supports inplace=False", exception_type=NotImplementedError)
     return clang.silu(a)
 
 


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

## What does this PR do?

Temporarily fixes #455 till we implement inplace operators by adding the keyword arg to the operator implementation.
I changed from testing the clang to testing the ltorch symbol as it is a superset of clang in this case so we test both.
