### PR TITLE
Functionalize in-place ops

### DIFF
--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -510,10 +510,8 @@ def jit(
             prologue_traces = [prologue_trc]
             computation_traces = [computation_trc]
             if not compile_options.get("skip_inplace_functionalization", False):
-                computation_trc = functionalize_inplace_ops(
-                    computation_trace=computation_trc,
-                    computation_traces=computation_traces,
-                )
+                computation_traces.extend(functionalize_inplace_ops(computation_trace=computation_trc))
+                computation_trc = computation_traces[-1]
 
             if epilogue_trc is not None:
                 epilogue_traces = [epilogue_trc]

--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -510,10 +510,8 @@ def jit(
             prologue_traces = [prologue_trc]
             computation_traces = [computation_trc]
             if not compile_options.get("skip_inplace_functionalization", False):
-                print(f"# Before functionalization\n{computation_trc}")
                 computation_traces.extend(functionalize_inplace_ops(computation_trace=computation_trc))
                 computation_trc = computation_traces[-1]
-                print(f"# After functionalization\n{computation_trc}")
 
             if epilogue_trc is not None:
                 epilogue_traces = [epilogue_trc]

--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -33,7 +33,13 @@ from thunder import functional as functional
 import thunder.core.prims as prims
 import thunder.core.dtypes as dtypes
 import thunder.core.devices as devices
-from thunder.core.transform_common import dce, EarlyTransform, AdditionalTransform, PostOptimizationTransform
+from thunder.core.transform_common import (
+    dce,
+    EarlyTransform,
+    AdditionalTransform,
+    PostOptimizationTransform,
+    functionalize_inplace_ops,
+)
 from thunder.common import (
     CompileData,
     CompileStats,
@@ -503,6 +509,11 @@ def jit(
 
             prologue_traces = [prologue_trc]
             computation_traces = [computation_trc]
+            if not compile_options.get("skip_inplace_functionalization", False):
+                computation_trc = functionalize_inplace_ops(
+                    computation_trace=computation_trc,
+                    computation_traces=computation_traces,
+                )
 
             if epilogue_trc is not None:
                 epilogue_traces = [epilogue_trc]

--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -510,8 +510,10 @@ def jit(
             prologue_traces = [prologue_trc]
             computation_traces = [computation_trc]
             if not compile_options.get("skip_inplace_functionalization", False):
+                print(f"# Before functionalization\n{computation_trc}")
                 computation_traces.extend(functionalize_inplace_ops(computation_trace=computation_trc))
                 computation_trc = computation_traces[-1]
+                print(f"# After functionalization\n{computation_trc}")
 
             if epilogue_trc is not None:
                 epilogue_traces = [epilogue_trc]

--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -1744,6 +1744,12 @@ def thunder_general_jit(
 
 
 def functionalize_inplace_ops(computation_trace: TraceCtx) -> TraceCtx:
+    """Functionalize in-place ops in ``computation_trace``.
+
+    This is a two-step function. The first step is to use the output of :func:`thunder.core.prims.copy_`'s
+    outputs as trace's outputs. The second step is to remove :func:`thunder.core.prims.copy_`
+    from :attr:`~thunder.core.symbol.Boundsymbol.subsymbols` if it's the last symbol.
+    """
     from thunder.core import utils
     from thunder.core.proxies import ProxyInterface
     from thunder.core.symbol import VariableInterface
@@ -1758,8 +1764,7 @@ def functionalize_inplace_ops(computation_trace: TraceCtx) -> TraceCtx:
     if not any(is_inplace(bsym) for bsym in computation_trace.bound_symbols):
         return computation_trace
 
-    # Step 1: don't return tensors who have their consumers in any way, i.e., return
-    # the tensors returned from `prims.copy_` as possible.
+    # Step 1: return the tensors returned from `prims.copy_` as possible not the args for clarity.
     bsym: BoundSymbol
     swap_map: dict[VariableInterface, ProxyInterface] = {}
     bsyms: list[BoundSymbol] = []

--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -67,7 +67,7 @@ from thunder.core.proxies import (
     unvariableify,
     is_proxy_name_available,
 )
-from thunder.core.trace import set_tracectx, reset_tracectx, tracectx, from_trace, TraceProvenance
+from thunder.core.trace import set_tracectx, reset_tracectx, tracectx, from_trace
 from thunder.core.interpreter import (
     InterpreterLogItem,
     interpret,

--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -1678,8 +1678,6 @@ def thunder_general_jit(
             process_recorded_modifications(ctx, epilogue_trace)
             last_interpreter_log = jfn._last_interpreter_log
 
-    computation_trace = functionalize_inplace_ops(computation_trace)
-
     pro_to_comp, computation_intermediates = get_computation_inputs_and_intermediates(computation_trace)
     epilogue_inputs, _ = get_computation_inputs_and_intermediates(epilogue_trace)
 
@@ -1741,100 +1739,3 @@ def thunder_general_jit(
         )
 
     return TraceResults(prologue_trace, computation_trace, epilogue_trace, last_interpreter_log)
-
-
-def functionalize_inplace_ops(computation_trace: TraceCtx) -> TraceCtx:
-    """Functionalize in-place ops in ``computation_trace``.
-
-    This is a two-step function. The first step is to use the output of :func:`thunder.core.prims.copy_`'s
-    outputs as trace's outputs. The second step is to remove :func:`thunder.core.prims.copy_`
-    from :attr:`~thunder.core.symbol.Boundsymbol.subsymbols` if it's the last symbol.
-    """
-    from thunder.core import utils
-    from thunder.core.proxies import ProxyInterface
-    from thunder.core.symbol import VariableInterface
-    from thunder.core.symbol import variableify
-
-    def is_inplace(bsym: BoundSymbol) -> bool:
-        if (isinstance(bsym.sym.id, str) and bsym.sym.id.endswith("_")) and bsym.subsymbols:
-            return bsym.subsymbols[-1].sym.id == prims.PrimIDs.COPY_
-        else:
-            return False
-
-    if not any(is_inplace(bsym) for bsym in computation_trace.bound_symbols):
-        return computation_trace
-
-    # Step 1: return the tensors returned from `prims.copy_` as possible not the args for clarity.
-    bsym: BoundSymbol
-    swap_map: dict[VariableInterface, ProxyInterface] = {}
-    bsyms: list[BoundSymbol] = []
-    for bsym in computation_trace.bound_symbols:
-        new_bsym = bsym.from_bsym_swap_proxies(swap_map)
-
-        # in-place ops has `prims.copy_` as the last subsymbol.
-        if not is_inplace(new_bsym):
-            bsyms.append(new_bsym)
-            continue
-
-        sub_bsyms: list[BoundSymbol] = bsym.subsymbols
-        utils.check(sub_bsyms, lambda: f"{bsym.sym.id=} expected to have subsymbols but {bsym.subsymbols=}")
-        copy_bsym = sub_bsyms[-1]
-        utils.check(
-            copy_bsym.sym.id == prims.PrimIDs.COPY_,
-            lambda: f"bsym.subsymbols[-1] expected to be {prims.PrimIDs.COPY_} but {copy_bsym.sym.id=}",
-        )
-        copy_out = copy_bsym.flat_proxy_outs[0]
-        copy_dst = copy_bsym.flat_proxy_args[1]
-        swap_map[variableify(copy_dst)] = copy_out
-        # Remove `prims.copy_`
-        new_bsym = new_bsym.from_bsym_swap_proxies(swap_map, skip_inputs=True, skip_subsymbols=True)
-        bsyms.append(new_bsym)
-
-    intermediate_trace = from_trace(computation_trace)
-    intermediate_trace.bound_symbols = bsyms[:]
-    del bsyms
-
-    # Step 2: Remove `prims.copy_` if it's the last one of `bsym.subsymbols`.
-    bsym_inplace_to_functional = {}
-    swap_map.clear()
-    new_bsyms: list[BoundSymbol] = []
-    for bsym in intermediate_trace.bound_symbols:
-        new_bsym = bsym.from_bsym_swap_proxies(swap_map)
-
-        # in-place ops has `prims.copy_` as the last subsymbol.
-        if not is_inplace(new_bsym):
-            new_bsyms.append(new_bsym)
-            continue
-        functional_sym_name = new_bsym.sym.id.split(".")[-1][:-1]
-        utils.check(
-            hasattr(thunder.torch, functional_sym_name),
-            lambda: f"{functional_sym_name}, out-of-place impl of {bsym.sym.id=} not found in `thunder.torch` namespace",
-        )
-        sub_bsyms: list[BoundSymbol] = bsym.subsymbols
-        utils.check(sub_bsyms, lambda: f"{bsym.sym.id=} expected to have subsymbols but {bsym.subsymbols=}")
-        copy_bsym = sub_bsyms[-1]
-        utils.check(
-            copy_bsym.sym.id == prims.PrimIDs.COPY_,
-            lambda: f"bsym.subsymbols[-1] expected to be {prims.PrimIDs.COPY_} but {copy_bsym.sym.id=}",
-        )
-        swap_map[variableify(copy_bsym.flat_proxy_outs[0])] = copy_bsym.flat_proxy_args[0]
-        new_bsym.subsymbols = new_bsym.subsymbols[:-1]
-        new_bsym = new_bsym.from_bsym_swap_proxies(swap_map)
-        functional_sym: Symbol = getattr(thunder.torch, functional_sym_name)
-        new_functional_bsym = functional_sym.bind(
-            *new_bsym.args,
-            **new_bsym.kwargs,
-            output=new_bsym.output,
-            subsymbols=new_bsym.subsymbols,
-            _call_ctx=new_bsym._call_ctx,
-        )
-        new_bsyms.append(new_functional_bsym)
-        bsym_inplace_to_functional[new_bsym] = new_functional_bsym
-
-    functionalized_computation_trace = from_trace(computation_trace)
-    functionalized_computation_trace.bound_symbols = new_bsyms
-    functionalized_computation_trace.set_provenance(TraceProvenance("Functionalize in-place ops"))
-    # note(crcrpar): I kind of want to do the following two.
-    # functionalized_computation_trace._provenance.swap_map = swap_map
-    # functionalized_computation_trace._provenance.bsym_inplace_to_functional = bsym_inplace_to_functional
-    return functionalized_computation_trace

--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -1588,7 +1588,7 @@ def bind_inputs(name, trace, input_vars, input_proxies):
     # with tracectx(trace):
     #     p: Proxy
     #     for p in input_proxies:
-    #         prims.unpack_trivial(p)
+    #         prims.unpack_trivial(p, name=p.name)
 
     for p in input_proxies:
         bsym = prims.unpack_trivial.bind(p, output=p)

--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -1663,6 +1663,8 @@ def thunder_general_jit(
             process_recorded_modifications(ctx, epilogue_trace)
             last_interpreter_log = jfn._last_interpreter_log
 
+    computation_trace = functionalize_inplace_ops(computation_trace)
+
     pro_to_comp, computation_intermediates = get_computation_inputs_and_intermediates(computation_trace)
     epilogue_inputs, _ = get_computation_inputs_and_intermediates(epilogue_trace)
 
@@ -1724,3 +1726,61 @@ def thunder_general_jit(
         )
 
     return TraceResults(prologue_trace, computation_trace, epilogue_trace, last_interpreter_log)
+
+
+def functionalize_inplace_ops(computation_trace: TraceCtx) -> TraceCtx:
+    from thunder.core import utils
+    from thunder.core.proxies import ProxyInterface
+    from thunder.core.symbol import VariableInterface
+    from thunder.core.symbol import variableify
+
+    swap_map: dict[VariableInterface, ProxyInterface] = {}
+    bound_symbols: list[BoundSymbol] = []
+    print(computation_trace)
+
+    bsym: BoundSymbol
+    found_copy_in_subsymbols = False
+    for bsym in computation_trace.bound_symbols:
+        new_bsym = bsym.from_bsym_swap_proxies(swap_map)
+
+        # This means the symbol of bsym is in-place.
+        if not (isinstance(bsym.sym.id, str) and bsym.sym.id.endswith("_")):
+            bound_symbols.append(new_bsym)
+            continue
+
+        found_copy_in_subsymbols = True
+        sub_bsyms: list[BoundSymbol] = bsym.subsymbols
+        utils.check(sub_bsyms, lambda: f"{bsym.sym.id=} expected to have subsymbols but {bsym.subsymbols=}")
+        copy_bsym = sub_bsyms[-1]
+        utils.check(
+            copy_bsym.sym.id == prims.PrimIDs.COPY_,
+            lambda: f"bsym.subsymbols[-1] expected to be {prims.PrimIDs.COPY_} but {copy_bsym.sym.id=}",
+        )
+        functional_out = copy_bsym.flat_proxy_args[0]
+        copy_dst = copy_bsym.flat_proxy_outs[0]
+        swap_map[variableify(copy_dst)] = functional_out
+        # Remove `prims.copy_`
+        new_bsym.subsymbols = new_bsym.subsymbols[:-1]
+        new_bsym = new_bsym.from_bsym_swap_proxies(swap_map, skip_subsymbols=True)
+
+        functional_sym_name = new_bsym.sym.id.split(".")[-1][:-1]
+        utils.check(
+            hasattr(thunder.torch, functional_sym_name),
+            lambda: f"{functional_sym_name}, out-of-place impl of {bsym.sym.id=} not found in `thunder.torch` namespace",
+        )
+        functional_sym: Symbol = getattr(thunder.torch, functional_sym_name)
+        new_bsym = functional_sym.bind(
+            *new_bsym.args,
+            **new_bsym.kwargs,
+            output=new_bsym.output,
+            subsymbols=new_bsym.subsymbols,
+            _call_ctx=new_bsym._call_ctx,
+        )
+        bound_symbols.append(new_bsym)
+
+    if not found_copy_in_subsymbols:
+        return computation_trace
+
+    functionalized_computation_trace = from_trace(computation_trace)
+    functionalized_computation_trace.bound_symbols = bound_symbols
+    return functionalized_computation_trace

--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -1576,29 +1576,14 @@ def process_recorded_modifications(ctx, epilogue_trace):
 
 
 def bind_inputs(name, trace, input_vars, input_proxies):
-    from thunder.core import utils
-
     # Unpacks inputs into the computation trace
     # TODO This currently does the unpacks at the end of the trace, then moves them to the beginning, there's
     #   almost certainly a more elegant way to do this
-    num_orig_bsyms = len(trace.bound_symbols)
+    with tracectx(trace):
+        p: Proxy
+        for p in input_proxies:
+            prims.unpack_trivial(p, name=p.name)
 
-    # note(crcrpar): The path looks neat but it does not work for a trace
-    # if it's :func:`thunder.core.jit_ext.functionalize_inplace_ops`'d, :shrug:
-    # with tracectx(trace):
-    #     p: Proxy
-    #     for p in input_proxies:
-    #         prims.unpack_trivial(p, name=p.name)
-
-    for p in input_proxies:
-        bsym = prims.unpack_trivial.bind(p, output=p)
-        trace.add_bound_symbol(bsym)
-
-    num_bsyms = len(trace.bound_symbols)
-    utils.check(
-        num_bsyms == len(input_proxies) + num_orig_bsyms,
-        lambda: f"{num_bsyms=} expected to be {len(input_proxies)=} + {num_orig_bsyms}",
-    )
     bsyms = trace.bound_symbols
     trace.bound_symbols = bsyms[-len(input_proxies) :] + bsyms[: -len(input_proxies)]
 

--- a/thunder/core/langctxs.py
+++ b/thunder/core/langctxs.py
@@ -72,7 +72,7 @@ def resolve_method(id: Any, *args, **kwargs) -> None | Callable:
         # ctx.get_method throws an AttributeError when the context does not have the requested attribute, except
         # for the prims language context, which always throws a ValueError
         method: Callable = ctx.get_method(id, *args, **kwargs)
-    except (AttributeError, ValueError) as e:
+    except (AttributeError, ValueError):
         return None
     return method
 

--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -275,6 +275,7 @@ class OpTags(Enum):
     DEVICE_SYNC_OP = auto()
     # Labels operations that should not be removed by the dead code elimination (DCE) pass
     DONT_DCE = auto()
+    IN_PLACE = auto()
 
 
 # TODO RC1 Document this function and describe the parts of a primitive

--- a/thunder/core/proxies.py
+++ b/thunder/core/proxies.py
@@ -1391,6 +1391,13 @@ class TensorProxy(Proxy, TensorProxyInterface):
         method = resolve_method("add", self, other)
         return method(self, other)
 
+    def __iadd__(self, other):
+        return self.add_(other)
+
+    def add_(self, other):
+        method = resolve_method("add_", self, other)
+        return method(self, other)
+
     def __radd__(self, other):
         method = resolve_method("add", other, self)
         return method(other, self)
@@ -1427,6 +1434,13 @@ class TensorProxy(Proxy, TensorProxyInterface):
         method = resolve_method("mul", self, other)
         return method(self, other)
 
+    def __imul__(self, other):
+        return self.mul_(other)
+
+    def mul_(self, other):
+        method = resolve_method("mul_", self, other)
+        return method(self, other)
+
     def __rmul__(self, other):
         method = resolve_method("mul", other, self)
         return method(other, self)
@@ -1435,12 +1449,26 @@ class TensorProxy(Proxy, TensorProxyInterface):
         method = resolve_method("pow", self, other)
         return method(self, other)
 
+    def __ipow__(self, other):
+        return self.pow_(other)
+
+    def pow_(self, other):
+        method = resolve_method("pow_", self, other)
+        return method(self, other)
+
     def __rpow__(self, other):
         method = resolve_method("pow", other, self)
         return method(other, self)
 
     def __sub__(self, other):
         method = resolve_method("sub", self, other)
+        return method(self, other)
+
+    def __isub__(self, other):
+        return self.sub_(other)
+
+    def sub_(self, other):
+        method = resolve_method("sub_", self, other)
         return method(self, other)
 
     def __rsub__(self, other):
@@ -1454,6 +1482,13 @@ class TensorProxy(Proxy, TensorProxyInterface):
     def __rtruediv__(self, other):
         method = resolve_method("true_divide", other, self)
         return method(other, self)
+
+    def __itruediv__(self, other):
+        return self.div_(other)
+
+    def div_(self, other):
+        method = resolve_method("div_", self, other)
+        return method(self, other)
 
     #
     # Logical operations

--- a/thunder/core/proxies.py
+++ b/thunder/core/proxies.py
@@ -1426,10 +1426,6 @@ class TensorProxy(Proxy, TensorProxyInterface):
         method = resolve_method("mod", self, other)
         return method(self, other)
 
-    # def __imod__(self, other):
-    #     method = resolve_method("mod_", self, other)
-    #     return method(self, other)
-
     def __rmod__(self, other):
         method = resolve_method("mod", other, self)
         return method(other, self)

--- a/thunder/core/proxies.py
+++ b/thunder/core/proxies.py
@@ -1426,6 +1426,10 @@ class TensorProxy(Proxy, TensorProxyInterface):
         method = resolve_method("mod", self, other)
         return method(self, other)
 
+    # def __imod__(self, other):
+    #     method = resolve_method("mod_", self, other)
+    #     return method(self, other)
+
     def __rmod__(self, other):
         method = resolve_method("mod", other, self)
         return method(other, self)
@@ -1486,8 +1490,8 @@ class TensorProxy(Proxy, TensorProxyInterface):
     def __itruediv__(self, other):
         return self.div_(other)
 
-    def div_(self, other):
-        method = resolve_method("div_", self, other)
+    def div_(self, other, *, rounding_mode: str | None = None):
+        method = resolve_method("div_", self, other, rounding_mode=rounding_mode)
         return method(self, other)
 
     #

--- a/thunder/core/transform_common.py
+++ b/thunder/core/transform_common.py
@@ -380,10 +380,12 @@ def functionalize_inplace_ops(computation_trace: Trace) -> list[Trace]:
     import thunder.torch
 
     def is_inplace(bsym: BoundSymbol) -> bool:
-        if (isinstance(bsym.sym.id, str) and bsym.sym.id.endswith("_")) and bsym.subsymbols:
-            return bsym.subsymbols[-1].sym.id == prims.PrimIDs.COPY_
-        else:
-            return False
+        return (
+            bsym.sym.tags
+            and prims.OpTags.IN_PLACE in bsym.sym.tags
+            and bsym.subsymbols
+            and bsym.subsymbols[-1].sym.id == prims.PrimIDs.COPY_
+        )
 
     if not any(is_inplace(bsym) for bsym in computation_trace.bound_symbols):
         return []

--- a/thunder/core/transform_common.py
+++ b/thunder/core/transform_common.py
@@ -406,7 +406,7 @@ def functionalize_inplace_ops(computation_trace: Trace) -> list[Trace]:
         copy_out = copy_bsym.flat_proxy_outs[0]
         copy_dst = copy_bsym.flat_proxy_args[1]
         swap_map[variableify(copy_dst)] = copy_out
-        # Remove `prims.copy_`
+        # make sure an in-place bsym returns `prims.copy_` output
         new_bsym = new_bsym.from_bsym_swap_proxies(swap_map, skip_inputs=True, skip_subsymbols=True)
         bsyms.append(new_bsym)
 
@@ -428,7 +428,6 @@ def functionalize_inplace_ops(computation_trace: Trace) -> list[Trace]:
     for bsym in intermediate_trace.bound_symbols:
         new_bsym = bsym.from_bsym_swap_proxies(swap_map)
 
-        # in-place ops has `prims.copy_` as the last subsymbol.
         if not is_inplace(new_bsym):
             new_bsyms.append(new_bsym)
             continue

--- a/thunder/core/transform_common.py
+++ b/thunder/core/transform_common.py
@@ -373,9 +373,15 @@ class PostOptimizationTransform(Transform, ABC):
 def functionalize_inplace_ops(computation_trace: Trace) -> list[Trace]:
     """Functionalize in-place ops in ``computation_trace``.
 
-    This is a two-step function. The first step is to use the output of :func:`thunder.core.prims.copy_`'s
-    outputs as trace's outputs. The second step is to remove :func:`thunder.core.prims.copy_`
-    from :attr:`~thunder.core.symbol.Boundsymbol.subsymbols` if it's the last symbol.
+    In thunder, an in-place is an out-of-place or functional op followed by :func:`~thunder.core.prims.copy_`.
+    This function replaces such in-place ops with out-of-place ops.
+
+    For example, :func:`thunder.torch.add_` is represented as a :class:`thunder.core.symbol.BoundSymbol`
+    whose `subsymbols` are :func:`thunder.torch.add` and :func:`thunder.core.prims.copy_`. This function
+    replaces it with a :class:`~thunder.core.symbol.BoundSymbol` of :func:`~thunder.torch.add`.
+
+    Note that functionalization is not applied, if any of an in-place op's arguments are
+    ``computation_trace.args`` or ``computation_trace.kwargs``.
     """
     import thunder.torch
 

--- a/thunder/core/transform_common.py
+++ b/thunder/core/transform_common.py
@@ -402,13 +402,7 @@ def functionalize_inplace_ops(computation_trace: Trace) -> list[Trace]:
             bsyms.append(new_bsym)
             continue
 
-        sub_bsyms: list[BoundSymbol] = bsym.subsymbols
-        check(sub_bsyms, lambda: f"{bsym.sym.id=} expected to have subsymbols but {bsym.subsymbols=}")
-        copy_bsym = sub_bsyms[-1]
-        check(
-            copy_bsym.sym.id == prims.PrimIDs.COPY_,
-            lambda: f"bsym.subsymbols[-1] expected to be {prims.PrimIDs.COPY_} but {copy_bsym.sym.id=}",
-        )
+        copy_bsym = bsym.subsymbols[-1]
         copy_out = copy_bsym.flat_proxy_outs[0]
         copy_dst = copy_bsym.flat_proxy_args[1]
         swap_map[variableify(copy_dst)] = copy_out

--- a/thunder/core/transform_common.py
+++ b/thunder/core/transform_common.py
@@ -403,7 +403,7 @@ def functionalize_inplace_ops(computation_trace: Trace) -> list[Trace]:
     for bsym in computation_trace.bound_symbols:
         new_bsym = bsym.from_bsym_swap_proxies(swap_map)
 
-        # in-place ops has `prims.copy_` as the last subsymbol.
+        # in-place functionalizable ops has `prims.copy_` as the last subsymbol.
         if not is_functionalizable(new_bsym):
             bsyms.append(new_bsym)
             continue

--- a/thunder/core/transform_common.py
+++ b/thunder/core/transform_common.py
@@ -363,3 +363,104 @@ class PostOptimizationTransform(Transform, ABC):
     @abstractmethod
     def transform_trace(self, computation_trace: Trace, **kwargs):
         pass
+
+
+def functionalize_inplace_ops(computation_trace: Trace, computation_traces: list[Trace]) -> Trace:
+    """Functionalize in-place ops in ``computation_trace``.
+
+    This is a two-step function. The first step is to use the output of :func:`thunder.core.prims.copy_`'s
+    outputs as trace's outputs. The second step is to remove :func:`thunder.core.prims.copy_`
+    from :attr:`~thunder.core.symbol.Boundsymbol.subsymbols` if it's the last symbol.
+    """
+    from thunder.core import utils
+    from thunder.core.proxies import ProxyInterface
+    from thunder.core.symbol import VariableInterface
+    from thunder.core.symbol import variableify
+    import thunder.torch
+
+    def is_inplace(bsym: BoundSymbol) -> bool:
+        if (isinstance(bsym.sym.id, str) and bsym.sym.id.endswith("_")) and bsym.subsymbols:
+            return bsym.subsymbols[-1].sym.id == prims.PrimIDs.COPY_
+        else:
+            return False
+
+    if not any(is_inplace(bsym) for bsym in computation_trace.bound_symbols):
+        return computation_trace
+
+    # Step 1: return the tensors returned from `prims.copy_` as possible not the args for clarity.
+    bsym: BoundSymbol
+    swap_map: dict[VariableInterface, ProxyInterface] = {}
+    bsyms: list[BoundSymbol] = []
+    for bsym in computation_trace.bound_symbols:
+        new_bsym = bsym.from_bsym_swap_proxies(swap_map)
+
+        # in-place ops has `prims.copy_` as the last subsymbol.
+        if not is_inplace(new_bsym):
+            bsyms.append(new_bsym)
+            continue
+
+        sub_bsyms: list[BoundSymbol] = bsym.subsymbols
+        utils.check(sub_bsyms, lambda: f"{bsym.sym.id=} expected to have subsymbols but {bsym.subsymbols=}")
+        copy_bsym = sub_bsyms[-1]
+        utils.check(
+            copy_bsym.sym.id == prims.PrimIDs.COPY_,
+            lambda: f"bsym.subsymbols[-1] expected to be {prims.PrimIDs.COPY_} but {copy_bsym.sym.id=}",
+        )
+        copy_out = copy_bsym.flat_proxy_outs[0]
+        copy_dst = copy_bsym.flat_proxy_args[1]
+        swap_map[variableify(copy_dst)] = copy_out
+        # Remove `prims.copy_`
+        new_bsym = new_bsym.from_bsym_swap_proxies(swap_map, skip_inputs=True, skip_subsymbols=True)
+        bsyms.append(new_bsym)
+
+    intermediate_trace = from_trace(computation_trace)
+    intermediate_trace.bound_symbols = bsyms[:]
+    intermediate_trace.set_provenance(TraceProvenance("Intermediate trace of `functionalize_inplace_ops`"))
+    del bsyms
+
+    # Step 2: Remove `prims.copy_` if it's the last one of `bsym.subsymbols`.
+    bsym_inplace_to_functional = {}
+    swap_map.clear()
+    new_bsyms: list[BoundSymbol] = []
+    for bsym in intermediate_trace.bound_symbols:
+        new_bsym = bsym.from_bsym_swap_proxies(swap_map)
+
+        # in-place ops has `prims.copy_` as the last subsymbol.
+        if not is_inplace(new_bsym):
+            new_bsyms.append(new_bsym)
+            continue
+        functional_sym_name = new_bsym.sym.id.split(".")[-1][:-1]
+        utils.check(
+            hasattr(thunder.torch, functional_sym_name),
+            lambda: f"{functional_sym_name}, out-of-place impl of {bsym.sym.id=} not found in `thunder.torch` namespace",
+        )
+        sub_bsyms: list[BoundSymbol] = bsym.subsymbols
+        utils.check(sub_bsyms, lambda: f"{bsym.sym.id=} expected to have subsymbols but {bsym.subsymbols=}")
+        copy_bsym = sub_bsyms[-1]
+        utils.check(
+            copy_bsym.sym.id == prims.PrimIDs.COPY_,
+            lambda: f"bsym.subsymbols[-1] expected to be {prims.PrimIDs.COPY_} but {copy_bsym.sym.id=}",
+        )
+        swap_map[variableify(copy_bsym.flat_proxy_outs[0])] = copy_bsym.flat_proxy_args[0]
+        new_bsym.subsymbols = new_bsym.subsymbols[:-1]
+        new_bsym = new_bsym.from_bsym_swap_proxies(swap_map)
+        functional_sym: Symbol = getattr(thunder.torch, functional_sym_name)
+        new_functional_bsym = functional_sym.bind(
+            *new_bsym.args,
+            **new_bsym.kwargs,
+            output=new_bsym.output,
+            subsymbols=new_bsym.subsymbols,
+            _call_ctx=new_bsym._call_ctx,
+        )
+        new_bsyms.append(new_functional_bsym)
+        bsym_inplace_to_functional[new_bsym] = new_functional_bsym
+
+    functionalized_computation_trace = from_trace(computation_trace)
+    functionalized_computation_trace.bound_symbols = new_bsyms
+    functionalized_computation_trace.set_provenance(TraceProvenance("Functionalize in-place ops"))
+    # note(crcrpar): I kind of want to do the following two.
+    # functionalized_computation_trace._provenance.swap_map = swap_map
+    # functionalized_computation_trace._provenance.bsym_inplace_to_functional = bsym_inplace_to_functional
+    computation_traces.append(intermediate_trace)
+    computation_traces.append(functionalized_computation_trace)
+    return functionalized_computation_trace

--- a/thunder/core/transform_common.py
+++ b/thunder/core/transform_common.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
 import time
-from typing import Any
+from typing import TYPE_CHECKING
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from itertools import filterfalse
@@ -12,6 +13,9 @@ from thunder.core.pytree import tree_flatten, tree_map
 from thunder.core.symbol import BoundSymbol, BoundSymbolRHS, has_tags
 from thunder.core.trace import from_trace, TraceProvenance, TraceCtx as Trace
 from thunder.core.utils import ProxyDict, producers, check
+
+if TYPE_CHECKING:
+    from thunder.core.symbol import Symbol
 
 
 #
@@ -375,7 +379,6 @@ def functionalize_inplace_ops(computation_trace: Trace, computation_traces: list
     from thunder.core import utils
     from thunder.core.proxies import ProxyInterface
     from thunder.core.symbol import VariableInterface
-    from thunder.core.symbol import variableify
     import thunder.torch
 
     def is_inplace(bsym: BoundSymbol) -> bool:

--- a/thunder/core/transform_common.py
+++ b/thunder/core/transform_common.py
@@ -369,7 +369,7 @@ class PostOptimizationTransform(Transform, ABC):
         pass
 
 
-def functionalize_inplace_ops(computation_trace: Trace, computation_traces: list[Trace]) -> Trace:
+def functionalize_inplace_ops(computation_trace: Trace) -> list[Trace]:
     """Functionalize in-place ops in ``computation_trace``.
 
     This is a two-step function. The first step is to use the output of :func:`thunder.core.prims.copy_`'s
@@ -388,7 +388,7 @@ def functionalize_inplace_ops(computation_trace: Trace, computation_traces: list
             return False
 
     if not any(is_inplace(bsym) for bsym in computation_trace.bound_symbols):
-        return computation_trace
+        return []
 
     # Step 1: return the tensors returned from `prims.copy_` as possible not the args for clarity.
     bsym: BoundSymbol
@@ -464,6 +464,4 @@ def functionalize_inplace_ops(computation_trace: Trace, computation_traces: list
     # note(crcrpar): I kind of want to do the following two.
     # functionalized_computation_trace._provenance.swap_map = swap_map
     # functionalized_computation_trace._provenance.bsym_inplace_to_functional = bsym_inplace_to_functional
-    computation_traces.append(intermediate_trace)
-    computation_traces.append(functionalized_computation_trace)
-    return functionalized_computation_trace
+    return [intermediate_trace, functionalized_computation_trace]

--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -1278,16 +1278,10 @@ signbit_opinfo = OpInfo(
 elementwise_unary_ops.append(signbit_opinfo)
 
 
-def silu_error_generator(op, device, dtype=torch.float32, **kwargs):
-    a = make_tensor((), dtype=dtype, device=device)
-    yield (SampleInput(a, inplace=True), NotImplementedError, "Thunder only supports silu with inplace=False")
-
-
 silu_opinfo = OpInfo(
     ltorch.silu,
     dtypes=(datatypes.floating,),
     sample_input_generator=partial(elementwise_unary_generator, supports_numbers=False),
-    error_input_generator=silu_error_generator,
     torch_reference=_elementwise_unary_torch(torch.nn.functional.silu),
     test_directives=(
         DecorateInfo(
@@ -1623,20 +1617,9 @@ reciprocal_opinfo = OpInfo(
 elementwise_unary_ops.append(reciprocal_opinfo)
 
 
-def relu_error_generator(op, device, dtype=torch.float32, **kwargs):
-    a = make_tensor((), dtype=dtype, device=device)
-    yield (SampleInput(a, inplace=True), NotImplementedError, "relu only supports inplace=False")
-
-
-def relu6_error_generator(op, device, dtype=torch.float32, **kwargs):
-    a = make_tensor((), dtype=dtype, device=device)
-    yield (SampleInput(a, inplace=True), NotImplementedError, "relu6 only supports inplace=False")
-
-
 relu_opinfo = OpInfo(
     ltorch.relu,
     sample_input_generator=elementwise_unary_generator,
-    error_input_generator=relu_error_generator,
     torch_reference=_elementwise_unary_torch(torch.relu),
     test_directives=(
         # PyTorch does not support bool and complex types
@@ -1665,7 +1648,6 @@ elementwise_unary_ops.append(relu_opinfo)
 relu6_opinfo = OpInfo(
     ltorch.relu6,
     sample_input_generator=elementwise_unary_generator,
-    error_input_generator=relu6_error_generator,
     torch_reference=_elementwise_unary_torch(torch.nn.functional.relu6),
     test_directives=(
         # PyTorch does not support bool for both CPU and CUDA relu6
@@ -1684,15 +1666,9 @@ relu6_opinfo = OpInfo(
 elementwise_unary_ops.append(relu6_opinfo)
 
 
-def hardswish_error_generator(op, device, dtype=torch.float32, **kwargs):
-    a = make_tensor((), dtype=dtype, device=device)
-    yield (SampleInput(a, inplace=True), NotImplementedError, "hardswish only supports inplace=False")
-
-
 hardswish_opinfo = OpInfo(
     ltorch.hardswish,
     sample_input_generator=elementwise_unary_generator,
-    error_input_generator=hardswish_error_generator,
     torch_reference=_elementwise_unary_torch(torch.nn.functional.hardswish),
     dtypes=(datatypes.floating,),
     test_directives=(
@@ -1713,16 +1689,10 @@ hardswish_opinfo = OpInfo(
 elementwise_unary_ops.append(hardswish_opinfo)
 
 
-def selu_error_generator(op, device, dtype=torch.float32, **kwargs):
-    a = make_tensor((), dtype=dtype, device=device)
-    yield (SampleInput(a, inplace=True), NotImplementedError, "selu only supports inplace=False")
-
-
 selu_opinfo = OpInfo(
     ltorch.selu,
     dtypes=(datatypes.floating,),
     sample_input_generator=elementwise_unary_generator,
-    error_input_generator=selu_error_generator,
     torch_reference=_elementwise_unary_torch(torch.selu),
     test_directives=(
         # Some versions of PyTorch do not support CPU float16 selu

--- a/thunder/tests/test_core.py
+++ b/thunder/tests/test_core.py
@@ -2121,7 +2121,8 @@ def test_inplace(executor, device, _):
 
     for t in tests:
         cfn = thunder.jit(t)
-        with pytest.raises(RuntimeError, match="not supported"):
+        # Some ops of `tests` already have in-place supported, leading to broadcast error
+        with pytest.raises(RuntimeError, match="not supported|Attempting"):
             cfn(t1, t2)
         # Note: Python maps inplace operations on (immutuables) to
         #       out of place operations, NumberProxy does this, too.

--- a/thunder/tests/test_inplace_copy.py
+++ b/thunder/tests/test_inplace_copy.py
@@ -89,8 +89,6 @@ def test_batch_norm_running_stats(executor, device, dtype):
         def __init__(self):
             super().__init__()
             self.dense1_bn = nn.BatchNorm3d(2, track_running_stats=True)
-            # To address the failure, use a workaround since `add_` is utilized in `nn.BatchNorm3d` when `num_batches_tracked` is not None.
-            self.dense1_bn.num_batches_tracked = None
 
         def forward(self, x):
             x = self.dense1_bn(x)
@@ -112,6 +110,9 @@ def test_batch_norm_running_stats(executor, device, dtype):
     assert_close(thunder_out, torch_out)
     assert_close(net.state_dict()["dense1_bn.running_mean"], torch_net.state_dict()["dense1_bn.running_mean"])
     assert_close(net.state_dict()["dense1_bn.running_var"], torch_net.state_dict()["dense1_bn.running_var"])
+    assert_close(
+        net.state_dict()["dense1_bn.num_batches_tracked"], torch_net.state_dict()["dense1_bn.num_batches_tracked"]
+    )
     assert_close(x.grad, x1.grad)
 
 

--- a/thunder/tests/test_inplace_functionalization.py
+++ b/thunder/tests/test_inplace_functionalization.py
@@ -13,6 +13,7 @@ from thunder.tests.make_tensor import make_tensor
 from thunder.torch import _torch_to_thunder_function_map, _inplace_to_out_of_place
 
 
+# `SampleInput`s of ops with `inplace` argument do not seem to come with `inplace` arg, so give it to them.
 def sample_generator_wrapper(sample_generator, is_silu: bool = False):
 
     def f(*args, **kwargs):

--- a/thunder/tests/test_inplace_functionalization.py
+++ b/thunder/tests/test_inplace_functionalization.py
@@ -86,7 +86,8 @@ class InplaceOpWrapper:
         t = args[idx] + 1.0
         args[idx] = t
 
-        return self.torch_func(*args, **kwargs)
+        self.torch_func(*args, **kwargs)
+        return t
 
 
 @ops(_inplace_opinfos, supported_dtypes=(dtypes.float32,))

--- a/thunder/tests/test_inplace_functionalization.py
+++ b/thunder/tests/test_inplace_functionalization.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from functools import partial
+from collections.abc import Callable
+
+import torch.testing
+
+from thunder.core import dtypes
+from thunder.core.prims import PrimIDs
+from thunder.tests.framework import ops
+from thunder.tests.opinfos import opinfos, OpInfo, make_number, SampleInput
+from thunder.tests.make_tensor import make_tensor
+from thunder.torch import _torch_to_thunder_function_map, _inplace_to_out_of_place
+
+
+def inplace_masked_fill_sample_generator(op, device, dtype, requires_grad, **kwargs):
+    make = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)
+    number = partial(make_number, dtype=dtype)
+
+    # pred_shape, a_shape, value
+    cases = (((2, 2, 2), (2, 2, 2), number()),)
+
+    for pred_shape, a_shape, value in cases:
+        pred, a = make(pred_shape, dtype=torch.bool, requires_grad=False), make(a_shape)
+        yield SampleInput(a, pred, value)
+
+
+_torchsymbol_to_torch: dict[Sybmol, Callable] = {v: k for k, v in _torch_to_thunder_function_map.items()}
+_functional_to_inplace: dict[Callable, Callable] = {
+    functional: inplace for inplace, (functional, index) in _inplace_to_out_of_place.items() if index == -1
+}
+_inplace_opinfos: list[OpInfo] = []
+for op in filter(lambda op: op.op in _functional_to_inplace, opinfos):
+    if op.op not in _functional_to_inplace:
+        continue
+    if (inplace_op := _functional_to_inplace.get(op.op, None)) is None:
+        continue
+    else:
+        inplace_opinfo = OpInfo(
+            inplace_op,
+            sample_input_generator=(
+                op.sample_input_generator if op.name != "masked_fill" else inplace_masked_fill_sample_generator
+            ),
+            torch_reference=_torchsymbol_to_torch[inplace_op],
+        )
+        _inplace_opinfos.append(inplace_opinfo)
+
+
+@dataclass(frozen=True)
+class InplaceOpWrapper:
+    torch_func: Callable
+    is_polygamma: bool
+    jitted: bool
+
+    def __call__(self, *args, **kwargs):
+        args = list(args)
+        idx = int(self.is_polygamma and self.jitted)
+        t = args[idx] + 1.0
+        args[idx] = t
+
+        return self.torch_func(*args, **kwargs)
+
+
+@ops(_inplace_opinfos, supported_dtypes=(dtypes.float32,))
+def test_functionalization(op: OpInfo, device: str, dtype: dtypes.dtype, executor, _):
+    import thunder
+
+    is_polygamma = op.name == "polygamma_"
+    inplace_op = InplaceOpWrapper(op.torch_reference, is_polygamma, False)
+    jitted_inplace_op = thunder.jit(
+        InplaceOpWrapper(op.torch_reference, is_polygamma, True),
+        executors=executor.executors_list(),
+    )
+    sample: SampleInput
+    for idx, sample in enumerate(op.sample_inputs(device, dtype)):
+        if idx > 0:
+            break
+
+        args = list(sample.args)
+        if is_polygamma:
+            tmp = args[0]
+            args[0] = args[1]
+            args[1] = tmp
+        expected = inplace_op(*args, **sample.kwargs)
+        actual = jitted_inplace_op(*sample.args, **sample.kwargs)
+        torch.testing.assert_close(actual, expected, equal_nan=True)
+
+    # make sure `prims.copy_` does not exist in the trace thanks to functionalization
+    fw_extrace = thunder.last_traces(jitted_inplace_op)[-1]
+    assert not list(
+        filter(
+            lambda bsym: bsym.sym.id == PrimIDs.COPY_,
+            fw_extrace.bound_symbols,
+        )
+    )

--- a/thunder/tests/test_inplace_functionalization.py
+++ b/thunder/tests/test_inplace_functionalization.py
@@ -63,6 +63,7 @@ for op in opinfos:
             torch_reference=getattr(torch.nn.functional, op.name),
         )
         _inplace_opinfos.append(inplace_opinfo)
+    # in-place ops whose name ends with `_`
     if op.op in _functional_to_inplace:
         inplace_op = _functional_to_inplace[op.op]
         inplace_opinfo = OpInfo(

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -1652,6 +1652,18 @@ def relu(a: TensorLike, /, inplace: bool = False) -> TensorLike:
 _inplace_to_out_of_place[relu] = relu, 1
 
 
+@torchsymbol(torch.relu_, torch.nn.functional.relu_, id="torch.relu_", is_method=True)
+def relu_(
+    a: TensorLike,
+    /,
+) -> TensorLike:
+    return prims.copy_(relu(a, False), a)
+
+
+# The default value of `inplace` is False, so no need to tweak args/kwargs
+_inplace_to_out_of_place[relu_] = relu, -1
+
+
 # id=torch.relu because we ignore inplace argument in torch.nn.functional.relu
 @torchsymbol(torch.nn.functional.relu6, id="torch.relu6", is_method=False)
 def relu6(a: TensorProxy, /, inplace: bool = False) -> TensorLike:

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -1709,9 +1709,6 @@ _inplace_to_out_of_place[selu] = selu, 1
 
 @torchsymbol(torch.nn.functional.silu)
 def silu(a: TensorLike, /, inplace: bool = False) -> TensorLike:
-    utils.check(
-        not inplace, lambda: "Thunder only supports silu with inplace=False", exception_type=NotImplementedError
-    )
     out = clang.silu(a)
     if inplace:
         return prims.copy_(out, a)

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -41,8 +41,6 @@ from thunder.core.transforms import register_grad
 from thunder.core.prims import get_grad, put_grad
 from thunder.core.baseutils import run_once
 
-if TYPE_CHECKING:
-    from thunder.core.symbol import BoundSymbol
 
 __all__ = [
     "is_available",

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -1655,7 +1655,7 @@ def relu_(
     a: TensorLike,
     /,
 ) -> TensorLike:
-    return relu(a, True)
+    return prims.copy_(relu(a, False), a)
 
 
 # The default value of `inplace` is False, so no need to tweak args/kwargs

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -1516,6 +1516,17 @@ def add(
     return clang.add(a, b)
 
 
+@torchsymbol(torch.Tensor.add_, is_method=True)
+def add_(
+    a: TensorLike,
+    b: NumberLike | TensorLike,
+    /,
+    *,
+    alpha: None | Number | TensorLike = None,
+) -> TensorLike:
+    return prims.copy_(add(a, b, alpha=alpha), a)
+
+
 @torchsymbol(torch.atan2, is_method=True)
 def atan2(a, b, /):
     return clang.atan2(a, b)
@@ -1561,6 +1572,22 @@ def div(
         return floor_divide(a, b)
     else:
         raise ValueError(f"div does not support the rounding_mode={rounding_mode} argument")
+
+
+@torchsymbol(torch.Tensor.div_, is_method=True)
+def div_(
+    a: TensorLike,
+    b: Number | TensorLike,
+    /,
+    *,
+    rounding_mode: None | str = None,
+) -> TensorLike:
+    utils.check(
+        rounding_mode is None,
+        lambda: f"Invalid {rounding_mode=}, `None` i.e. true is only supported",
+    )
+
+    return prims.copy_(div(a, b), a)
 
 
 @torchsymbol(torch.eq, is_method=True)
@@ -1630,6 +1657,11 @@ def mul(a, b, /):
     return clang.mul(a, b)
 
 
+@torchsymbol(torch.Tensor.mul_, is_method=True)
+def mul_(a, b, /):
+    return prims.copy_(mul(a, b), a)
+
+
 @torchsymbol(torch.ne, is_method=True)
 def ne(a, b, /):
     return clang.ne(a, b)
@@ -1663,6 +1695,11 @@ def pow(a, b, /):
     return clang.pow(a, b)
 
 
+@torchsymbol(torch.Tensor.pow_, is_method=True)
+def pow_(a, b, /):
+    return prims.copy_(pow(a, b), a)
+
+
 @torchsymbol(torch.remainder, is_method=True)
 def remainder(a, b, /):
     return clang.remainder(a, b)
@@ -1674,6 +1711,11 @@ def sub(a, b, /, *, alpha=None):
         b = b * alpha
 
     return clang.sub(a, b)
+
+
+@torchsymbol(torch.Tensor.sub_, is_method=True)
+def sub_(a, b, /, *, alpha=None):
+    return prims.copy_(sub(a, b, alpha=alpha), a)
 
 
 @torchsymbol(torch.true_divide, is_method=True)

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -1655,7 +1655,7 @@ def relu_(
     a: TensorLike,
     /,
 ) -> TensorLike:
-    return prims.copy_(relu(a, False), a)
+    return relu(a, True)
 
 
 # The default value of `inplace` is False, so no need to tweak args/kwargs

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -71,6 +71,7 @@ _torch_to_thunder_function_map: dict[Callable, Callable] = {}
 #
 # torch operation definitions
 #
+_inplace_to_out_of_place: dict[Callable, Callable] = {}
 
 
 # A wrapper that executes the operations within the torch language context
@@ -147,6 +148,12 @@ class torchsymbol:
         if self.torchfns is not None:
             for torchfn in self.torchfns:
                 _torch_to_thunder_function_map[torchfn] = sym
+
+        if self.tags and prims.OpTags.IN_PLACE in self.tags:
+            _inplace_to_out_of_place[sym] = globals()[name[:-1]]
+
+        if "relu" in id:
+            print(f"### {sym = }")
 
         return sym
 
@@ -1241,7 +1248,7 @@ def abs(a: NumberLike | TensorLike, /) -> Number | TensorLike:
     return clang.abs(a)
 
 
-@torchsymbol(torch.Tensor.abs_, is_method=True)
+@torchsymbol(torch.Tensor.abs_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def abs_(a: NumberLike | TensorLike, /) -> Number | TensorLike:
     return prims.copy_(abs(a), a)
 
@@ -1251,7 +1258,7 @@ def acos(a: NumberLike | TensorLike, /) -> Number | TensorLike:
     return clang.acos(a)
 
 
-@torchsymbol(torch.Tensor.acos_, is_method=True)
+@torchsymbol(torch.Tensor.acos_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def acos_(a: TensorLike, /) -> TensorLike:
     return prims.copy_(acos(a), a)
 
@@ -1261,7 +1268,7 @@ def acosh(a):
     return clang.acosh(a)
 
 
-@torchsymbol(torch.Tensor.acosh_, is_method=True)
+@torchsymbol(torch.Tensor.acosh_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def acosh_(a):
     return prims.copy_(acosh(a), a)
 
@@ -1271,7 +1278,7 @@ def asin(a):
     return clang.asin(a)
 
 
-@torchsymbol(torch.Tensor.asin_, is_method=True)
+@torchsymbol(torch.Tensor.asin_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def asin_(a):
     return prims.copy_(asin(a), a)
 
@@ -1281,7 +1288,7 @@ def asinh(a):
     return clang.asinh(a)
 
 
-@torchsymbol(torch.Tensor.asinh_, is_method=True)
+@torchsymbol(torch.Tensor.asinh_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def asinh_(a):
     return prims.copy_(asinh(a), a)
 
@@ -1291,7 +1298,7 @@ def atan(a):
     return clang.atan(a)
 
 
-@torchsymbol(torch.Tensor.atan_, is_method=True)
+@torchsymbol(torch.Tensor.atan_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def atan_(a):
     return prims.copy_(atan(a), a)
 
@@ -1301,7 +1308,7 @@ def atanh(a):
     return clang.atanh(a)
 
 
-@torchsymbol(torch.Tensor.atanh_, is_method=True)
+@torchsymbol(torch.Tensor.atanh_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def atanh_(a):
     return prims.copy_(atanh(a), a)
 
@@ -1311,7 +1318,7 @@ def bitwise_not(a):
     return clang.bitwise_not(a)
 
 
-@torchsymbol(torch.Tensor.bitwise_not_, is_method=True)
+@torchsymbol(torch.Tensor.bitwise_not_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def bitwise_not_(a):
     return prims.copy_(bitwise_not(a), a)
 
@@ -1321,7 +1328,7 @@ def ceil(a):
     return clang.ceil(a)
 
 
-@torchsymbol(torch.Tensor.ceil_, is_method=True)
+@torchsymbol(torch.Tensor.ceil_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def ceil_(a):
     return prims.copy_(ceil(a), a)
 
@@ -1331,7 +1338,7 @@ def cos(a):
     return clang.cos(a)
 
 
-@torchsymbol(torch.Tensor.cos_, is_method=True)
+@torchsymbol(torch.Tensor.cos_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def cos_(a):
     return prims.copy_(cos(a), a)
 
@@ -1341,7 +1348,7 @@ def cosh(a):
     return clang.cosh(a)
 
 
-@torchsymbol(torch.Tensor.cosh_, is_method=True)
+@torchsymbol(torch.Tensor.cosh_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def cosh_(a):
     return prims.copy_(cosh(a), a)
 
@@ -1351,7 +1358,7 @@ def digamma(a):
     return clang.digamma(a)
 
 
-@torchsymbol(torch.Tensor.digamma_, is_method=True)
+@torchsymbol(torch.Tensor.digamma_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def digamma_(a):
     return prims.copy_(digamma(a), a)
 
@@ -1361,7 +1368,7 @@ def erf(a):
     return clang.erf(a)
 
 
-@torchsymbol(torch.Tensor.erf_, is_method=True)
+@torchsymbol(torch.Tensor.erf_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def erf_(a):
     return prims.copy_(erf(a), a)
 
@@ -1371,7 +1378,7 @@ def erfc(a):
     return clang.erfc(a)
 
 
-@torchsymbol(torch.Tensor.erfc_, is_method=True)
+@torchsymbol(torch.Tensor.erfc_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def erfc_(a):
     return prims.copy_(erfc(a), a)
 
@@ -1381,7 +1388,7 @@ def erfinv(a):
     return clang.erfinv(a)
 
 
-@torchsymbol(torch.Tensor.erfinv_, is_method=True)
+@torchsymbol(torch.Tensor.erfinv_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def erfinv_(a):
     return prims.copy_(erfinv(a), a)
 
@@ -1391,7 +1398,7 @@ def exp(a):
     return clang.exp(a)
 
 
-@torchsymbol(torch.Tensor.exp_, is_method=True)
+@torchsymbol(torch.Tensor.exp_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def exp_(a):
     return prims.copy_(exp(a), a)
 
@@ -1401,7 +1408,7 @@ def exp2(a):
     return clang.exp2(a)
 
 
-@torchsymbol(torch.Tensor.exp2_, is_method=True)
+@torchsymbol(torch.Tensor.exp2_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def exp2_(a):
     return prims.copy_(exp2(a), a)
 
@@ -1411,7 +1418,7 @@ def expm1(a):
     return clang.expm1(a)
 
 
-@torchsymbol(torch.Tensor.expm1_, is_method=True)
+@torchsymbol(torch.Tensor.expm1_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def expm1_(a):
     return prims.copy_(expm1(a), a)
 
@@ -1421,7 +1428,7 @@ def floor(a):
     return clang.floor(a)
 
 
-@torchsymbol(torch.Tensor.floor_, is_method=True)
+@torchsymbol(torch.Tensor.floor_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def floor_(a):
     return prims.copy_(floor(a), a)
 
@@ -1436,7 +1443,7 @@ def lgamma(a):
     return clang.lgamma(a)
 
 
-@torchsymbol(torch.Tensor.lgamma_, is_method=True)
+@torchsymbol(torch.Tensor.lgamma_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def lgamma_(a):
     return prims.copy_(lgamma(a), a)
 
@@ -1446,7 +1453,7 @@ def log(a):
     return clang.log(a)
 
 
-@torchsymbol(torch.Tensor.log_, is_method=True)
+@torchsymbol(torch.Tensor.log_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def log_(a):
     return prims.copy_(log(a), a)
 
@@ -1456,7 +1463,7 @@ def log10(a):
     return clang.log10(a)
 
 
-@torchsymbol(torch.Tensor.log10_, is_method=True)
+@torchsymbol(torch.Tensor.log10_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def log10_(a):
     return prims.copy_(log10(a), a)
 
@@ -1466,7 +1473,7 @@ def log1p(a):
     return clang.log1p(a)
 
 
-@torchsymbol(torch.Tensor.log1p_, is_method=True)
+@torchsymbol(torch.Tensor.log1p_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def log1p_(a):
     return prims.copy_(log1p(a), a)
 
@@ -1476,7 +1483,7 @@ def log2(a):
     return clang.log2(a)
 
 
-@torchsymbol(torch.Tensor.log2_, is_method=True)
+@torchsymbol(torch.Tensor.log2_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def log2_(a):
     return prims.copy_(log2(a), a)
 
@@ -1492,7 +1499,7 @@ def neg(a):
     return clang.neg(a)
 
 
-@torchsymbol(torch.Tensor.neg_, is_method=True)
+@torchsymbol(torch.Tensor.neg_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def neg_(a):
     return prims.copy_(neg(a), a)
 
@@ -1502,7 +1509,7 @@ def reciprocal(a):
     return clang.reciprocal(a)
 
 
-@torchsymbol(torch.Tensor.reciprocal_, is_method=True)
+@torchsymbol(torch.Tensor.reciprocal_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def reciprocal_(a):
     return prims.copy_(reciprocal(a), a)
 
@@ -1512,7 +1519,7 @@ def round(a):
     return clang.round(a)
 
 
-@torchsymbol(torch.Tensor.round_, is_method=True)
+@torchsymbol(torch.Tensor.round_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def round_(a):
     return prims.copy_(round(a), a)
 
@@ -1522,7 +1529,7 @@ def rsqrt(a):
     return clang.rsqrt(a)
 
 
-@torchsymbol(torch.Tensor.rsqrt_, is_method=True)
+@torchsymbol(torch.Tensor.rsqrt_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def rsqrt_(a):
     return prims.copy_(rsqrt(a), a)
 
@@ -1534,7 +1541,7 @@ def sign(a):
     return clang.sign(a)
 
 
-@torchsymbol(torch.Tensor.sign_, is_method=True)
+@torchsymbol(torch.Tensor.sign_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def sign_(a):
     return prims.copy_(sign(a), a)
 
@@ -1549,7 +1556,7 @@ def sin(a):
     return clang.sin(a)
 
 
-@torchsymbol(torch.Tensor.sin_, is_method=True)
+@torchsymbol(torch.Tensor.sin_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def sin_(a):
     return prims.copy_(sin(a), a)
 
@@ -1559,7 +1566,7 @@ def sinh(a):
     return clang.sinh(a)
 
 
-@torchsymbol(torch.Tensor.sinh_, is_method=True)
+@torchsymbol(torch.Tensor.sinh_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def sinh_(a):
     return prims.copy_(sinh(a), a)
 
@@ -1569,7 +1576,7 @@ def sqrt(a):
     return clang.sqrt(a)
 
 
-@torchsymbol(torch.Tensor.sqrt_, is_method=True)
+@torchsymbol(torch.Tensor.sqrt_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def sqrt_(a):
     return prims.copy_(sqrt(a), a)
 
@@ -1579,7 +1586,7 @@ def tan(a):
     return clang.tan(a)
 
 
-@torchsymbol(torch.Tensor.tan_, is_method=True)
+@torchsymbol(torch.Tensor.tan_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def tan_(a):
     return prims.copy_(tan(a), a)
 
@@ -1589,7 +1596,7 @@ def tanh(a):
     return clang.tanh(a)
 
 
-@torchsymbol(torch.Tensor.tanh_, is_method=True)
+@torchsymbol(torch.Tensor.tanh_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def tanh_(a):
     return prims.copy_(tanh(a), a)
 
@@ -1599,7 +1606,7 @@ def trunc(a):
     return clang.trunc(a)
 
 
-@torchsymbol(torch.Tensor.trunc_, is_method=True)
+@torchsymbol(torch.Tensor.trunc_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def trunc_(a):
     return prims.copy_(trunc(a), a)
 

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -8,7 +8,7 @@ from collections.abc import Sequence
 from enum import Enum
 from functools import partial, reduce, wraps
 from numbers import Number
-from typing import Any, overload, TYPE_CHECKING
+from typing import Any, overload
 from types import NoneType
 from collections.abc import Callable
 

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -1241,9 +1241,19 @@ def abs(a: NumberLike | TensorLike, /) -> Number | TensorLike:
     return clang.abs(a)
 
 
+@torchsymbol(torch.Tensor.abs_, is_method=True)
+def abs_(a: NumberLike | TensorLike, /) -> Number | TensorLike:
+    return prims.copy_(abs(a), a)
+
+
 @torchsymbol(torch.acos, is_method=True)
 def acos(a: NumberLike | TensorLike, /) -> Number | TensorLike:
     return clang.acos(a)
+
+
+@torchsymbol(torch.Tensor.acos_, is_method=True)
+def acos_(a: TensorLike, /) -> TensorLike:
+    return prims.copy_(acos(a), a)
 
 
 @torchsymbol(torch.acosh, is_method=True)
@@ -1251,9 +1261,19 @@ def acosh(a):
     return clang.acosh(a)
 
 
+@torchsymbol(torch.Tensor.acosh_, is_method=True)
+def acosh_(a):
+    return prims.copy_(acosh(a), a)
+
+
 @torchsymbol(torch.asin, is_method=True)
 def asin(a):
     return clang.asin(a)
+
+
+@torchsymbol(torch.Tensor.asin_, is_method=True)
+def asin_(a):
+    return prims.copy_(asin(a), a)
 
 
 @torchsymbol(torch.asinh, is_method=True)
@@ -1261,9 +1281,19 @@ def asinh(a):
     return clang.asinh(a)
 
 
+@torchsymbol(torch.Tensor.asinh_, is_method=True)
+def asinh_(a):
+    return prims.copy_(asinh(a), a)
+
+
 @torchsymbol(torch.atan, is_method=True)
 def atan(a):
     return clang.atan(a)
+
+
+@torchsymbol(torch.Tensor.atan_, is_method=True)
+def atan_(a):
+    return prims.copy_(atan(a), a)
 
 
 @torchsymbol(torch.atanh, is_method=True)
@@ -1271,9 +1301,19 @@ def atanh(a):
     return clang.atanh(a)
 
 
+@torchsymbol(torch.Tensor.atanh_, is_method=True)
+def atanh_(a):
+    return prims.copy_(atanh(a), a)
+
+
 @torchsymbol(torch.bitwise_not, is_method=True)
 def bitwise_not(a):
     return clang.bitwise_not(a)
+
+
+@torchsymbol(torch.Tensor.bitwise_not_, is_method=True)
+def bitwise_not_(a):
+    return prims.copy_(bitwise_not(a), a)
 
 
 @torchsymbol(torch.ceil, is_method=True)
@@ -1281,9 +1321,19 @@ def ceil(a):
     return clang.ceil(a)
 
 
+@torchsymbol(torch.Tensor.ceil_, is_method=True)
+def ceil_(a):
+    return prims.copy_(ceil(a), a)
+
+
 @torchsymbol(torch.cos, is_method=True)
 def cos(a):
     return clang.cos(a)
+
+
+@torchsymbol(torch.Tensor.cos_, is_method=True)
+def cos_(a):
+    return prims.copy_(cos(a), a)
 
 
 @torchsymbol(torch.cosh, is_method=True)
@@ -1291,9 +1341,19 @@ def cosh(a):
     return clang.cosh(a)
 
 
+@torchsymbol(torch.Tensor.cosh_, is_method=True)
+def cosh_(a):
+    return prims.copy_(cosh(a), a)
+
+
 @torchsymbol(torch.digamma, torch.special.digamma, is_method=True)
 def digamma(a):
     return clang.digamma(a)
+
+
+@torchsymbol(torch.Tensor.digamma_, is_method=True)
+def digamma_(a):
+    return prims.copy_(digamma(a), a)
 
 
 @torchsymbol(torch.erf, is_method=True)
@@ -1301,9 +1361,19 @@ def erf(a):
     return clang.erf(a)
 
 
+@torchsymbol(torch.Tensor.erf_, is_method=True)
+def erf_(a):
+    return prims.copy_(erf(a), a)
+
+
 @torchsymbol(torch.erfc, is_method=True)
 def erfc(a):
     return clang.erfc(a)
+
+
+@torchsymbol(torch.Tensor.erfc_, is_method=True)
+def erfc_(a):
+    return prims.copy_(erfc(a), a)
 
 
 @torchsymbol(torch.erfinv, is_method=True)
@@ -1311,9 +1381,19 @@ def erfinv(a):
     return clang.erfinv(a)
 
 
+@torchsymbol(torch.Tensor.erfinv_, is_method=True)
+def erfinv_(a):
+    return prims.copy_(erfinv(a), a)
+
+
 @torchsymbol(torch.exp, is_method=True)
 def exp(a):
     return clang.exp(a)
+
+
+@torchsymbol(torch.Tensor.exp_, is_method=True)
+def exp_(a):
+    return prims.copy_(exp(a), a)
 
 
 @torchsymbol(torch.exp2, is_method=True)
@@ -1321,14 +1401,29 @@ def exp2(a):
     return clang.exp2(a)
 
 
+@torchsymbol(torch.Tensor.exp2_, is_method=True)
+def exp2_(a):
+    return prims.copy_(exp2(a), a)
+
+
 @torchsymbol(torch.expm1, is_method=True)
 def expm1(a):
     return clang.expm1(a)
 
 
+@torchsymbol(torch.Tensor.expm1_, is_method=True)
+def expm1_(a):
+    return prims.copy_(expm1(a), a)
+
+
 @torchsymbol(torch.floor, is_method=True)
 def floor(a):
     return clang.floor(a)
+
+
+@torchsymbol(torch.Tensor.floor_, is_method=True)
+def floor_(a):
+    return prims.copy_(floor(a), a)
 
 
 @torchsymbol(torch.isfinite, is_method=True)
@@ -1341,9 +1436,19 @@ def lgamma(a):
     return clang.lgamma(a)
 
 
+@torchsymbol(torch.Tensor.lgamma_, is_method=True)
+def lgamma_(a):
+    return prims.copy_(lgamma(a), a)
+
+
 @torchsymbol(torch.log, is_method=True)
 def log(a):
     return clang.log(a)
+
+
+@torchsymbol(torch.Tensor.log_, is_method=True)
+def log_(a):
+    return prims.copy_(log(a), a)
 
 
 @torchsymbol(torch.log10, is_method=True)
@@ -1351,14 +1456,29 @@ def log10(a):
     return clang.log10(a)
 
 
+@torchsymbol(torch.Tensor.log10_, is_method=True)
+def log10_(a):
+    return prims.copy_(log10(a), a)
+
+
 @torchsymbol(torch.log1p, is_method=True)
 def log1p(a):
     return clang.log1p(a)
 
 
+@torchsymbol(torch.Tensor.log1p_, is_method=True)
+def log1p_(a):
+    return prims.copy_(log1p(a), a)
+
+
 @torchsymbol(torch.log2, is_method=True)
 def log2(a):
     return clang.log2(a)
+
+
+@torchsymbol(torch.Tensor.log2_, is_method=True)
+def log2_(a):
+    return prims.copy_(log2(a), a)
 
 
 # TODO Move to special
@@ -1372,9 +1492,19 @@ def neg(a):
     return clang.neg(a)
 
 
+@torchsymbol(torch.Tensor.neg_, is_method=True)
+def neg_(a):
+    return prims.copy_(neg(a), a)
+
+
 @torchsymbol(torch.reciprocal, is_method=True)
 def reciprocal(a):
     return clang.reciprocal(a)
+
+
+@torchsymbol(torch.Tensor.reciprocal_, is_method=True)
+def reciprocal_(a):
+    return prims.copy_(reciprocal(a), a)
 
 
 @torchsymbol(torch.round, is_method=True)
@@ -1382,9 +1512,19 @@ def round(a):
     return clang.round(a)
 
 
+@torchsymbol(torch.Tensor.round_, is_method=True)
+def round_(a):
+    return prims.copy_(round(a), a)
+
+
 @torchsymbol(torch.rsqrt, is_method=True)
 def rsqrt(a):
     return clang.rsqrt(a)
+
+
+@torchsymbol(torch.Tensor.rsqrt_, is_method=True)
+def rsqrt_(a):
+    return prims.copy_(rsqrt(a), a)
 
 
 # TODO Complain about complex numbers like PyTorch does?
@@ -1392,6 +1532,11 @@ def rsqrt(a):
 @torchsymbol(torch.sign, is_method=True)
 def sign(a):
     return clang.sign(a)
+
+
+@torchsymbol(torch.Tensor.sign_, is_method=True)
+def sign_(a):
+    return prims.copy_(sign(a), a)
 
 
 @torchsymbol(torch.signbit, is_method=True)
@@ -1404,9 +1549,19 @@ def sin(a):
     return clang.sin(a)
 
 
+@torchsymbol(torch.Tensor.sin_, is_method=True)
+def sin_(a):
+    return prims.copy_(sin(a), a)
+
+
 @torchsymbol(torch.sinh, is_method=True)
 def sinh(a):
     return clang.sinh(a)
+
+
+@torchsymbol(torch.Tensor.sinh_, is_method=True)
+def sinh_(a):
+    return prims.copy_(sinh(a), a)
 
 
 @torchsymbol(torch.sqrt, is_method=True)
@@ -1414,9 +1569,19 @@ def sqrt(a):
     return clang.sqrt(a)
 
 
+@torchsymbol(torch.Tensor.sqrt_, is_method=True)
+def sqrt_(a):
+    return prims.copy_(sqrt(a), a)
+
+
 @torchsymbol(torch.tan, is_method=True)
 def tan(a):
     return clang.tan(a)
+
+
+@torchsymbol(torch.Tensor.tan_, is_method=True)
+def tan_(a):
+    return prims.copy_(tan(a), a)
 
 
 @torchsymbol(torch.tanh, is_method=True)
@@ -1424,9 +1589,19 @@ def tanh(a):
     return clang.tanh(a)
 
 
+@torchsymbol(torch.Tensor.tanh_, is_method=True)
+def tanh_(a):
+    return prims.copy_(tanh(a), a)
+
+
 @torchsymbol(torch.trunc, is_method=True)
 def trunc(a):
     return clang.trunc(a)
+
+
+@torchsymbol(torch.Tensor.trunc_, is_method=True)
+def trunc_(a):
+    return prims.copy_(trunc(a), a)
 
 
 @torchsymbol(torch.real, is_method=False)
@@ -1457,40 +1632,47 @@ def gelu(a: TensorProxy, /, *, approximate: str = "none") -> TensorLike:
 # TODO Should this use clamp? -- Would that propagate NaNs properly?
 @torchsymbol(torch.relu, torch.nn.functional.relu, id="torch.relu", is_method=True)
 def relu(a: TensorLike, /, inplace: bool = False) -> TensorLike:
-    utils.check(not inplace, lambda: f"relu only supports inplace=False", exception_type=NotImplementedError)
 
-    return where(a > 0, a, 0)
+    out = where(a > 0, a, 0)
+    if inplace:
+        return prims.copy_(out, a)
+    return out
 
 
 # id=torch.relu because we ignore inplace argument in torch.nn.functional.relu
 @torchsymbol(torch.nn.functional.relu6, id="torch.relu6", is_method=False)
 def relu6(a: TensorProxy, /, inplace: bool = False) -> TensorLike:
-    utils.check(not inplace, lambda: f"relu6 only supports inplace=False", exception_type=NotImplementedError)
-    return clamp(a, 0, 6)
+    out = clamp(a, 0, 6)
+    if inplace:
+        return prims.copy_(out, a)
+    return out
 
 
 @torchsymbol(torch.nn.functional.hardswish, id="torch.hardswish", is_method=False)
 def hardswish(a: TensorProxy, /, inplace: bool = False) -> TensorLike:
-    utils.check(not inplace, lambda: f"hardswish only supports inplace=False", exception_type=NotImplementedError)
     utils.check(
         dtypes.is_float_dtype(a.dtype),
         lambda: f"hardswish only supports floating point dtypes, got {a.dtype}",
         exception_type=ValueError,
     )
-    return a * relu6(a + 3) / 6
+    out = a * relu6(a + 3) / 6
+    if inplace:
+        return prims.copy_(out, a)
+    return out
 
 
 # id=torch.selu because we ignore inplace argument in torch.nn.functional.selu
 @torchsymbol(torch.selu, torch.nn.functional.selu, id="torch.selu", is_method=False)
 def selu(a: TensorProxy, /, inplace: bool = False) -> TensorLike:
-    utils.check(not inplace, lambda: f"selu only supports inplace=False", exception_type=NotImplementedError)
-
     alpha = 1.6732632423543772848170429916717
     scale = 1.0507009873554804934193349852946
 
     rhs = alpha * expm1(a)
 
-    return scale * where(a > 0, a, rhs)
+    out = scale * where(a > 0, a, rhs)
+    if inplace:
+        return prims.copy_(out, a)
+    return out
 
 
 @torchsymbol(torch.nn.functional.silu)
@@ -1498,7 +1680,10 @@ def silu(a: TensorLike, /, inplace: bool = False) -> TensorLike:
     utils.check(
         not inplace, lambda: "Thunder only supports silu with inplace=False", exception_type=NotImplementedError
     )
-    return clang.silu(a)
+    out = clang.silu(a)
+    if inplace:
+        return prims.copy_(out, a)
+    return out
 
 
 #
@@ -1532,9 +1717,19 @@ def atan2(a, b, /):
     return clang.atan2(a, b)
 
 
+@torchsymbol(torch.Tensor.atan2_, is_method=True)
+def atan2_(a, b, /):
+    return prims.copy_(atan2(a, b), a)
+
+
 @torchsymbol(torch.bitwise_and, is_method=True)
 def bitwise_and(a, b, /):
     return clang.bitwise_and(a, b)
+
+
+@torchsymbol(torch.Tensor.bitwise_and_, is_method=True)
+def bitwise_and_(a, b, /):
+    return prims.copy_(bitwise_and(a, b), a)
 
 
 @torchsymbol(torch.bitwise_or, is_method=True)
@@ -1542,14 +1737,29 @@ def bitwise_or(a, b, /):
     return clang.bitwise_or(a, b)
 
 
+@torchsymbol(torch.Tensor.bitwise_or_, is_method=True)
+def bitwise_or_(a, b, /):
+    return prims.copy_(bitwise_or(a, b), a)
+
+
 @torchsymbol(torch.bitwise_xor, is_method=True)
 def bitwise_xor(a, b, /):
     return clang.bitwise_xor(a, b)
 
 
+@torchsymbol(torch.Tensor.bitwise_xor_, is_method=True)
+def bitwise_xor_(a, b, /):
+    return prims.copy_(bitwise_xor(a, b), a)
+
+
 @torchsymbol(torch.copysign, is_method=True)
 def copysign(a, b, /):
     return clang.copysign(a, b)
+
+
+@torchsymbol(torch.Tensor.copysign_, is_method=True)
+def copysign_(a, b, /):
+    return prims.copy_(copysign(a, b), a)
 
 
 # TODO Implement div
@@ -1582,11 +1792,6 @@ def div_(
     *,
     rounding_mode: None | str = None,
 ) -> TensorLike:
-    utils.check(
-        rounding_mode is None,
-        lambda: f"Invalid {rounding_mode=}, `None` i.e. true is only supported",
-    )
-
     return prims.copy_(div(a, b), a)
 
 
@@ -1595,9 +1800,19 @@ def eq(a, b, /):
     return clang.eq(a, b)
 
 
+@torchsymbol(torch.Tensor.eq_, is_method=True)
+def eq_(a, b, /):
+    return prims.copy_(eq(a, b), a)
+
+
 @torchsymbol(torch.floor_divide, is_method=True)
 def floor_divide(a, b, /):
     return clang.floor_divide(a, b)
+
+
+@torchsymbol(torch.Tensor.floor_divide_, is_method=True)
+def floor_divide_(a, b, /):
+    return prims.copy_(floor_divide(a, b), a)
 
 
 @torchsymbol(torch.fmod, is_method=True)
@@ -1605,9 +1820,19 @@ def fmod(a, b, /):
     return clang.fmod(a, b)
 
 
+@torchsymbol(torch.Tensor.fmod_, is_method=True)
+def fmod_(a, b, /):
+    return prims.copy_(fmod(a, b), a)
+
+
 @torchsymbol(torch.ge, is_method=True)
 def ge(a, b, /):
     return clang.ge(a, b)
+
+
+@torchsymbol(torch.Tensor.ge_, is_method=True)
+def ge_(a, b, /):
+    return prims.copy_(ge(a, b), a)
 
 
 @torchsymbol(torch.gt, is_method=True)
@@ -1615,9 +1840,19 @@ def gt(a, b, /):
     return clang.gt(a, b)
 
 
+@torchsymbol(torch.Tensor.gt_, is_method=True)
+def gt_(a, b, /):
+    return prims.copy_(gt(a, b), a)
+
+
 @torchsymbol(torch.logical_and, is_method=True)
 def logical_and(a, b, /):
     return clang.logical_and(a, b)
+
+
+@torchsymbol(torch.Tensor.logical_and_, is_method=True)
+def logical_and_(a, b, /):
+    return prims.copy_(logical_and(a, b), a)
 
 
 @torchsymbol(torch.logical_not, is_method=True)
@@ -1625,14 +1860,29 @@ def logical_not(a: TensorLike, /) -> TensorLike:
     return clang.logical_not(a)
 
 
+@torchsymbol(torch.Tensor.logical_not_, is_method=True)
+def logical_not_(a: TensorLike, /) -> TensorLike:
+    return prims.copy_(logical_not(a), a)
+
+
 @torchsymbol(torch.le, is_method=True)
 def le(a, b, /):
     return clang.le(a, b)
 
 
+@torchsymbol(torch.Tensor.le_, is_method=True)
+def le_(a, b, /):
+    return prims.copy_(le(a, b), a)
+
+
 @torchsymbol(torch.lt, is_method=True)
 def lt(a, b, /):
     return clang.lt(a, b)
+
+
+@torchsymbol(torch.Tensor.lt_, is_method=True)
+def lt_(a, b, /):
+    return prims.copy_(lt(a, b), a)
 
 
 @torchsymbol(torch.maximum, is_method=True)
@@ -1652,6 +1902,10 @@ def mod(a, b):
     return clang.mod(a, b)
 
 
+def mod_(a, b):
+    return prims.copy_(mod(a, b), a)
+
+
 @torchsymbol(torch.mul, is_method=True)
 def mul(a, b, /):
     return clang.mul(a, b)
@@ -1667,9 +1921,19 @@ def ne(a, b, /):
     return clang.ne(a, b)
 
 
+@torchsymbol(torch.Tensor.ne_, is_method=True)
+def ne_(a, b, /):
+    return prims.copy_(ne(a, b), a)
+
+
 @torchsymbol(torch.nextafter, is_method=True)
 def nextafter(a, b, /):
     return clang.nextafter(a, b)
+
+
+@torchsymbol(torch.Tensor.nextafter_, is_method=True)
+def nextafter_(a, b, /):
+    return prims.copy_(nextafter(a, b), a)
 
 
 # TODO Extend to tensor x tensor
@@ -1690,6 +1954,11 @@ def polygamma(n: int, a: TensorLike, /) -> TensorLike:
     return sign * factorial_mul_zeta
 
 
+@torchsymbol(torch.Tensor.polygamma_, is_method=True)
+def polygamma_(a: TensorLike, n: int, /) -> TensorLike:
+    return prims.copy_(polygamma(n, a), a)
+
+
 @torchsymbol(torch.pow, is_method=True)
 def pow(a, b, /):
     return clang.pow(a, b)
@@ -1703,6 +1972,11 @@ def pow_(a, b, /):
 @torchsymbol(torch.remainder, is_method=True)
 def remainder(a, b, /):
     return clang.remainder(a, b)
+
+
+@torchsymbol(torch.Tensor.remainder_, is_method=True)
+def remainder_(a, b, /):
+    return prims.copy_(remainder(a, b), a)
 
 
 @torchsymbol(torch.sub, is_method=True)
@@ -1721,6 +1995,11 @@ def sub_(a, b, /, *, alpha=None):
 @torchsymbol(torch.true_divide, is_method=True)
 def true_divide(a: NumberLike | TensorLike, b: NumberLike | TensorLike, /) -> Number | TensorLike:
     return clang.true_divide(a, b)
+
+
+@torchsymbol(torch.Tensor.true_divide_, is_method=True)
+def true_divide_(a: TensorLike, b: NumberLike | TensorLike, /) -> TensorLike:
+    return prims.copy_(true_divide(a, b))
 
 
 @torchsymbol(torch.special.zeta)
@@ -1757,9 +2036,19 @@ def addcmul(a: TensorLike, b: TensorLike, c: TensorLike, /, *, value: None | Num
     return addcmul_addcdiv_helper(a, b, c, add, mul, value=value)
 
 
+@torchsymbol(torch.Tensor.addcmul_, is_method=True)
+def addcmul_(a: TensorLike, b: TensorLike, c: TensorLike, /, *, value: None | Number = None) -> TensorLike:
+    return prims.copy_(addcmul(a, b, c, value=value), a)
+
+
 @torchsymbol(torch.addcdiv, is_method=True)
 def addcdiv(a: TensorLike, b: TensorLike, c: TensorLike, /, *, value: None | Number = None) -> TensorLike:
     return addcmul_addcdiv_helper(a, b, c, add, true_divide, value=value)
+
+
+@torchsymbol(torch.Tensor.addcdiv_, is_method=True)
+def addcdiv_(a: TensorLike, b: TensorLike, c: TensorLike, /, *, value: None | Number = None) -> TensorLike:
+    return prims.copy_(addcdiv(a, b, c, value=value), a)
 
 
 #
@@ -1802,6 +2091,13 @@ def clamp(
     return a
 
 
+@torchsymbol(torch.Tensor.clamp_, is_method=True)
+def clamp_(
+    a: TensorLike, /, min: None | Number | TensorLike = None, max: None | Number | TensorLike = None
+) -> TensorLike:
+    return prims.copy_(clamp(a, min, max), a)
+
+
 def _mask_tensor(a, mask, fill_value):
     utils.check(
         dtypes.is_boolean_dtype(mask.dtype), lambda: f"_mask_tensor: mask ({mask.dtype=}) must have a boolean dtype"
@@ -1825,6 +2121,11 @@ def masked_fill(a: TensorLike, /, mask: TensorLike, value: NumberLike | TensorLi
     return result
 
 
+@torchsymbol(torch.Tensor.masked_fill_, is_method=True)
+def masked_fill_(a: TensorLike, /, mask: TensorLike, value: NumberLike | TensorLike) -> TensorLike:
+    return prims.copy_(masked_fill(a, mask, value))
+
+
 # NOTE The key to understanding tril is that it generates a mask
 #   which (by default) masks elements of a matrix (or batch of matrices)
 #   s.t. elements whose row number is greater than or equal to its column number
@@ -1845,6 +2146,11 @@ def tril(a: TensorLike, /, diagonal: int = 0, *, fill_value: None | Number = Non
         fill_value = 0
 
     return _mask_tensor(a, mask, fill_value)
+
+
+@torchsymbol(torch.Tensor.tril_, is_method=True)
+def tril_(a: TensorLike, /, diagonal: int = 0, *, fill_value: None | Number = None) -> TensorLike:
+    return prims.copy_(tril(a, diagonal, fill_value=fill_value), a)
 
 
 @torchsymbol(torch.where, is_method=True)
@@ -2267,6 +2573,11 @@ def cumsum(a: TensorLike, dim: int, *, dtype: None | dtypeLike = None) -> Tensor
         return TensorProxy(like=a, dtype=to_dtype(dtype))
 
 
+@torchsymbol(torch.Tensor.cumsum_, is_method=True)
+def cumsum_(a: TensorLike, dim: int, *, dtype: None | dtypeLike = None) -> TensorLike:
+    return prims.copy_(cumsum(a, dim, dtype=dtype), a)
+
+
 @torchsymbol(torch.var, is_method=True)
 def var(
     a: TensorProxy,
@@ -2337,6 +2648,11 @@ def index_add(a: TensorLike, /, dim: int, index: TensorLike, source: TensorLike)
     return clang.index_add(a, index, source, dim)
 
 
+@torchsymbol(torch.Tensor.index_add_, is_method=True)
+def index_add_(a: TensorLike, /, dim: int, index: TensorLike, source: TensorLike) -> TensorLike:
+    return prims.copy_(index_add(a, dim, index, source), a)
+
+
 @torchsymbol(torch.index_select, is_method=True)
 def index_select(a: TensorLike, /, dim: int, index: TensorLike) -> TensorLike:
     return clang.take(a, index, dim)
@@ -2353,6 +2669,11 @@ def scatter_add(a: TensorLike, /, dim: int, index: TensorLike, src: TensorLike) 
     return clang.scatter_add(a, indices=index, value=src, dim=dim)
 
 
+@torchsymbol(torch.Tensor.scatter_add_, is_method=True)
+def scatter_add_(a: TensorLike, /, dim: int, index: TensorLike, src: TensorLike) -> TensorLike:
+    return prims.copy_(scatter_add(a, dim, index, src), a)
+
+
 @torchsymbol(torch.take_along_dim)
 def take_along_dim(a: TensorLike, /, indices: TensorLike, dim: int) -> TensorLike:
     return clang.take_along_axis(a, indices, dim)
@@ -2363,6 +2684,17 @@ def index_put(
     a: TensorLike, /, indices: Sequence[TensorLike], values: TensorLike, accumulate: bool = False
 ) -> TensorLike:
     return clang.index_put(a, indices, values, accumulate)
+
+
+@torchsymbol(torch.Tensor.index_put_, is_method=True)
+def index_put_(
+    a: TensorLike,
+    /,
+    indices: Sequence[TensorLike],
+    values: TensorLike,
+    accumulate: bool = False,
+) -> TensorLike:
+    return prims.copy_(index_put(a, indices, values, accumulate), a)
 
 
 #

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -1701,7 +1701,7 @@ def add(
     return clang.add(a, b)
 
 
-@torchsymbol(torch.Tensor.add_, is_method=True)
+@torchsymbol(torch.Tensor.add_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def add_(
     a: TensorLike,
     b: NumberLike | TensorLike,
@@ -1717,7 +1717,7 @@ def atan2(a, b, /):
     return clang.atan2(a, b)
 
 
-@torchsymbol(torch.Tensor.atan2_, is_method=True)
+@torchsymbol(torch.Tensor.atan2_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def atan2_(a, b, /):
     return prims.copy_(atan2(a, b), a)
 
@@ -1727,7 +1727,7 @@ def bitwise_and(a, b, /):
     return clang.bitwise_and(a, b)
 
 
-@torchsymbol(torch.Tensor.bitwise_and_, is_method=True)
+@torchsymbol(torch.Tensor.bitwise_and_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def bitwise_and_(a, b, /):
     return prims.copy_(bitwise_and(a, b), a)
 
@@ -1737,7 +1737,7 @@ def bitwise_or(a, b, /):
     return clang.bitwise_or(a, b)
 
 
-@torchsymbol(torch.Tensor.bitwise_or_, is_method=True)
+@torchsymbol(torch.Tensor.bitwise_or_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def bitwise_or_(a, b, /):
     return prims.copy_(bitwise_or(a, b), a)
 
@@ -1747,7 +1747,7 @@ def bitwise_xor(a, b, /):
     return clang.bitwise_xor(a, b)
 
 
-@torchsymbol(torch.Tensor.bitwise_xor_, is_method=True)
+@torchsymbol(torch.Tensor.bitwise_xor_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def bitwise_xor_(a, b, /):
     return prims.copy_(bitwise_xor(a, b), a)
 
@@ -1757,7 +1757,7 @@ def copysign(a, b, /):
     return clang.copysign(a, b)
 
 
-@torchsymbol(torch.Tensor.copysign_, is_method=True)
+@torchsymbol(torch.Tensor.copysign_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def copysign_(a, b, /):
     return prims.copy_(copysign(a, b), a)
 
@@ -1784,7 +1784,7 @@ def div(
         raise ValueError(f"div does not support the rounding_mode={rounding_mode} argument")
 
 
-@torchsymbol(torch.Tensor.div_, is_method=True)
+@torchsymbol(torch.Tensor.div_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def div_(
     a: TensorLike,
     b: Number | TensorLike,
@@ -1800,7 +1800,7 @@ def eq(a, b, /):
     return clang.eq(a, b)
 
 
-@torchsymbol(torch.Tensor.eq_, is_method=True)
+@torchsymbol(torch.Tensor.eq_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def eq_(a, b, /):
     return prims.copy_(eq(a, b), a)
 
@@ -1810,7 +1810,7 @@ def floor_divide(a, b, /):
     return clang.floor_divide(a, b)
 
 
-@torchsymbol(torch.Tensor.floor_divide_, is_method=True)
+@torchsymbol(torch.Tensor.floor_divide_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def floor_divide_(a, b, /):
     return prims.copy_(floor_divide(a, b), a)
 
@@ -1820,7 +1820,7 @@ def fmod(a, b, /):
     return clang.fmod(a, b)
 
 
-@torchsymbol(torch.Tensor.fmod_, is_method=True)
+@torchsymbol(torch.Tensor.fmod_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def fmod_(a, b, /):
     return prims.copy_(fmod(a, b), a)
 
@@ -1830,7 +1830,7 @@ def ge(a, b, /):
     return clang.ge(a, b)
 
 
-@torchsymbol(torch.Tensor.ge_, is_method=True)
+@torchsymbol(torch.Tensor.ge_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def ge_(a, b, /):
     return prims.copy_(ge(a, b), a)
 
@@ -1840,7 +1840,7 @@ def gt(a, b, /):
     return clang.gt(a, b)
 
 
-@torchsymbol(torch.Tensor.gt_, is_method=True)
+@torchsymbol(torch.Tensor.gt_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def gt_(a, b, /):
     return prims.copy_(gt(a, b), a)
 
@@ -1850,7 +1850,7 @@ def logical_and(a, b, /):
     return clang.logical_and(a, b)
 
 
-@torchsymbol(torch.Tensor.logical_and_, is_method=True)
+@torchsymbol(torch.Tensor.logical_and_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def logical_and_(a, b, /):
     return prims.copy_(logical_and(a, b), a)
 
@@ -1860,7 +1860,7 @@ def logical_not(a: TensorLike, /) -> TensorLike:
     return clang.logical_not(a)
 
 
-@torchsymbol(torch.Tensor.logical_not_, is_method=True)
+@torchsymbol(torch.Tensor.logical_not_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def logical_not_(a: TensorLike, /) -> TensorLike:
     return prims.copy_(logical_not(a), a)
 
@@ -1870,7 +1870,7 @@ def le(a, b, /):
     return clang.le(a, b)
 
 
-@torchsymbol(torch.Tensor.le_, is_method=True)
+@torchsymbol(torch.Tensor.le_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def le_(a, b, /):
     return prims.copy_(le(a, b), a)
 
@@ -1880,7 +1880,7 @@ def lt(a, b, /):
     return clang.lt(a, b)
 
 
-@torchsymbol(torch.Tensor.lt_, is_method=True)
+@torchsymbol(torch.Tensor.lt_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def lt_(a, b, /):
     return prims.copy_(lt(a, b), a)
 
@@ -1911,7 +1911,7 @@ def mul(a, b, /):
     return clang.mul(a, b)
 
 
-@torchsymbol(torch.Tensor.mul_, is_method=True)
+@torchsymbol(torch.Tensor.mul_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def mul_(a, b, /):
     return prims.copy_(mul(a, b), a)
 
@@ -1921,7 +1921,7 @@ def ne(a, b, /):
     return clang.ne(a, b)
 
 
-@torchsymbol(torch.Tensor.ne_, is_method=True)
+@torchsymbol(torch.Tensor.ne_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def ne_(a, b, /):
     return prims.copy_(ne(a, b), a)
 
@@ -1931,7 +1931,7 @@ def nextafter(a, b, /):
     return clang.nextafter(a, b)
 
 
-@torchsymbol(torch.Tensor.nextafter_, is_method=True)
+@torchsymbol(torch.Tensor.nextafter_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def nextafter_(a, b, /):
     return prims.copy_(nextafter(a, b), a)
 
@@ -1954,7 +1954,7 @@ def polygamma(n: int, a: TensorLike, /) -> TensorLike:
     return sign * factorial_mul_zeta
 
 
-@torchsymbol(torch.Tensor.polygamma_, is_method=True)
+@torchsymbol(torch.Tensor.polygamma_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def polygamma_(a: TensorLike, n: int, /) -> TensorLike:
     return prims.copy_(polygamma(n, a), a)
 
@@ -1964,7 +1964,7 @@ def pow(a, b, /):
     return clang.pow(a, b)
 
 
-@torchsymbol(torch.Tensor.pow_, is_method=True)
+@torchsymbol(torch.Tensor.pow_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def pow_(a, b, /):
     return prims.copy_(pow(a, b), a)
 
@@ -1974,7 +1974,7 @@ def remainder(a, b, /):
     return clang.remainder(a, b)
 
 
-@torchsymbol(torch.Tensor.remainder_, is_method=True)
+@torchsymbol(torch.Tensor.remainder_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def remainder_(a, b, /):
     return prims.copy_(remainder(a, b), a)
 
@@ -1987,7 +1987,7 @@ def sub(a, b, /, *, alpha=None):
     return clang.sub(a, b)
 
 
-@torchsymbol(torch.Tensor.sub_, is_method=True)
+@torchsymbol(torch.Tensor.sub_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def sub_(a, b, /, *, alpha=None):
     return prims.copy_(sub(a, b, alpha=alpha), a)
 
@@ -1997,7 +1997,7 @@ def true_divide(a: NumberLike | TensorLike, b: NumberLike | TensorLike, /) -> Nu
     return clang.true_divide(a, b)
 
 
-@torchsymbol(torch.Tensor.true_divide_, is_method=True)
+@torchsymbol(torch.Tensor.true_divide_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def true_divide_(a: TensorLike, b: NumberLike | TensorLike, /) -> TensorLike:
     return prims.copy_(true_divide(a, b))
 
@@ -2036,7 +2036,7 @@ def addcmul(a: TensorLike, b: TensorLike, c: TensorLike, /, *, value: None | Num
     return addcmul_addcdiv_helper(a, b, c, add, mul, value=value)
 
 
-@torchsymbol(torch.Tensor.addcmul_, is_method=True)
+@torchsymbol(torch.Tensor.addcmul_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def addcmul_(a: TensorLike, b: TensorLike, c: TensorLike, /, *, value: None | Number = None) -> TensorLike:
     return prims.copy_(addcmul(a, b, c, value=value), a)
 
@@ -2046,7 +2046,7 @@ def addcdiv(a: TensorLike, b: TensorLike, c: TensorLike, /, *, value: None | Num
     return addcmul_addcdiv_helper(a, b, c, add, true_divide, value=value)
 
 
-@torchsymbol(torch.Tensor.addcdiv_, is_method=True)
+@torchsymbol(torch.Tensor.addcdiv_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def addcdiv_(a: TensorLike, b: TensorLike, c: TensorLike, /, *, value: None | Number = None) -> TensorLike:
     return prims.copy_(addcdiv(a, b, c, value=value), a)
 
@@ -2091,7 +2091,7 @@ def clamp(
     return a
 
 
-@torchsymbol(torch.Tensor.clamp_, is_method=True)
+@torchsymbol(torch.Tensor.clamp_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def clamp_(
     a: TensorLike, /, min: None | Number | TensorLike = None, max: None | Number | TensorLike = None
 ) -> TensorLike:
@@ -2121,7 +2121,7 @@ def masked_fill(a: TensorLike, /, mask: TensorLike, value: NumberLike | TensorLi
     return result
 
 
-@torchsymbol(torch.Tensor.masked_fill_, is_method=True)
+@torchsymbol(torch.Tensor.masked_fill_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def masked_fill_(a: TensorLike, /, mask: TensorLike, value: NumberLike | TensorLike) -> TensorLike:
     return prims.copy_(masked_fill(a, mask, value))
 
@@ -2148,7 +2148,7 @@ def tril(a: TensorLike, /, diagonal: int = 0, *, fill_value: None | Number = Non
     return _mask_tensor(a, mask, fill_value)
 
 
-@torchsymbol(torch.Tensor.tril_, is_method=True)
+@torchsymbol(torch.Tensor.tril_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def tril_(a: TensorLike, /, diagonal: int = 0, *, fill_value: None | Number = None) -> TensorLike:
     return prims.copy_(tril(a, diagonal, fill_value=fill_value), a)
 
@@ -2573,7 +2573,7 @@ def cumsum(a: TensorLike, dim: int, *, dtype: None | dtypeLike = None) -> Tensor
         return TensorProxy(like=a, dtype=to_dtype(dtype))
 
 
-@torchsymbol(torch.Tensor.cumsum_, is_method=True)
+@torchsymbol(torch.Tensor.cumsum_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def cumsum_(a: TensorLike, dim: int, *, dtype: None | dtypeLike = None) -> TensorLike:
     return prims.copy_(cumsum(a, dim, dtype=dtype), a)
 
@@ -2648,7 +2648,7 @@ def index_add(a: TensorLike, /, dim: int, index: TensorLike, source: TensorLike)
     return clang.index_add(a, index, source, dim)
 
 
-@torchsymbol(torch.Tensor.index_add_, is_method=True)
+@torchsymbol(torch.Tensor.index_add_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def index_add_(a: TensorLike, /, dim: int, index: TensorLike, source: TensorLike) -> TensorLike:
     return prims.copy_(index_add(a, dim, index, source), a)
 
@@ -2669,7 +2669,7 @@ def scatter_add(a: TensorLike, /, dim: int, index: TensorLike, src: TensorLike) 
     return clang.scatter_add(a, indices=index, value=src, dim=dim)
 
 
-@torchsymbol(torch.Tensor.scatter_add_, is_method=True)
+@torchsymbol(torch.Tensor.scatter_add_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def scatter_add_(a: TensorLike, /, dim: int, index: TensorLike, src: TensorLike) -> TensorLike:
     return prims.copy_(scatter_add(a, dim, index, src), a)
 
@@ -2686,7 +2686,7 @@ def index_put(
     return clang.index_put(a, indices, values, accumulate)
 
 
-@torchsymbol(torch.Tensor.index_put_, is_method=True)
+@torchsymbol(torch.Tensor.index_put_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def index_put_(
     a: TensorLike,
     /,

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -1992,7 +1992,7 @@ def polygamma(n: int, a: TensorLike, /) -> TensorLike:
 
 
 @torchsymbol(torch.Tensor.polygamma_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
-def polygamma_(a: TensorLike, n: int, /) -> TensorLike:
+def polygamma_(n: int, a: TensorLike, /) -> TensorLike:
     return prims.copy_(polygamma(n, a), a)
 
 
@@ -2160,7 +2160,7 @@ def masked_fill(a: TensorLike, /, mask: TensorLike, value: NumberLike | TensorLi
 
 @torchsymbol(torch.Tensor.masked_fill_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def masked_fill_(a: TensorLike, /, mask: TensorLike, value: NumberLike | TensorLike) -> TensorLike:
-    return prims.copy_(masked_fill(a, mask, value))
+    return prims.copy_(masked_fill(a, mask, value), a)
 
 
 # NOTE The key to understanding tril is that it generates a mask


### PR DESCRIPTION
## What does this PR do?

Express in-place ops using their out-of-place counterpart with following `prims.copy_`. e.g. `a.add_(b)` as `prims.copy_(prims.add(a, b), a)`, then let the added transform functionalize the trace by removing the trailing copy amd updating the signature. 
Let’s say we have `t.exp_()` in a script and `t` is used afterwards, thunder translates it into `t_out = ltorch.exp_(t)`. This bound symbol has two sub bound symbols: `t0 = ltorch.exp(t)` and `t_out = prims.copy_(t0, t)`. The functionalization removes the copy, and replaces `ltorch.exp_(t)` with `t0 = ltorch.exp(t)` and `t` uses after `exp_` with `t0`.

The covered ops are ones that either (a) have in-place variant such as `torch.exp` and `torch.add` or (b) have `inplace` as one of their args such as `torch.nn.functional.relu`.
 
So this would not cover the entire #145 broadly, nor take aliases into considerations.