### PR TITLE
Restore usage of CUDAGraphExecutor with compiled backward function

### DIFF
--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -621,6 +621,8 @@ def jit(
             # See https://github.com/Lightning-AI/lightning-thunder/issues/433
             if cd.use_cudagraphs:
                 comp = CUDAGraphExecutor(comp)
+                if backward_fn is not None:
+                    backward_fn = CUDAGraphExecutor(backward_fn, num_constant_args=len(backward_trc.args[0][0]))
 
             # TODO RC1 Update the cache
             cache_entry = CacheEntry(

--- a/thunder/executors/torch_autograd.py
+++ b/thunder/executors/torch_autograd.py
@@ -10,6 +10,7 @@ from thunder.core.pytree import tree_flatten
 from thunder.core.symbol import BoundSymbol
 from thunder.core.trace import TraceCtx, from_trace, set_tracectx, reset_tracectx
 from thunder.core.transform_common import replace_redundant_inputs
+from thunder.cudagraphs import CUDAGraphExecutor
 
 if TYPE_CHECKING:
     from thunder.core.trace import VariableInterface
@@ -93,6 +94,9 @@ class ThunderFunction(torch.autograd.Function):
         # reference to the saved tensors in the context
         ctx.maybe_clear_saved_tensors()  # Delete the reference to all saved tensors in the context
         grads = ctx.compiled_backward([saved_tensors_list, ctx.saved_other], args)
+
+        if isinstance(ctx.compiled_backward, CUDAGraphExecutor):
+            saved_tensors_list.clear()
 
         # Inside the compiled backward we must clear the saved_tensors_list
         assert not saved_tensors_list, "saved_tensors_list must be empty after calling compiled_backward"


### PR DESCRIPTION
We had CUDA Graphs being applied to the backward function before (here's a snapshot from Feb):
https://github.com/Lightning-AI/lightning-thunder/blob/91a45a84f322a029f6fa536371789dcd277dec52/thunder/executors/torch_autograd.py#L169-L174
and this PR restores this functionality. The test already exists:
https://github.com/Lightning-AI/lightning-thunder/blob/6bc5752373c085a284413d84f420371212a9b996/thunder/tests/test_networks.py#L97