### PR TITLE
Add a transform to add nvtx range on the optimized trace

### DIFF
--- a/thunder/dev_utils/nvtx_profile_transform.py
+++ b/thunder/dev_utils/nvtx_profile_transform.py
@@ -1,0 +1,99 @@
+from thunder.core.trace import TraceCtx as Trace, from_trace, TraceProvenance
+from thunder.core.prims import PrimIDs
+from thunder.extend import OperatorExecutor
+import time
+import torch
+import thunder
+
+
+class Timer:
+    def __init__(self):
+        self.start_time_ns = None
+        self.end_time_ns = None
+
+    def __enter__(self):
+        self.start_time_ns = time.time_ns()
+        return self
+
+    def __exit__(self, *args):
+        self.end_time_ns = time.time_ns()
+
+    def get_elapsed_time_in_ms(self):
+        elapsed_time_ns = self.end_time_ns - self.start_time_ns
+        return elapsed_time_ns // int(1e6)
+
+
+nvtx_profiler_ex = OperatorExecutor("nvtx_profiler_ex")
+
+
+def nvtx_push_impl(msg):
+    torch.cuda.nvtx.range_push(msg)
+
+
+def nvtx_pop_impl():
+    torch.cuda.nvtx.range_pop()
+
+
+# Symbols for profiling.
+nvtx_push = nvtx_profiler_ex.register_operator("nvtx_range_push", meta=lambda msg: None, fn=nvtx_push_impl)
+nvtx_pop = nvtx_profiler_ex.register_operator("nvtx_range_pop", meta=lambda: None, fn=nvtx_pop_impl)
+
+NON_COMPUTATION_PRIMS = (
+    PrimIDs.ASSERT_TENSOR_METADATA,
+    PrimIDs.CHECK_TENSOR_SHAPE_AND_METADATA,
+    PrimIDs.CHECK_NONE,
+    PrimIDs.CHECK_EMPTY,
+    PrimIDs.CHECK_LITERAL_LIKE,
+    PrimIDs.CHECK_TYPE,
+    PrimIDs.CHECK_INSTANCE,
+    PrimIDs.CHECK_NUMBER_TYPE_AND_VALUE,
+    PrimIDs.CHECK_BOOL_CONVERSION,
+    PrimIDs.CHECK_STRING_VALUE,
+    PrimIDs.CHECK_LEN,
+    PrimIDs.ASSERT_COMPARE,
+    PrimIDs.PYTHON_VARS,
+    PrimIDs.UNPACK_FUNCTION_OBJ,
+    PrimIDs.UNPACK_CACHE_INFO,
+    PrimIDs.UNPACK_ATTR,
+    PrimIDs.UNPACK_GETITEM,
+    PrimIDs.UNPACK_EMPTY_DICT,
+    PrimIDs.UNPACK_ITER,
+    PrimIDs.UNPACK_NEXT,
+    PrimIDs.UNPACK_KEY,
+    PrimIDs.UNPACK_SEQUENCE,
+    PrimIDs.UNPACK_TRIVIAL,
+    PrimIDs.UNPACK_TUPLE,
+    PrimIDs.UNPACK_LIST,
+    PrimIDs.UNPACK_DICT_KEY,
+    PrimIDs.CONSTRUCT_TUPLE,
+    PrimIDs.PACK_SETITEM,
+    # TODO: UNPACK_SET
+    # Utility prims
+    PrimIDs.COMMENT,
+    PrimIDs.DEL,
+    PrimIDs.PRINT,
+    PrimIDs.RETURN,
+)
+
+
+class NvtxProfileTransform(thunder.core.transforms.PostOptimizationTransform):
+    def transform_trace(self, trace: Trace, **kwargs) -> Trace:
+        with Timer() as timer:
+            profile_trace = from_trace(trace)
+
+            for bound_symbol in trace.bound_symbols:
+                if bound_symbol.sym.id in NON_COMPUTATION_PRIMS:
+                    profile_trace.bound_symbols.append(bound_symbol)
+                    continue
+
+                # Add nvtx range for the symbol.
+                profile_trace.bound_symbols.append(
+                    nvtx_push.bind(f"{''.join(bound_symbol.python(indent=0))}", output=None)
+                )
+                profile_trace.bound_symbols.append(bound_symbol)
+                profile_trace.bound_symbols.append(nvtx_pop.bind(output=None))
+
+        profile_trace.set_provenance(
+            TraceProvenance(f"NVTX Profile Transform (took {timer.get_elapsed_time_in_ms()} milliseconds)")
+        )
+        return profile_trace

--- a/thunder/tests/test_transforms.py
+++ b/thunder/tests/test_transforms.py
@@ -1,0 +1,66 @@
+import thunder
+from thunder.dev_utils.nvtx_profile_transform import NvtxProfileTransform, nvtx_push, nvtx_pop
+
+import torch
+
+
+def test_nvtx_transform():
+    DIM = 2
+
+    class Model(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.fc1 = torch.nn.Linear(DIM, DIM)
+            self.fc2 = torch.nn.Linear(DIM, DIM)
+
+        def forward(self, x):
+            x = self.fc1(x)
+            x = torch.nn.functional.relu(x)
+            x = self.fc2(x)
+            return x
+
+    model = Model()
+    x = torch.randn(4, DIM)
+
+    # Transform for profiling with NVTX markers.
+    # This transform adds NVTX markers to all the computation symbols in the execution trace.
+
+    nvtx_profile_transform = NvtxProfileTransform()
+
+    jmodel = thunder.jit(
+        model,
+        post_optimization_transforms=[
+            nvtx_profile_transform,
+        ],
+    )
+    o = jmodel(x)
+    o.sum().backward()
+
+    fwd_trc = thunder.last_traces(jmodel)[-1]
+    bwd_trc = thunder.last_backward_traces(jmodel)[-1]
+
+    def _test_equal_nvtx_push_and_pop(trc):
+        # This test verifies that we see equal number of `nvtx_push` and `nvtx_pop` symbols
+        # and also order is `nvtx_push` followed by `nvtx_pop`
+
+        # First NVTX symbol will always be push.
+        EXPECT_PUSH = True
+        push_cnt = 0
+        pop_cnt = 0
+        for bsym in trc.bound_symbols:
+            if bsym.sym.id in (nvtx_push.id, nvtx_pop.id):
+                if EXPECT_PUSH:
+                    assert bsym.sym.id == nvtx_push.id
+                    push_cnt += 1
+                    # After `nvtx_push` we expect next the `nvtx` symbol to be `nvtx_pop`
+                    EXPECT_PUSH = False
+                else:
+                    assert bsym.sym.id == nvtx_pop.id
+                    pop_cnt += 1
+                    # After `nvtx_pop` we expect next the `nvtx` symbol to be `nvtx_push`
+                    EXPECT_PUSH = True
+
+        assert push_cnt == pop_cnt
+
+    _test_equal_nvtx_push_and_pop(fwd_trc)
+    _test_equal_nvtx_push_and_pop(bwd_trc)

--- a/thunder/tests/test_transforms.py
+++ b/thunder/tests/test_transforms.py
@@ -1,9 +1,11 @@
-import thunder
-from thunder.dev_utils.nvtx_profile_transform import NvtxProfileTransform, nvtx_push, nvtx_pop
-
 import torch
 
+import thunder
+from thunder.dev_utils.nvtx_profile_transform import NvtxProfileTransform, nvtx_push, nvtx_pop
+from thunder.tests.framework import requiresCUDA
 
+
+@requiresCUDA
 def test_nvtx_transform():
     DIM = 2
 


### PR DESCRIPTION
This PR adds a post optimization transform to wrap compute symbols in `NVTX` range. This makes it easy to profile the trace with `Nsight Systems` and to easily map trace operations to GPU execution timeline.

For Future, we should allow user to:
1. specify selective operations from trace to profile.
2. specify regions of the trace to profile.


Usage
```python
import os
import torch
import torch.distributed as tdist
import thunder
import thunder.distributed
from thunder.tests.litgpt_model import GPT, Config
from thunder.dev_utils.nvtx_profile_transform import NvtxProfileTransform

if __name__ == "__main__":
    tdist.init_process_group(backend="nccl")
    LOCAL_RANK = int(os.environ["LOCAL_RANK"])
    device = torch.device("cuda", LOCAL_RANK)
    torch.set_default_device(device)

    config = Config.from_name("open_llama_3b")
    config.n_layer = 2
    with device:
        model = GPT(config)

    nvtx_profile_transform = NvtxProfileTransform()
    model = thunder.distributed.fsdp(thunder.jit(model, post_optimization_transforms=[nvtx_profile_transform]))

    input_ids = torch.randint(1, 30010, (128, 256), dtype=torch.long, device=device)

    if LOCAL_RANK == 0:
        torch.cuda.cudart().cudaProfilerStart()
    logits = model(input_ids)
    logits.sum().backward()

    if LOCAL_RANK == 0:
        torch.cuda.cudart().cudaProfilerStop()


```

Example of the transformed trace (for brevity, generated from a different script than above):
```python
# Constructed by NVTX Profile Transform (took 0 milliseconds)
import torch
import torch.nn.functional
from thunder.executors.torchex import no_autocast

@torch.no_grad()
@no_autocast
def augmented_forward_fn(x, t_fc1_bias, t_fc1_weight, t_fc2_bias, t_fc2_weight):
  # x: "cuda:0 f32[4, 4096, 4096]"
  # t_fc1_bias: "cuda:0 f32[4096]"
  # t_fc1_weight: "cuda:0 f32[4096, 4096]"
  # t_fc2_bias: "cuda:0 f32[4096]"
  # t_fc2_weight: "cuda:0 f32[4096, 4096]"
  nvtx_range_push('t0 = torch.nn.functional.linear(x, t_fc1_weight, t_fc1_bias)  # t0: "cuda:0 f32[4, 4096, 4096]"')
  t0 = torch.nn.functional.linear(x, t_fc1_weight, t_fc1_bias)  # t0: "cuda:0 f32[4, 4096, 4096]"
    # t0 = ltorch.linear(x, t_fc1_weight, t_fc1_bias)  # t0: "cuda:0 f32[4, 4096, 4096]"
      # t0 = prims.linear(x, t_fc1_weight, t_fc1_bias)  # t0: "cuda:0 f32[4, 4096, 4096]"
  nvtx_range_pop()
  nvtx_range_push('[t1, t2] = nvFusion0(t0)')
  [t1, t2] = nvFusion0(t0)
    # t1 = prims.gt(t0, 0.0)  # t1: "cuda:0 b8[4, 4096, 4096]"
    # t2 = prims.where(t1, t0, 0.0)  # t2: "cuda:0 f32[4, 4096, 4096]"
  nvtx_range_pop()
  del t0
  nvtx_range_push('t3 = torch.nn.functional.linear(t2, t_fc2_weight, t_fc2_bias)  # t3: "cuda:0 f32[4, 4096, 4096]"')
  t3 = torch.nn.functional.linear(t2, t_fc2_weight, t_fc2_bias)  # t3: "cuda:0 f32[4, 4096, 4096]"
    # t3 = ltorch.linear(t2, t_fc2_weight, t_fc2_bias)  # t3: "cuda:0 f32[4, 4096, 4096]"
      # t3 = prims.linear(t2, t_fc2_weight, t_fc2_bias)  # t3: "cuda:0 f32[4, 4096, 4096]"
  nvtx_range_pop()
  return {'output': t3, 'flat_args': [x, t_fc1_bias, t_fc1_weight, t_fc2_bias, t_fc2_weight], 'flat_output': (t3,)}, ((t1, t2, t_fc2_weight, x), ())
```

Example in nsight GUI
![image](https://github.com/Lightning-AI/lightning-thunder/assets/19503980/2ba5abff-a37e-44bd-9771-3c2a407cb851)


Alternative:
One alternative to this is to use [nvtx](https://nvtx.readthedocs.io/en/latest/) package with automatic annotation but this leads to a very dense (and big profile) report (with more information than required to absorb)
Eg.

![image](https://github.com/Lightning-AI/lightning-thunder/assets/19503980/fcc8ead9-2d04-4b92-8e37-3f409d4aed05)

---------
