### PR TITLE
Remove  _create_callable usage

### DIFF
--- a/thunder/common.py
+++ b/thunder/common.py
@@ -703,11 +703,10 @@ def _execute_trace(
 def _create_callable(
     cd: CompileData,
     cs: CompileStats,
-    *,
-    transforms: list[Callable] = [],
-    post_optimization_transforms: list[Callable] = [],
-    _using_grad_transform: bool = False,
 ) -> Callable:
+    transforms = []
+    post_optimization_transforms = []
+    _using_grad_transform = False
     @wraps(cd.fn)
     def _fn(*args, **kwargs) -> tuple[Any, list[TraceCtx]]:
         cs.last_trace_host_start = time.time_ns()

--- a/thunder/common.py
+++ b/thunder/common.py
@@ -648,9 +648,8 @@ def transform_for_execution(
     return traces
 
 
-# Executes the trace with the given args and kwargs and returns the result,
-#   the callable executed, and the series of traces constructed to produce
-#   that callable from the trace
+# NOTE: Do not use this function and do not update it.
+# Use `thunder.jit` instead.
 def _execute_trace(
     trc: TraceCtx,
     *,
@@ -700,6 +699,8 @@ def _execute_trace(
 #   a helper to convert torch tensors to NumPy arrays on output?
 
 
+# NOTE: Do not use this function and do not update it.
+# Use `thunder.jit` instead.
 def _create_callable(
     cd: CompileData,
     cs: CompileStats,

--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -405,7 +405,7 @@ def add_transform(
     early_transform: EarlyTransform | None = None,
     disable_torch_autograd_support=False,
 ) -> Callable:
-    from thunder.common import _create_callable, CompileData, CompileStats
+    from thunder.common import CompileData
 
     cd: None | Any = getattr(cfn, "_lc_cd", None)
 
@@ -445,28 +445,13 @@ def add_transform(
             jfn._overrides_buffers = cfn._overrides_buffers
         return jfn
 
-    cs = getattr(cfn, "_lc_cs", None)
-    if cs is None:
-        cs = CompileStats()
-
-    transforms = cfn._lc_transforms + [transform]
-    potransforms = cfn._lc_post_optimization_transforms
-    using_grad_transform = cfn._using_grad_transform
-
-    ncfn = _create_callable(
-        cd,
-        cs,
-        transforms=transforms,
-        post_optimization_transforms=potransforms,
-        _using_grad_transform=using_grad_transform,
-    )
-    return ncfn
+    raise NotImplementedError("Using the non-jit functions was an experiment that is no longer supported.")
 
 
 # TODO Consider refactoring this with the above
 # Helper function to add a post-optimization transform
 def add_post_optimization_transform(cfn: Callable, transform: PostOptimizationTransform) -> Callable:
-    from thunder.common import _create_callable, CompileData, CompileStats
+    from thunder.common import CompileData
 
     cd: None | Any = getattr(cfn, "_lc_cd", None)
 
@@ -498,12 +483,7 @@ def add_post_optimization_transform(cfn: Callable, transform: PostOptimizationTr
             jfn._overrides_buffers = cfn._overrides_buffers
         return jfn
 
-    cs = CompileStats()
-    transforms = cfn._lc_transforms
-    potransforms = cfn._lc_post_optimization_transforms + [transform]
-
-    ncfn = _create_callable(cd, cs, transforms=transforms, post_optimization_transforms=potransforms)
-    return ncfn
+    raise NotImplementedError("Using the non-jit functions was an experiment that is no longer supported.")
 
 
 # The no-op transform. A trivial composable transform, only useful as an example.


### PR DESCRIPTION
Cleaning up usage of old function that is now used only for soft-deprecated `thunder.compile`.