### PR TITLE
fsdp(jit(model)) + parameter sharing - dont duplicate allgather

### DIFF
--- a/thunder/distributed/__init__.py
+++ b/thunder/distributed/__init__.py
@@ -453,6 +453,19 @@ def fsdp_transform_module(
     # Key to this dictionary is the original parameter from the user's Module.
     # Values are the copied and sharded parameter for the thunder module and meta-data related to sharding.
     shared_params = WeakTensorKeyDictionary()
+
+    # NOTE: Shared Parameters in Trace
+    # Shared parameters in PyTorch eager are parameters of module which have different name but share the underlying tensor.
+    # For shared parameter, we replace all occurence shared parameter with it's corresponding `base` parameter.
+    # In our implementation `base` parameter is the parameter and corresponding name which we see the first time while
+    # iterating our parameters (see below). We track subsequent parameter which share the underlying Tensor with this `base` parameter
+    # in `shared_params_name` dictionary.
+    # Then while, transforming the trace - `see FSDPTraceTransform.transform_traces` - we replace all the proxy of shared parameter
+    # with the corresponding proxy of base parameter in the computation trace.
+
+    # This is used to track the shared parameters when the transform is applied.
+    # key - parameter name, value - `base` parameter name.
+    shared_params_name: dict[str, str] = {}
     for module_name, _ in thunder_model._model.named_modules():
         submodule = thunder_model.get_submodule(module_name)
 
@@ -500,6 +513,8 @@ def fsdp_transform_module(
             # If there are shared params in the original user Module, we reuse the sharded copy created from the original parameter below.
             # This way we re-create parameter sharing in thunder's copy of the Module.
             if p in shared_params:
+                # Shared param names : current param - base param
+                shared_params_name[pn] = shared_params[p]["param_name"]
                 # Re-use the previous copy of this parameter.
                 thunder_model._overrides_parameters[pn] = shared_params[p]["param_copy"]
                 sharded_params[pn] = shared_params[p]["param_shard_meta"]
@@ -520,11 +535,13 @@ def fsdp_transform_module(
             shared_params[p] = {
                 "param_copy": thunder_model._overrides_parameters[pn],
                 "param_shard_meta": sharded_params[pn],
+                "param_name": pn,
             }
 
     early_transform_from_trace_to_fsdp_trace = FSDPTraceTransform(
         sharded_params=sharded_params,
         process_group=process_group,
+        shared_params_name=shared_params_name,
     )
     # add prologue + compute transform
     thunder_model = add_transform(thunder_model, early_transform=early_transform_from_trace_to_fsdp_trace)

--- a/thunder/distributed/transforms/fsdp_v2.py
+++ b/thunder/distributed/transforms/fsdp_v2.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
+from collections import defaultdict
 
 from thunder.core import devices
 from thunder.core import prims
@@ -27,6 +28,7 @@ __all__ = [
 class FSDPTraceTransform(EarlyTransform):
     sharded_params: dict[str, Any]
     process_group: ProcessGroup
+    shared_params_name: dict[str, str]
 
     def transform_traces(self, prologue_trace, computation_trace, epilogue_trace, **kwargs):
         from thunder.distributed import prims as dist_prims
@@ -49,6 +51,7 @@ class FSDPTraceTransform(EarlyTransform):
         computation_trace.push_scope([])
 
         synchronized_parameters = []
+        param_name_to_comp_trc_proxy = {}  # Track param_name to it's corresponding proxy in computation_trc.
         # todo: deal with epilogue output
         for pro_out_p, comp_inp_p in zip(prologue_trace.output, computation_trace.args):
             bsym = prologue_producers[pro_out_p]
@@ -56,6 +59,7 @@ class FSDPTraceTransform(EarlyTransform):
                 param_thunder_module, param_name = bsym.args
                 assert param_thunder_module is thunder_module_proxy
                 if param_name in self.sharded_params:
+                    param_name_to_comp_trc_proxy[param_name] = comp_inp_p
                     old_shape, new_shape, new_torch_device = self.sharded_params[param_name]
                     thunder_device = devices.to_device(new_torch_device)
                     thunder_device_str = str(thunder_device)
@@ -90,6 +94,13 @@ class FSDPTraceTransform(EarlyTransform):
                     bsym.args = (a0, shape, thunder_device_str, *a2pp)
 
         proxies_to_replace = {id(bsym.args[0]): bsym.output for bsym in new_scope}
+
+        # See NOTE: Shared Parameters in Trace
+        for param_name, base_param in self.shared_params_name.items():
+            param_proxy = param_name_to_comp_trc_proxy[param_name]
+            base_param_proxy = param_name_to_comp_trc_proxy[base_param]
+            # Replace - all usage of `param_proxy` with the output of `AllGather` on `base_param_proxy`.
+            proxies_to_replace[id(param_proxy)] = proxies_to_replace[id(base_param_proxy)]
 
         new_computation_trace = from_trace(computation_trace)
         for idx, bsym in enumerate(computation_trace.bound_symbols):

--- a/thunder/distributed/transforms/fsdp_v2.py
+++ b/thunder/distributed/transforms/fsdp_v2.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
-from collections import defaultdict
 
 from thunder.core import devices
 from thunder.core import prims

--- a/thunder/distributed/transforms/fsdp_v2.py
+++ b/thunder/distributed/transforms/fsdp_v2.py
@@ -98,8 +98,10 @@ class FSDPTraceTransform(EarlyTransform):
         for param_name, base_param in self.shared_params_name.items():
             param_proxy = param_name_to_comp_trc_proxy[param_name]
             base_param_proxy = param_name_to_comp_trc_proxy[base_param]
-            # Replace - all usage of `param_proxy` with the output of `AllGather` on `base_param_proxy`.
-            proxies_to_replace[id(param_proxy)] = proxies_to_replace[id(base_param_proxy)]
+            allgather_base_param_proxy = proxies_to_replace[id(base_param_proxy)]
+            # Update `proxies_to_replace` so we replace all usage of `param_proxy`
+            # with the output of `AllGather` on `base_param_proxy`.
+            proxies_to_replace[id(param_proxy)] = allgather_base_param_proxy
 
         new_computation_trace = from_trace(computation_trace)
         for idx, bsym in enumerate(computation_trace.bound_symbols):


### PR DESCRIPTION
Ref: https://github.com/Lightning-AI/lightning-thunder/issues/257 and https://github.com/Lightning-AI/lightning-thunder/issues/257#issuecomment-2133070264

Currently, for shared parameters - we AllGather (which creates a new tensor for its output) for each name of the shared parameter creating multiple copies during the execution. In this PR, we track the shared parameters and update the computation trace such that we only have one copy.

NOTE: This PR just handles `fsdp(jit(model))` path. Will have a look at `jit(fsdp(model))` seperately.

Eg.
```python
import os
import torch
import torch.distributed as tdist
import thunder
import thunder.distributed

if __name__ == "__main__":
    tdist.init_process_group(backend="nccl")
    LOCAL_RANK = int(os.environ["LOCAL_RANK"])
    device = torch.device("cuda", LOCAL_RANK)
    torch.set_default_device(device)

    class Model(torch.nn.Module):
        def __init__(self) -> None:
            super().__init__()
            self.fc1 = torch.nn.Linear(16, 16, bias=False)
            self.fc2 = torch.nn.Linear(16, 16, bias=False)

        def forward(self, x):
            return self.fc1(x) + self.fc2(x)

    with device:
        model = Model()

    # shared parameter
    model.fc1.weight = model.fc2.weight

    model = thunder.jit(model, executors=["torch"])
    model = thunder.distributed.fsdp(model)

    logits = model(torch.randn(4, 16, device=device))

    if LOCAL_RANK == 0:
        # print(torch.cuda.max_memory_allocated())
        pro_trace = thunder.last_prologue_traces(model)[-1]
        with open("weight_sharing_trace_pro.py", 'w') as f:
            f.write(str(pro_trace))
        trace = thunder.last_traces(model)[-1]
        with open("weight_sharing_trace.py", 'w') as f:
            f.write(str(trace))
        bwd_trace = thunder.last_backward_traces(model)[-1]
        with open("weight_sharing_bwd_trace.py", 'w') as f:
            f.write(str(bwd_trace))

```

Computation Trace (Before PR)
```python
# Constructed by Delete Last Used (took 0 milliseconds)
import torch
import torch.nn.functional
from thunder.executors.torchex import no_autocast

@torch.no_grad()
@no_autocast
def augmented_forward_fn(x, t_fc1_weight, t_fc2_weight):
  # x: "cuda:0 f32[4, 16]"
  # t_fc1_weight: "cuda:0 f32[8, 16]"
  # t_fc2_weight: "cuda:0 f32[8, 16]"
  p0 = torch_all_gather_prim_impl(t_fc1_weight, _torch_distributed_distributed_c10d_ProcessGroup_0, True, None)  # p0: "FUTURE cuda:0 f32[16, 16]"
  p3 = torch_all_gather_prim_impl(t_fc2_weight, _torch_distributed_distributed_c10d_ProcessGroup_0, True, None)  # p3: "FUTURE cuda:0 f32[16, 16]"
  t1 = torch_wait_prim_impl(p0)  # t1: "cuda:0 f32[16, 16]"
  del p0
  t2 = torch.nn.functional.linear(x, t1, None)  # t2: "cuda:0 f32[4, 16]"
    # t2 = ltorch.linear(x, t1, None)  # t2: "cuda:0 f32[4, 16]"
      # t2 = prims.linear(x, t1, None)  # t2: "cuda:0 f32[4, 16]"
  del t1
  t4 = torch_wait_prim_impl(p3)  # t4: "cuda:0 f32[16, 16]"
  del p3
  t5 = torch.nn.functional.linear(x, t4, None)  # t5: "cuda:0 f32[4, 16]"
    # t5 = ltorch.linear(x, t4, None)  # t5: "cuda:0 f32[4, 16]"
      # t5 = prims.linear(x, t4, None)  # t5: "cuda:0 f32[4, 16]"
  del t4
  t6 = torch.add(t2, t5)  # t6: "cuda:0 f32[4, 16]"
    # t6 = ltorch.add(t2, t5, alpha=None)  # t6: "cuda:0 f32[4, 16]"
      # t6 = prims.add(t2, t5)  # t6: "cuda:0 f32[4, 16]"
  del t2, t5
  return {'output': t6, 'flat_args': [x, t_fc1_weight, t_fc2_weight], 'flat_output': (t6,)}, ((x,), ())
```

Computation Trace (After PR) - NOTE - we don't change the signature of the trace and it still takes all the parameters as input but we just don't utilize the shared parameters. It is ok, as they are backed by shared tensor and don't incur extra memory.
```python
# Constructed by Delete Last Used (took 0 milliseconds)
import torch
import torch.nn.functional
from thunder.executors.torchex import no_autocast

@torch.no_grad()
@no_autocast
def augmented_forward_fn(x, t_fc1_weight, t_fc2_weight):
  # x: "cuda:0 f32[4, 16]"
  # t_fc1_weight: "cuda:0 f32[8, 16]"
  # t_fc2_weight: "cuda:0 f32[8, 16]"
  p0 = torch_all_gather_prim_impl(t_fc1_weight, _torch_distributed_distributed_c10d_ProcessGroup_0, True, None)  # p0: "FUTURE cuda:0 f32[16, 16]"
  t1 = torch_wait_prim_impl(p0)  # t1: "cuda:0 f32[16, 16]"
  del p0
  t2 = torch.nn.functional.linear(x, t1, None)  # t2: "cuda:0 f32[4, 16]"
    # t2 = ltorch.linear(x, t1, None)  # t2: "cuda:0 f32[4, 16]"
      # t2 = prims.linear(x, t1, None)  # t2: "cuda:0 f32[4, 16]"
  t3 = torch.nn.functional.linear(x, t1, None)  # t3: "cuda:0 f32[4, 16]"
    # t3 = ltorch.linear(x, t1, None)  # t3: "cuda:0 f32[4, 16]"
      # t3 = prims.linear(x, t1, None)  # t3: "cuda:0 f32[4, 16]"
  del t1
  t4 = torch.add(t2, t3)  # t4: "cuda:0 f32[4, 16]"
    # t4 = ltorch.add(t2, t3, alpha=None)  # t4: "cuda:0 f32[4, 16]"
      # t4 = prims.add(t2, t3)  # t4: "cuda:0 f32[4, 16]"
  del t2, t3
  return {'output': t4, 'flat_args': [x, t_fc1_weight, t_fc2_weight], 'flat_output': (t4,)}, ((x,), ())
```