### PR TITLE
Match torch signature for `torch.nn.functional.silu`

### DIFF
--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -1494,7 +1494,7 @@ def selu(a: TensorProxy, /, inplace: bool = False) -> TensorLike:
 
 
 @torchsymbol(torch.nn.functional.silu)
-def silu(a: TensorLike, /, *, inplace: bool = False):
+def silu(a: TensorLike, /, inplace: bool = False) -> TensorLike:
     utils.check(
         not inplace, lambda: "Thunder only supports silu with inplace=False", exception_type=NotImplementedError
     )


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Matched the signature from torch documentation for `torch.nn.functional.silu` as discussed in a comment of #570. It's not the best idea to be able to pass the `inplace` argument without k-word but like this we match torch implementation signature. 

