### PR TITLE
Fix flaky torch max grad

### DIFF
--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -5007,7 +5007,7 @@ def max_sample_generator(op, device, dtype, requires_grad, **kwargs):
     # So, we use the function below to create tensor with unique values.
     def make_t(shape):
         if dtype.is_floating_point and requires_grad:
-            # Use `linspace` to create unique values.
+            # Use `linspace` to create tensor with unique values.
             numel = math.prod(shape)
             inp_t = torch.linspace(
                 -1000, 1000, steps=numel, dtype=dtype, device=device, requires_grad=requires_grad

--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -5004,6 +5004,7 @@ def max_sample_generator(op, device, dtype, requires_grad, **kwargs):
     # Currently, if there are multiple `max` values
     # `torch` eager - gradients max(dim) propagates gradient only to a single index in the source tensor
     # `thunder` - gradients are distributed evenly.
+    # Also, we need unique values when grad check with finite differences.
     # So, we use the function below to create tensor with unique values.
     def make_t(shape):
         if dtype.is_floating_point and requires_grad:

--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -5005,9 +5005,18 @@ def max_sample_generator(op, device, dtype, requires_grad, **kwargs):
     # `torch` eager - gradients max(dim) propagates gradient only to a single index in the source tensor
     # `thunder` - gradients are distributed evenly.
     # So, we use the function below to create tensor with unique values.
-    def make_unique_t(shape):
-        # Add two random inputs, so it is unlikely to have same value across the tensor elements.
-        return make(shape) + make(shape)
+    def make_t(shape):
+        if dtype.is_floating_point and requires_grad:
+            # Use `linspace` to create unique values.
+            numel = math.prod(shape)
+            inp_t = torch.linspace(
+                -1000, 1000, steps=numel, dtype=dtype, device=device, requires_grad=requires_grad
+            ).view(shape)
+            return inp_t
+
+        # If we are not computing gradients,
+        # it is ok to have repeated values.
+        return make(shape)
 
     # shape, dim, keepdim
     cases = (
@@ -5018,7 +5027,7 @@ def max_sample_generator(op, device, dtype, requires_grad, **kwargs):
     for shape, dim, keepdim in cases:
         # overload: torch_max(a: TensorLike, /) -> TensorLike
         # This overload corresponds to taking the max over the flattened tensor.
-        yield SampleInput(make_unique_t(shape))
+        yield SampleInput(make_t(shape))
 
         if not requires_grad and dtype.is_floating_point:
             # See NOTE: Gradient Computation with multiple max values
@@ -5035,8 +5044,8 @@ def max_sample_generator(op, device, dtype, requires_grad, **kwargs):
             # This overload corresponds to taking the max along the specified dimension `dim`.
             # It returns first occurence of the maximum value along the dimension and it's corresponding index.
             # NOTE: When same values are present, the first occurence of the `value` and corresponding index is returned
-            yield SampleInput(make_unique_t(shape), dim)
-            yield SampleInput(make_unique_t(shape), dim, keepdim)
+            yield SampleInput(make_t(shape), dim)
+            yield SampleInput(make_t(shape), dim, keepdim)
 
             if not requires_grad and dtype.is_floating_point:
                 # See NOTE: Gradient Computation with multiple max values


### PR DESCRIPTION
Grad tests from the recently merged `torch.max` (https://github.com/Lightning-AI/lightning-thunder/pull/599) is flaky.

Eg. https://dev.azure.com/Lightning-AI/lightning/_build/results?buildId=205629&view=logs&j=5b0799f7-725e-5b16-9b83-c0a5a25d03f0&t=97651ec4-0b0f-5455-bbb5-3c30427a0a7e&l=11496

The reason for failure is due to the note below.
https://github.com/Lightning-AI/lightning-thunder/blob/21a222b180009616a4cc48176958b4506894a330/thunder/tests/opinfos.py#L5003-L5010

It so happens that the sample input may still have repeated element and it can be observed by looking at one of the failure.
```python
a = tensor([[[0.0000],
         [0.5000],
         [0.0000]],

        [[1.0000],
         [0.5000],
         [1.0000]]], device='cuda:0', dtype=torch.bfloat16)
b = tensor([[[0.],
         [1.],
         [0.]],

        [[1.],
         [0.],
         [1.]]], device='cuda:0', dtype=torch.float64), kwargs = {'check_dtype': False}

>       lambda a, b, **kwargs: comp(a, b, equal_nan=True, **kwargs),
        op.singularity_fn,
    )
E   AssertionError: Tensor-likes are not close!
E   
E   Mismatched elements: 2 / 6 (33.3%)
E   Greatest absolute difference: 0.5 at index (0, 1, 0) (up to 1e-05 allowed)
E   Greatest relative difference: inf at index (1, 1, 0) (up to 0.016 allowed)

thunder/tests/test_grad.py:1365: AssertionError
```

Also, running the grad test 100 times - (with `pytest-repeat`) 

Command - `pytest thunder/tests/test_grad.py -k torch_max -v --count 100`

I could see 8 failures
```
================================================================================================= 8 failed, 4492 passed, 94200 deselected, 31 warnings in 156.91s (0:02:36) ==================================================================================================
```

----------------
Fix: When `requires_grad=True`, use linspace to create unique inputs so that the test doesn't fail.

Re-running the test 100 times with fix.
```
====================================================================================================== 4500 passed, 94200 deselected, 31 warnings in 159.96s (0:02:39) =======================================================================================================
```