### PR TITLE
Copy to the original tensors

### DIFF
--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -1533,7 +1533,7 @@ def bind_inputs(name, trace, input_vars, input_proxies):
     # with tracectx(trace):
     #     p: Proxy
     #     for p in input_proxies:
-    #         prims.unpack_trivial(p)
+    #         prims.unpack_trivial(p, name=p.name)
 
     for p in input_proxies:
         bsym = prims.unpack_trivial.bind(p, output=p)

--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -1687,6 +1687,12 @@ def thunder_general_jit(
 
 
 def functionalize_inplace_ops(computation_trace: TraceCtx) -> TraceCtx:
+    """Functionalize in-place ops in ``computation_trace``.
+
+    This is a two-step function. The first step is to use the output of :func:`thunder.core.prims.copy_`'s
+    outputs as trace's outputs. The second step is to remove :func:`thunder.core.prims.copy_`
+    from :attr:`~thunder.core.symbol.Boundsymbol.subsymbols` if it's the last symbol.
+    """
     from thunder.core import utils
     from thunder.core.proxies import ProxyInterface
     from thunder.core.symbol import VariableInterface
@@ -1701,8 +1707,7 @@ def functionalize_inplace_ops(computation_trace: TraceCtx) -> TraceCtx:
     if not any(is_inplace(bsym) for bsym in computation_trace.bound_symbols):
         return computation_trace
 
-    # Step 1: don't return tensors who have their consumers in any way, i.e., return
-    # the tensors returned from `prims.copy_` as possible.
+    # Step 1: return the tensors returned from `prims.copy_` as possible not the args for clarity.
     bsym: BoundSymbol
     swap_map: dict[VariableInterface, ProxyInterface] = {}
     bsyms: list[BoundSymbol] = []

--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -1521,14 +1521,29 @@ def process_recorded_modifications(ctx, epilogue_trace):
 
 
 def bind_inputs(name, trace, input_vars, input_proxies):
+    from thunder.core import utils
+
     # Unpacks inputs into the computation trace
     # TODO This currently does the unpacks at the end of the trace, then moves them to the beginning, there's
     #   almost certainly a more elegant way to do this
-    with tracectx(trace):
-        p: Proxy
-        for p in input_proxies:
-            prims.unpack_trivial(p, name=p.name)
+    num_orig_bsyms = len(trace.bound_symbols)
 
+    # note(crcrpar): The path looks neat but it does not work for a trace
+    # if it's :func:`thunder.core.jit_ext.functionalize_inplace_ops`'d, :shrug:
+    # with tracectx(trace):
+    #     p: Proxy
+    #     for p in input_proxies:
+    #         prims.unpack_trivial(p)
+
+    for p in input_proxies:
+        bsym = prims.unpack_trivial.bind(p, output=p)
+        trace.add_bound_symbol(bsym)
+
+    num_bsyms = len(trace.bound_symbols)
+    utils.check(
+        num_bsyms == len(input_proxies) + num_orig_bsyms,
+        lambda: f"{num_bsyms=} expected to be {len(input_proxies)=} + {num_orig_bsyms}",
+    )
     bsyms = trace.bound_symbols
     trace.bound_symbols = bsyms[-len(input_proxies) :] + bsyms[: -len(input_proxies)]
 

--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -67,7 +67,7 @@ from thunder.core.proxies import (
     unvariableify,
     is_proxy_name_available,
 )
-from thunder.core.trace import set_tracectx, reset_tracectx, tracectx, from_trace
+from thunder.core.trace import set_tracectx, reset_tracectx, tracectx, from_trace, TraceProvenance
 from thunder.core.interpreter import (
     InterpreterLogItem,
     interpret,
@@ -1677,21 +1677,28 @@ def functionalize_inplace_ops(computation_trace: TraceCtx) -> TraceCtx:
     from thunder.core.symbol import VariableInterface
     from thunder.core.symbol import variableify
 
-    swap_map: dict[VariableInterface, ProxyInterface] = {}
-    bound_symbols: list[BoundSymbol] = []
-    print(computation_trace)
+    def is_inplace(bsym: BoundSymbol) -> bool:
+        if (isinstance(bsym.sym.id, str) and bsym.sym.id.endswith("_")) and bsym.subsymbols:
+            return bsym.subsymbols[-1].sym.id == prims.PrimIDs.COPY_
+        else:
+            return False
 
+    if not any(is_inplace(bsym) for bsym in computation_trace.bound_symbols):
+        return computation_trace
+
+    # Step 1: don't return tensors who have their consumers in any way, i.e., return
+    # the tensors returned from `prims.copy_` as possible.
     bsym: BoundSymbol
-    found_copy_in_subsymbols = False
+    swap_map: dict[VariableInterface, ProxyInterface] = {}
+    bsyms: list[BoundSymbol] = []
     for bsym in computation_trace.bound_symbols:
         new_bsym = bsym.from_bsym_swap_proxies(swap_map)
 
-        # This means the symbol of bsym is in-place.
-        if not (isinstance(bsym.sym.id, str) and bsym.sym.id.endswith("_")):
-            bound_symbols.append(new_bsym)
+        # in-place ops has `prims.copy_` as the last subsymbol.
+        if not is_inplace(new_bsym):
+            bsyms.append(new_bsym)
             continue
 
-        found_copy_in_subsymbols = True
         sub_bsyms: list[BoundSymbol] = bsym.subsymbols
         utils.check(sub_bsyms, lambda: f"{bsym.sym.id=} expected to have subsymbols but {bsym.subsymbols=}")
         copy_bsym = sub_bsyms[-1]
@@ -1699,31 +1706,58 @@ def functionalize_inplace_ops(computation_trace: TraceCtx) -> TraceCtx:
             copy_bsym.sym.id == prims.PrimIDs.COPY_,
             lambda: f"bsym.subsymbols[-1] expected to be {prims.PrimIDs.COPY_} but {copy_bsym.sym.id=}",
         )
-        functional_out = copy_bsym.flat_proxy_args[0]
-        copy_dst = copy_bsym.flat_proxy_outs[0]
-        swap_map[variableify(copy_dst)] = functional_out
+        copy_out = copy_bsym.flat_proxy_outs[0]
+        copy_dst = copy_bsym.flat_proxy_args[1]
+        swap_map[variableify(copy_dst)] = copy_out
         # Remove `prims.copy_`
-        new_bsym.subsymbols = new_bsym.subsymbols[:-1]
-        new_bsym = new_bsym.from_bsym_swap_proxies(swap_map, skip_subsymbols=True)
+        new_bsym = new_bsym.from_bsym_swap_proxies(swap_map, skip_inputs=True, skip_subsymbols=True)
+        bsyms.append(new_bsym)
 
+    intermediate_trace = from_trace(computation_trace)
+    intermediate_trace.bound_symbols = bsyms[:]
+    del bsyms
+
+    # Step 2: Remove `prims.copy_` if it's the last one of `bsym.subsymbols`.
+    bsym_inplace_to_functional = {}
+    swap_map.clear()
+    new_bsyms: list[BoundSymbol] = []
+    for bsym in intermediate_trace.bound_symbols:
+        new_bsym = bsym.from_bsym_swap_proxies(swap_map)
+
+        # in-place ops has `prims.copy_` as the last subsymbol.
+        if not is_inplace(new_bsym):
+            new_bsyms.append(new_bsym)
+            continue
         functional_sym_name = new_bsym.sym.id.split(".")[-1][:-1]
         utils.check(
             hasattr(thunder.torch, functional_sym_name),
             lambda: f"{functional_sym_name}, out-of-place impl of {bsym.sym.id=} not found in `thunder.torch` namespace",
         )
+        sub_bsyms: list[BoundSymbol] = bsym.subsymbols
+        utils.check(sub_bsyms, lambda: f"{bsym.sym.id=} expected to have subsymbols but {bsym.subsymbols=}")
+        copy_bsym = sub_bsyms[-1]
+        utils.check(
+            copy_bsym.sym.id == prims.PrimIDs.COPY_,
+            lambda: f"bsym.subsymbols[-1] expected to be {prims.PrimIDs.COPY_} but {copy_bsym.sym.id=}",
+        )
+        swap_map[variableify(copy_bsym.flat_proxy_outs[0])] = copy_bsym.flat_proxy_args[0]
+        new_bsym.subsymbols = new_bsym.subsymbols[:-1]
+        new_bsym = new_bsym.from_bsym_swap_proxies(swap_map)
         functional_sym: Symbol = getattr(thunder.torch, functional_sym_name)
-        new_bsym = functional_sym.bind(
+        new_functional_bsym = functional_sym.bind(
             *new_bsym.args,
             **new_bsym.kwargs,
             output=new_bsym.output,
             subsymbols=new_bsym.subsymbols,
             _call_ctx=new_bsym._call_ctx,
         )
-        bound_symbols.append(new_bsym)
-
-    if not found_copy_in_subsymbols:
-        return computation_trace
+        new_bsyms.append(new_functional_bsym)
+        bsym_inplace_to_functional[new_bsym] = new_functional_bsym
 
     functionalized_computation_trace = from_trace(computation_trace)
-    functionalized_computation_trace.bound_symbols = bound_symbols
+    functionalized_computation_trace.bound_symbols = new_bsyms
+    functionalized_computation_trace.set_provenance(TraceProvenance("Functionalize in-place ops"))
+    # note(crcrpar): I kind of want to do the following two.
+    # functionalized_computation_trace._provenance.swap_map = swap_map
+    # functionalized_computation_trace._provenance.bsym_inplace_to_functional = bsym_inplace_to_functional
     return functionalized_computation_trace

--- a/thunder/core/langctxs.py
+++ b/thunder/core/langctxs.py
@@ -72,7 +72,7 @@ def resolve_method(id: Any, *args, **kwargs) -> None | Callable:
         # ctx.get_method throws an AttributeError when the context does not have the requested attribute, except
         # for the prims language context, which always throws a ValueError
         method: Callable = ctx.get_method(id, *args, **kwargs)
-    except (AttributeError, ValueError) as e:
+    except (AttributeError, ValueError):
         return None
     return method
 

--- a/thunder/core/proxies.py
+++ b/thunder/core/proxies.py
@@ -1349,6 +1349,13 @@ class TensorProxy(Proxy, TensorProxyInterface):
         method = resolve_method("add", self, other)
         return method(self, other)
 
+    def __iadd__(self, other):
+        return self.add_(other)
+
+    def add_(self, other):
+        method = resolve_method("add_", self, other)
+        return method(self, other)
+
     def __radd__(self, other):
         method = resolve_method("add", other, self)
         return method(other, self)
@@ -1385,6 +1392,13 @@ class TensorProxy(Proxy, TensorProxyInterface):
         method = resolve_method("mul", self, other)
         return method(self, other)
 
+    def __imul__(self, other):
+        return self.mul_(other)
+
+    def mul_(self, other):
+        method = resolve_method("mul_", self, other)
+        return method(self, other)
+
     def __rmul__(self, other):
         method = resolve_method("mul", other, self)
         return method(other, self)
@@ -1393,12 +1407,26 @@ class TensorProxy(Proxy, TensorProxyInterface):
         method = resolve_method("pow", self, other)
         return method(self, other)
 
+    def __ipow__(self, other):
+        return self.pow_(other)
+
+    def pow_(self, other):
+        method = resolve_method("pow_", self, other)
+        return method(self, other)
+
     def __rpow__(self, other):
         method = resolve_method("pow", other, self)
         return method(other, self)
 
     def __sub__(self, other):
         method = resolve_method("sub", self, other)
+        return method(self, other)
+
+    def __isub__(self, other):
+        return self.sub_(other)
+
+    def sub_(self, other):
+        method = resolve_method("sub_", self, other)
         return method(self, other)
 
     def __rsub__(self, other):
@@ -1412,6 +1440,13 @@ class TensorProxy(Proxy, TensorProxyInterface):
     def __rtruediv__(self, other):
         method = resolve_method("true_divide", other, self)
         return method(other, self)
+
+    def __itruediv__(self, other):
+        return self.div_(other)
+
+    def div_(self, other):
+        method = resolve_method("div_", self, other)
+        return method(self, other)
 
     #
     # Logical operations

--- a/thunder/tests/test_core.py
+++ b/thunder/tests/test_core.py
@@ -2121,7 +2121,8 @@ def test_inplace(executor, device, _):
 
     for t in tests:
         cfn = thunder.jit(t)
-        with pytest.raises(RuntimeError, match="not supported"):
+        # Some ops of `tests` already have in-place supported, leading to broadcast error
+        with pytest.raises(RuntimeError, match="not supported|Attempting"):
             cfn(t1, t2)
         # Note: Python maps inplace operations on (immutuables) to
         #       out of place operations, NumberProxy does this, too.

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -1507,6 +1507,17 @@ def add(
     return clang.add(a, b)
 
 
+@torchsymbol(torch.Tensor.add_, is_method=True)
+def add_(
+    a: TensorLike,
+    b: NumberLike | TensorLike,
+    /,
+    *,
+    alpha: None | Number | TensorLike = None,
+) -> TensorLike:
+    return prims.copy_(add(a, b, alpha=alpha), a)
+
+
 @torchsymbol(torch.atan2, is_method=True)
 def atan2(a, b, /):
     return clang.atan2(a, b)
@@ -1552,6 +1563,22 @@ def div(
         return floor_divide(a, b)
     else:
         raise ValueError(f"div does not support the rounding_mode={rounding_mode} argument")
+
+
+@torchsymbol(torch.Tensor.div_, is_method=True)
+def div_(
+    a: TensorLike,
+    b: Number | TensorLike,
+    /,
+    *,
+    rounding_mode: None | str = None,
+) -> TensorLike:
+    utils.check(
+        rounding_mode is None,
+        lambda: f"Invalid {rounding_mode=}, `None` i.e. true is only supported",
+    )
+
+    return prims.copy_(div(a, b), a)
 
 
 @torchsymbol(torch.eq, is_method=True)
@@ -1621,6 +1648,11 @@ def mul(a, b, /):
     return clang.mul(a, b)
 
 
+@torchsymbol(torch.Tensor.mul_, is_method=True)
+def mul_(a, b, /):
+    return prims.copy_(mul(a, b), a)
+
+
 @torchsymbol(torch.ne, is_method=True)
 def ne(a, b, /):
     return clang.ne(a, b)
@@ -1654,6 +1686,11 @@ def pow(a, b, /):
     return clang.pow(a, b)
 
 
+@torchsymbol(torch.Tensor.pow_, is_method=True)
+def pow_(a, b, /):
+    return prims.copy_(pow(a, b), a)
+
+
 @torchsymbol(torch.remainder, is_method=True)
 def remainder(a, b, /):
     return clang.remainder(a, b)
@@ -1665,6 +1702,11 @@ def sub(a, b, /, *, alpha=None):
         b = b * alpha
 
     return clang.sub(a, b)
+
+
+@torchsymbol(torch.Tensor.sub_, is_method=True)
+def sub_(a, b, /, *, alpha=None):
+    return prims.copy_(sub(a, b, alpha=alpha), a)
 
 
 @torchsymbol(torch.true_divide, is_method=True)


### PR DESCRIPTION
note that nvfuser executor does not work for this impl:
```
import torch
from thunder.executors.torchex import no_autocast

@torch.no_grad()
@no_autocast
def computation(a, b):
  # a: "cuda:0 f32[2, 2]"
  # b: "cuda:0 f32[2, 2]"
  [c, d] = nvFusion0(a, b)
    # c = prims.exp(a)  # c: "cuda:0 f32[2, 2]"
    # d = prims.tanh(b)  # d: "cuda:0 f32[2, 2]"
    # t2 = prims.add(c, d)  # t2: "cuda:0 f32[2, 2]"
    # t6 = prims.sub(t5, b)  # t6: "cuda:0 f32[2, 2]"
    # prims.copy_(t2, c)
    # prims.copy_(t6, d)
  del a, b
  return (c, d)
Traceback (most recent call last):
  File "/home/mkozuki/ghq/github.com/Lightning-AI/lightning-thunder/snipet.py", line 28, in <module>
    main()
  File "/home/mkozuki/ghq/github.com/Lightning-AI/lightning-thunder/snipet.py", line 19, in main
    c, d = jit_f(a, b)
  File "/home/mkozuki/ghq/github.com/Lightning-AI/lightning-thunder/thunder/__init__.py", line 662, in fn_
    result = cache_entry.computation_fn(*inps)
  File "/home/mkozuki/ghq/github.com/crcrpar/pytorch/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/home/mkozuki/ghq/github.com/crcrpar/pytorch/torch/amp/autocast_mode.py", line 16, in decorate_autocast
    return func(*args, **kwargs)
  File "/home/mkozuki/ghq/github.com/crcrpar/pytorch/torch/amp/autocast_mode.py", line 16, in decorate_autocast
    return func(*args, **kwargs)
  File "thunder.computation_1", line 10, in computation
  File "/home/mkozuki/ghq/github.com/Lightning-AI/lightning-thunder/thunder/executors/nvfuserex_impl.py", line 402, in __call__
    fd = self.get_fd(to_descriptors(args))
  File "/home/mkozuki/ghq/github.com/Lightning-AI/lightning-thunder/thunder/executors/nvfuserex_impl.py", line 512, in get_fd
    return create_fd(bsyms, input_descriptors, sorted_unique_inputs, sorted_unique_outputs)
  File "/home/mkozuki/ghq/github.com/Lightning-AI/lightning-thunder/thunder/executors/nvfuserex_impl.py", line 274, in create_fd
    translate_bound_symbol(bsym)
  File "/home/mkozuki/ghq/github.com/Lightning-AI/lightning-thunder/thunder/executors/nvfuserex_impl.py", line 264, in translate_bound_symbol
    nvresults = translator(*bsym.args, **bsym.kwargs, fd=fd, lc_to_nv_map=lc_to_nv_map)
  File "/home/mkozuki/ghq/github.com/Lightning-AI/lightning-thunder/thunder/executors/nvfuserex_impl.py", line 1842, in sub
    nva = getnv(a, fd, lc_to_nv_map)
  File "/home/mkozuki/ghq/github.com/Lightning-AI/lightning-thunder/thunder/executors/nvfuserex_impl.py", line 116, in getnv
    return lc_to_nv_map[x]
  File "/home/mkozuki/ghq/github.com/Lightning-AI/lightning-thunder/thunder/core/utils.py", line 919, in __getitem__
    return self._dict[key_]
KeyError: 't5'
```

torch executor only can generate the following trace:
```python
# Constructed by Delete Last Used (took 0 milliseconds)
import torch
from thunder.executors.torchex import no_autocast

@torch.no_grad()
@no_autocast
def computation(a, b):
  # a: "cuda:0 f32[2, 2]"
  # b: "cuda:0 f32[2, 2]"
  c = torch.exp(a)  # c: "cuda:0 f32[2, 2]"
    # c = ltorch.exp(a)  # c: "cuda:0 f32[2, 2]"
      # c = prims.exp(a)  # c: "cuda:0 f32[2, 2]"
  d = torch.tanh(b)  # d: "cuda:0 f32[2, 2]"
    # d = ltorch.tanh(b)  # d: "cuda:0 f32[2, 2]"
      # d = prims.tanh(b)  # d: "cuda:0 f32[2, 2]"
  t2 = torch.add(c, d)  # t2: "cuda:0 f32[2, 2]"
    # t2 = ltorch.add(c, d, alpha=None)  # t2: "cuda:0 f32[2, 2]"
      # t2 = prims.add(c, d)  # t2: "cuda:0 f32[2, 2]"
  t4 = torch.div(d, a)  # t4: "cuda:0 f32[2, 2]"
    # t4 = ltorch.div(d, a, rounding_mode=None, out=None)  # t4: "cuda:0 f32[2, 2]"
      # t4 = ltorch.true_divide(d, a)  # t4: "cuda:0 f32[2, 2]"
        # t4 = prims.div(d, a)  # t4: "cuda:0 f32[2, 2]"
  del a
  t6 = torch.sub(t4, b)  # t6: "cuda:0 f32[2, 2]"
    # t6 = ltorch.sub(t4, b, alpha=None)  # t6: "cuda:0 f32[2, 2]"
      # t6 = prims.sub(t4, b)  # t6: "cuda:0 f32[2, 2]"
  del t4, b
  copy_(t2, c)
  del t2
  copy_(t6, d)
  del t6
  return (c, d)
```

the used snippet is:
```python
import torch
import thunder

def f(a: torch.Tensor, b: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
    c = torch.exp(a)
    d = torch.tanh(b)
    c += d

    d.div_(a)
    d.sub_(b)
    return c, d

def main():
    a, b = [torch.randn((2, 2), device="cuda", requires_grad=False) for _ in range(2)]
    a_, b_ = a.clone().detach(), b.clone().detach()
    jit_f = thunder.jit(f)  #, executors=[thunder.executors.get_torch_executor()])
    c, d = jit_f(a, b)
    c_, d_ = f(a_, b_)
    print(thunder.last_traces(jit_f)[-1])

    torch.testing.assert_close(c, c_)
    torch.testing.assert_close(d, d_)

if __name__ == "__main__":
    main()
```