### PR TITLE
Add torch.max

### DIFF
--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -1364,10 +1364,11 @@ def _maximum_grad(a: TensorProxy, b: TensorProxy, /):
     g = get_grad(fwd)
 
     # Compute sub-gradient if `a == b`
-    a_grad = prims.where(a == b, g / 2, 0.0)
-    b_grad = prims.where(a == b, g / 2, 0.0)
-    a_grad = prims.where(a > b, g, a_grad)
-    b_grad = prims.where(b > a, g, b_grad)
+    # NOTE: We evenly distribute the gradient where the values are equal.
+    vals_equal_grad = prims.where(a == b, g / 2, 0.0)
+
+    a_grad = prims.where(a > b, g, vals_equal_grad)
+    b_grad = prims.where(b > a, g, vals_equal_grad)
 
     put_grad(a, a_grad)
     put_grad(b, b_grad)

--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -1357,6 +1357,27 @@ def _embedding_prim_grad(
 
 register_grad(pids.EMBEDDING, _embedding_prim_grad)
 
+
+def _maximum_grad(a: TensorProxy, b: TensorProxy, /):
+    fwd = prims.maximum(a, b)
+
+    g = get_grad(fwd)
+
+    a_grad = prims.where(a == b, g / 2, 0.0)
+    b_grad = prims.where(a == b, g / 2, 0.0)
+    a_grad = prims.where(a > b, g, a_grad)
+    b_grad = prims.where(b > a, g, b_grad)
+
+    put_grad(a, a_grad)
+    put_grad(b, b_grad)
+    return fwd
+
+
+register_grad(pids.MAXIMUM, _maximum_grad)
+
+# This operation creates no grad associations
+register_grad(pids.ARGMAX, prims.argmax)
+
 #
 # Phantom grad transform helpers
 #

--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -1365,7 +1365,7 @@ def _maximum_grad(a: TensorProxy, b: TensorProxy, /):
 
     # Compute sub-gradient if `a == b`
     # NOTE: We evenly distribute the gradient where the values are equal.
-    vals_equal_grad = prims.where(a == b, g / 2, 0.0)
+    vals_equal_grad = prims.where(a == b, g / 2, g)
 
     a_grad = prims.where(a > b, g, vals_equal_grad)
     b_grad = prims.where(b > a, g, vals_equal_grad)

--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -1363,12 +1363,22 @@ def _maximum_grad(a: TensorProxy, b: TensorProxy, /):
 
     g = get_grad(fwd)
 
+    # NOTE: NaN propagation if either `a` or `b` is a NaN, then both elements receive `g` as gradient.
+    # This is because comparison in presence of NaN is False (except for Not Equal which is always True).
+    # Eg. Here `a` = NaN and `b` = 42
+    # sub_g = where(NaN == 42 i.e. False, g / 2, g)  # sub_grad = g
+    # grad_a = where(NaN < 42 i.e. False, 0., sub_g)  # grad_a = sub_g = g
+    # grad_b = where(42 < NaN i.e. False, 0., sub_g)  # grad_b = sub_g = g
+    # NOTE: If `g` is `NaN` then it will be propagated as the gradient of max element between a and b
+    # and if both are equal, then as we evenly distributing the gradients, `NaN` will propagate through
+    # the gradients of both `a` and `b`.
+
     # Compute sub-gradient if `a == b`
     # NOTE: We evenly distribute the gradient where the values are equal.
-    vals_equal_grad = prims.where(a == b, g / 2, g)
+    sub_grad = prims.where(a == b, g / 2, g)
 
-    a_grad = prims.where(a > b, g, vals_equal_grad)
-    b_grad = prims.where(b > a, g, vals_equal_grad)
+    a_grad = prims.where(a < b, 0.0, sub_grad)
+    b_grad = prims.where(b < a, 0.0, sub_grad)
 
     put_grad(a, a_grad)
     put_grad(b, b_grad)

--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -1363,6 +1363,7 @@ def _maximum_grad(a: TensorProxy, b: TensorProxy, /):
 
     g = get_grad(fwd)
 
+    # Compute sub-gradient if `a == b`
     a_grad = prims.where(a == b, g / 2, 0.0)
     b_grad = prims.where(a == b, g / 2, 0.0)
     a_grad = prims.where(a > b, g, a_grad)

--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -5016,10 +5016,21 @@ def max_sample_generator(op, device, dtype, requires_grad, **kwargs):
             yield SampleInput(make(shape), dim, keepdim)
 
 
+def max_error_generator(op, device, **kwargs):
+    make = partial(make_tensor, device=device, dtype=torch.float, low=-1000, high=1000)
+
+    err_msg = r"keepdim=True is invalid for torch.max\(a, b\) overload."
+    yield (SampleInput(make(3, 3), make(3, 3), keepdim=True), RuntimeError, err_msg)
+
+    err_msg = r"keepdim=True is invalid for torch.max\(a\) overload."
+    yield (SampleInput(make(3, 3), keepdim=True), RuntimeError, err_msg)
+
+
 max_opinfo = OpInfo(
     ltorch.torch_max,
     supports_grad=True,
     sample_input_generator=max_sample_generator,
+    error_input_generator=max_error_generator,
     torch_reference=torch.max,
     # Complex numbers are unordered
     dtypes=(datatypes.exact, datatypes.floating),

--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -2094,6 +2094,7 @@ maximum_opinfo = OpInfo(
     clang.maximum,
     sample_input_generator=partial(elementwise_binary_generator, no_rhs_numbers=True),
     torch_reference=torch.maximum,
+    supports_grad=True,
 )
 elementwise_binary_ops.append(maximum_opinfo)
 
@@ -5003,10 +5004,15 @@ def max_sample_generator(op, device, dtype, requires_grad, **kwargs):
     )
 
     for shape, dim, keepdim in cases:
+        # overload: torch_max(a: TensorLike, /) -> TensorLike
         yield SampleInput(make(shape))
+
+        # overload: torch_max(a: TensorLike, b: TensorLike, /) -> TensorLike
         yield SampleInput(make(shape), make(shape))
 
         if not (dtype is torch.bool):  # argmax is not supported on `bool`
+            # overload: torch_max(a: TensorLike, /, dim: int | tuple[int], keepdim: bool = False) -> TensorLike, TensorLike
+            yield SampleInput(make(shape), dim)
             yield SampleInput(make(shape), dim, keepdim)
 
 

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -2063,7 +2063,9 @@ def torch_max(
     a, /, dim: NumberLike | TensorLike | None = None, keepdim: bool = False
 ) -> TensorLike | tuple[TensorLike, TensorLike]:
     utils.check_type(dim, (NumberLike, TensorLike, NoneType))
-    utils.check_type(keepdim, bool)
+    utils.check_type(
+        keepdim, (bool, IntegerProxy)
+    )  # `keepdim` can be a [IntegerProxy (bool type) name=keepdim, value=False]
     if isinstance(dim, TensorLike):
         # overload - torch_max(a: TensorLike, b: TensorLike, /) -> TensorLike
         utils.check(not keepdim, lambda: "keepdim=True is invalid for torch.max(a, b) overload.")

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -7,7 +7,7 @@ from collections.abc import Sequence
 from enum import Enum
 from functools import partial, reduce, wraps
 from numbers import Number
-from typing import Any, overload, Optional, Union
+from typing import Any, overload
 from types import NoneType
 from collections.abc import Callable
 
@@ -2045,6 +2045,7 @@ def amin(a, /, dim=None, keepdim: bool = False):
     )
 
 
+# NOTE: Using name `torch_max` to avoid conflict with Python's `max`
 @overload
 def torch_max(a: TensorLike, /) -> TensorLike: ...
 

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -2068,17 +2068,21 @@ def torch_max(
     )  # `keepdim` can be a [IntegerProxy (bool type) name=keepdim, value=False]
     if isinstance(dim, TensorLike):
         # overload - torch_max(a: TensorLike, b: TensorLike, /) -> TensorLike
+        # This overload corresponds to taking the elementwise max between tensors `a` and `b`.
         utils.check(not keepdim, lambda: "keepdim=True is invalid for torch.max(a, b) overload.")
         b = dim
         return maximum(a, b)
 
     if dim is None:
         # overload - torch_max(a: TensorLike, /) -> TensorLike
+        # This overload corresponds to taking the max over the flattened tensor.
         utils.check(not keepdim, lambda: "keepdim=True is invalid for torch.max(a) overload.")
         dim = list(range(a.ndim))
         return amax(a, dim, keepdim)
 
     # overload - torch_max(a: TensorLike, /, dim: int | tuple[int], keepdim: bool = False) -> TensorLike, TensorLike
+    # This overload corresponds to taking the max along the specified dimension `dim`.
+    # NOTE: It returns first occurence of the maximum value along the dimension and it's corresponding index.
     utils.check_type(dim, NumberLike)
     max_vals = amax(a, dim, keepdim)
     argmax_vals = argmax(a, dim, keepdim)


### PR DESCRIPTION
Fixes: https://github.com/Lightning-AI/lightning-thunder/issues/338

`torch.max` is an interesting operator with multiple overloads and different return types based on the overload.
Ref: https://pytorch.org/docs/stable/generated/torch.max.html

In this PR, we implement `torch.max` as decomposition of `amax`, `argmax` and `maximum` depending on the input.

Also, we add grad formula for `maximum` and also `argmax` (which is no gradients for input).

**Problem**: However, using `amax` leads to a difference in gradient computation.

As noted in the PyTorch [docs](https://pytorch.org/docs/stable/generated/torch.amax.html), 
> amax/amin evenly distributes gradient between equal values, while max(dim)/min(dim) propagates gradient only to a single index in the source tensor.

I am planning to tackle this seperately in a follow-up but wanted to know if we should add a new primitive or if there are other ways around the same.

If this PR looks good, will also follow-up with `torch.min`  (and relevant updates) seperately.