### PR TITLE
[inplace][distributed] support `torch.distributed` common ops

### DIFF
--- a/thunder/distributed/prims.py
+++ b/thunder/distributed/prims.py
@@ -65,27 +65,11 @@ def all_gather_meta(
     group: torch.distributed.ProcessGroup,
     do_async: Number,
     dim: int | None = None,
-    output_tensor: TensorProxy | None = None,
 ) -> TensorProxy:
     check_if_distributed_available()
     utils.check_type(a, TensorProxy)
     utils.check_type(group, torch.distributed.ProcessGroup)
     utils.check(pytype(do_async) is bool, lambda: f"Expected {do_async=} to be a boolean value")
-
-    if output_tensor is not None:
-        utils.check_same_device(output_tensor, a)
-        utils.check_same_dtype(output_tensor, a)
-        utils.check(a.ndim == output_tensor.ndim, lambda: f"{output_tensor.ndim=} must be equal to {a.ndim=}")
-        utils.check(
-            output_tensor.numel == a.numel * group.size(),
-            lambda: f"{output_tensor.numel=} must be equal to {group.size()=}*{a.numel=}",
-        )
-
-        if dim is None:
-            for idx, (o_size, a_size) in enumerate(zip(output_tensor.shape, a.shape)):
-                if o_size != a_size:
-                    dim = idx
-                    break
 
     if dim is not None:
         utils.check_type(dim, int)
@@ -95,11 +79,6 @@ def all_gather_meta(
     else:
         result_shape = a.shape[0] * group.size(), *a.shape[1:]
     result_shape = tuple(result_shape)
-    if output_tensor is not None:
-        utils.check(
-            result_shape == output_tensor.shape,
-            lambda: f"{output_tensor.shape=} does not match {result_shape=}",
-        )
 
     if do_async:
         return FutureTensorProxy(shape=result_shape, like=a)
@@ -148,12 +127,6 @@ def broadcast_meta(
     return TensorProxy(like=a)
 
 
-# NOTE(crcrpar): Why `output_tensor`, not `output`? We cannot use `output`
-# [rank0]:E0619 08:52:42.515000 140083954114432 torch/testing/_internal/common_distributed.py:664]   File "/opt/pytorch/lightning-thunder/thunder/torch/__init__.py", line 5072, in reduce_scatter_
-# [rank0]:E0619 08:52:42.515000 140083954114432 torch/testing/_internal/common_distributed.py:664]     out = dist_prims.reduce_scatter(input, op, group, async_op, dim=None, output=output)
-# [rank0]:E0619 08:52:42.515000 140083954114432 torch/testing/_internal/common_distributed.py:664]   File "/opt/pytorch/lightning-thunder/thunder/core/symbol.py", line 271, in __call__
-# [rank0]:E0619 08:52:42.515000 140083954114432 torch/testing/_internal/common_distributed.py:664]     bsym = self.bind(*args, **kwargs, output=result, subsymbols=subsymbols)
-# [rank0]:E0619 08:52:42.515000 140083954114432 torch/testing/_internal/common_distributed.py:664] TypeError: thunder.core.symbol.Symbol.bind() got multiple values for keyword argument 'output'
 def reduce_scatter(
     a: TensorProxy,
     /,
@@ -161,28 +134,12 @@ def reduce_scatter(
     group: torch.distributed.ProcessGroup,
     do_async: Number,
     dim: int | None = None,
-    output_tensor: TensorProxy | None = None,
 ) -> TensorProxy:
     check_if_distributed_available()
     utils.check_type(a, TensorProxy)
     utils.check_type(op, DistributedReduceOps)
     utils.check_type(group, torch.distributed.ProcessGroup)
     utils.check(pytype(do_async) is bool, lambda: f"Expected {do_async=} to be a boolean value")
-
-    if output_tensor is not None:
-        utils.check_same_device(output_tensor, a)
-        utils.check_same_dtype(output_tensor, a)
-        utils.check(a.ndim == output_tensor.ndim, lambda: f"{output_tensor.ndim=} must be equal to {a.ndim=}")
-        utils.check(
-            output_tensor.numel * group.size() == a.numel,
-            lambda: f"{output_tensor.numel=} must be equal to {a.numel=} / {group.size()=}",
-        )
-
-        if dim is None:
-            for idx, (o_size, a_size) in enumerate(zip(output_tensor.shape, a.shape)):
-                if o_size != a_size:
-                    dim = idx
-                    break
 
     result_shape = list(a.shape)
     if dim is not None:
@@ -196,12 +153,6 @@ def reduce_scatter(
         result_shape[0] //= group.size()
         utils.check(
             a.shape[0] % group.size() == 0, lambda: f"Expected {a.shape[0]=} to be divisible by {group.size()=}"
-        )
-
-    if output_tensor is not None:
-        utils.check(
-            tuple(result_shape) == output_tensor.shape,
-            lambda: f"{output_tensor.shape=} does not match {result_shape=}",
         )
 
     if do_async:

--- a/thunder/distributed/prims.py
+++ b/thunder/distributed/prims.py
@@ -78,7 +78,6 @@ def all_gather_meta(
         result_shape[dim] *= group.size()
     else:
         result_shape = a.shape[0] * group.size(), *a.shape[1:]
-    result_shape = tuple(result_shape)
 
     if do_async:
         return FutureTensorProxy(shape=result_shape, like=a)

--- a/thunder/executors/torchex.py
+++ b/thunder/executors/torchex.py
@@ -1784,15 +1784,20 @@ if torch.distributed.is_available():
         group: torch.distributed.ProcessGroup,
         do_async: Number,
         dim: int | None = None,
+        output_tensor: torch.Tensor | None = None,
     ) -> torch.Tensor | tuple[torch.distributed.distributed_c10d.Work, torch.Tensor]:
-        result_shape = list(a.shape)
-        if dim is not None:
-            utils.check_type(dim, int)
-            utils.check(dim >= 0 and dim < a.dim(), lambda: f"dim must satisfy 0 <= {dim=} < {a.dim()=}")
-            result_shape[dim] *= group.size()
+        out: torch.Tensor
+        if output_tensor is not None:
+            out = output_tensor
         else:
-            result_shape[0] *= group.size()
-        out: torch.Tensor = torch.empty(result_shape, dtype=a.dtype, device=a.device)
+            result_shape = list(a.shape)
+            if dim is not None:
+                utils.check_type(dim, int)
+                utils.check(dim >= 0 and dim < a.dim(), lambda: f"dim must satisfy 0 <= {dim=} < {a.dim()=}")
+                result_shape[dim] *= group.size()
+            else:
+                result_shape[0] *= group.size()
+            out = torch.empty(result_shape, dtype=a.dtype, device=a.device)
         do_async: bool = bool(do_async)
 
         handle: None | torch.distributed.distributed_c10d.Work = torch.distributed.all_gather_into_tensor(

--- a/thunder/executors/torchex.py
+++ b/thunder/executors/torchex.py
@@ -1784,20 +1784,15 @@ if torch.distributed.is_available():
         group: torch.distributed.ProcessGroup,
         do_async: Number,
         dim: int | None = None,
-        output_tensor: torch.Tensor | None = None,
     ) -> torch.Tensor | tuple[torch.distributed.distributed_c10d.Work, torch.Tensor]:
-        out: torch.Tensor
-        if output_tensor is not None:
-            out = output_tensor
+        result_shape = list(a.shape)
+        if dim is not None:
+            utils.check_type(dim, int)
+            utils.check(dim >= 0 and dim < a.dim(), lambda: f"dim must satisfy 0 <= {dim=} < {a.dim()=}")
+            result_shape[dim] *= group.size()
         else:
-            result_shape = list(a.shape)
-            if dim is not None:
-                utils.check_type(dim, int)
-                utils.check(dim >= 0 and dim < a.dim(), lambda: f"dim must satisfy 0 <= {dim=} < {a.dim()=}")
-                result_shape[dim] *= group.size()
-            else:
-                result_shape[0] *= group.size()
-            out = torch.empty(result_shape, dtype=a.dtype, device=a.device)
+            result_shape[0] *= group.size()
+        out = torch.empty(result_shape, dtype=a.dtype, device=a.device)
         do_async: bool = bool(do_async)
 
         handle: None | torch.distributed.distributed_c10d.Work = torch.distributed.all_gather_into_tensor(
@@ -1851,20 +1846,15 @@ if torch.distributed.is_available():
         group: torch.distributed.ProcessGroup,
         do_async: Number,
         dim: int | None,
-        output: torch.Tensor | None = None,
     ) -> torch.Tensor | tuple[torch.distributed.distributed_c10d.Work, torch.Tensor]:
-        out: torch.Tensor
-        if output is not None:
-            out = output
+        result_shape = list(a.shape)
+        if dim is not None:
+            utils.check_type(dim, int)
+            utils.check(dim >= 0 and dim < a.dim(), lambda: f"dim must satisfry 0 <= {dim=} < {a.dim()=}")
+            result_shape[dim] //= group.size()
         else:
-            result_shape = list(a.shape)
-            if dim is not None:
-                utils.check_type(dim, int)
-                utils.check(dim >= 0 and dim < a.dim(), lambda: f"dim must satisfry 0 <= {dim=} < {a.dim()=}")
-                result_shape[dim] //= group.size()
-            else:
-                result_shape[0] //= group.size()
-            out = torch.empty(result_shape, dtype=a.dtype, device=a.device)
+            result_shape[0] //= group.size()
+        out = torch.empty(result_shape, dtype=a.dtype, device=a.device)
         op: torch.distributed.ReduceOp = ltorch.to_torch_distributed_reduce_op(op)
         do_async: bool = bool(do_async)
 

--- a/thunder/tests/distributed/test_ddp.py
+++ b/thunder/tests/distributed/test_ddp.py
@@ -262,17 +262,8 @@ class CompileDDPTest(DataParallelTestCase):
 
         for async_op in (True, False):
             expected = foo(a, b, process_group, async_op, dim)
-
-            if not (async_op and inplace):
-                actual = cfoo(a, b, process_group, async_op, dim)
-
-                self.assertEqual(actual, expected)
-            else:
-                with self.assertRaisesRegex(
-                    NotImplementedError,
-                    re.escape("`torch.distributed.all_gather_into_tensor` with async_op=True is not supported"),
-                ):
-                    cfoo(a, b, process_group, async_op, dim)
+            actual = cfoo(a, b, process_group, async_op, dim)
+            self.assertEqual(actual, expected)
 
     @common_utils.parametrize("executor", tuple(executors_map.keys()))
     def test_broadcast(self, executor):
@@ -393,17 +384,8 @@ class CompileDDPTest(DataParallelTestCase):
 
         for op, async_op in product((None, torch.distributed.ReduceOp.SUM), (False, True)):
             expected = foo(a, b, op, process_group, async_op, dim=dim)
-
-            if not (async_op and inplace):
-                actual = cfoo(a, b, op, process_group, async_op, dim=dim)
-
-                self.assertEqual(actual, expected)
-            else:
-                with self.assertRaisesRegex(
-                    NotImplementedError,
-                    re.escape("`torch.distributed.reduce_scatter_tensor` with async_op=True is not supported"),
-                ):
-                    cfoo(a, b, op, process_group, async_op, dim)
+            actual = cfoo(a, b, op, process_group, async_op, dim=dim)
+            self.assertEqual(actual, expected)
 
     @common_utils.parametrize("executor,bucket_size_in_mb", product(tuple(executors_map.keys()), (0, 1000)))
     def test_ddp_grad_bucketing(self, executor, bucket_size_in_mb: int):

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -5085,8 +5085,8 @@ if torch.distributed.is_available():
             NotImplementedError,
         )
         group = group if group is not None else torch.distributed.new_group()
-        out = dist_prims.all_gather(input_tensor, group, async_op, dim=None, output_tensor=output_tensor)
-        return prims.copy_(out, output_tensor)
+        out = dist_prims.all_gather(input_tensor, group, async_op, dim=None)
+        return prims.copy_(out.view(output_tensor.shape), output_tensor)
 
     # NOTE torch.distributed.all_reduce is an inplace operation (although the underlying NCCL
     #   call does not need to be inplace). This, however, is modeled as an out-of-place functional
@@ -5185,8 +5185,8 @@ if torch.distributed.is_available():
         )
         op = to_thunder_distributed_reduce_op(op)
         group = group if group is not None else torch.distributed.new_group()
-        out = dist_prims.reduce_scatter(input, op, group, async_op, dim=None, output_tensor=output)
-        return prims.copy_(out, output)
+        out = dist_prims.reduce_scatter(input, op, group, async_op, dim=None)
+        return prims.copy_(out.view(output.shape), output)
 
 else:
 

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -5197,6 +5197,15 @@ else:
     ) -> None:
         utils.check(False, lambda: f"torch.distributed is not available")
 
+    def all_gather_(
+        output_tensor: TensorLike,
+        input_tensor: TensorLike,
+        /,
+        group: torch.distributed.ProcessGroup | None = None,
+        async_op: bool = False,
+    ) -> None:
+        utils.check(False, lambda: "torch.distributed is not available")
+
     # NOTE torch.distributed is not available
     def all_reduce(
         a: TensorLike,
@@ -5205,6 +5214,15 @@ else:
         async_op: bool = False,
     ) -> None:
         utils.check(False, lambda: f"torch.distributed is not available")
+
+    def all_reduce_(
+        a: TensorLike,
+        /,
+        op: DistributedReduceOpLike = torch.distributed.ReduceOp.SUM,
+        group: torch.distributed.ProcessGroup | None = None,
+        async_op: bool = False,
+    ) -> None:
+        utils.check(False, lambda: "torch.distributed is not available")
 
     def broadcast(
         a: TensorLike,
@@ -5221,6 +5239,15 @@ else:
         async_op: bool = False,
     ) -> None:
         utils.check(False, lambda: f"torch.distributed is not available")
+
+    def reduce_scatter_(
+        output: TensorLike,
+        input: TensorLike,
+        op: DistributedReduceOpLike | None = None,
+        group: torch.distributed.ProcessGroup | None = None,
+        async_op: bool = False,
+    ) -> None:
+        utils.check(False, lambda: "torch.distributed is not available")
 
 
 #

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -5165,6 +5165,29 @@ if torch.distributed.is_available():
 
         return dist_prims.reduce_scatter(a, op, group, async_op, dim=dim)
 
+    @torchsymbol(
+        torch.distributed.reduce_scatter_tensor,
+        is_method=False,
+        id="reduce_scatter_",
+        tags=(prims.OpTags.IN_PLACE,),
+    )
+    def reduce_scatter_(
+        output: TensorLike,
+        input: TensorLike,
+        op: DistributedReduceOpLike | None = None,
+        group: torch.distributed.ProcessGroup | None = None,
+        async_op: bool = False,
+    ) -> TensorLike:
+        utils.check(
+            not async_op,
+            lambda: f"`torch.distributed.reduce_scatter_tensor` with {async_op=} is not supported",
+            NotImplementedError,
+        )
+        op = to_thunder_distributed_reduce_op(op)
+        group = group if group is not None else torch.distributed.new_group()
+        out = dist_prims.reduce_scatter(input, op, group, async_op, dim=None, output_tensor=output)
+        return prims.copy_(out, output)
+
 else:
 
     def all_gather(

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -5084,6 +5084,8 @@ if torch.distributed.is_available():
             lambda: f"`torch.distributed.all_gather_into_tensor` with {async_op=} is not supported",
             NotImplementedError,
         )
+        result_numel = input_tensor._numel * group.size()
+        utils.check(result_numel == output_tensor._numel, lambda: f"{output_tensor._numel=} should be {result_numel=}")
         group = group if group is not None else torch.distributed.new_group()
         out = dist_prims.all_gather(input_tensor, group, async_op, dim=None)
         return prims.copy_(out.view(output_tensor.shape), output_tensor)
@@ -5185,6 +5187,8 @@ if torch.distributed.is_available():
         )
         op = to_thunder_distributed_reduce_op(op)
         group = group if group is not None else torch.distributed.new_group()
+        result_numel = input._numel // group.size()
+        utils.check(result_numel == output._numel, lambda: f"{output._numel=} should be {result_numel=}")
         out = dist_prims.reduce_scatter(input, op, group, async_op, dim=None)
         return prims.copy_(out.view(output.shape), output)
 


### PR DESCRIPTION
This implements in-place all_reduce, all_gather_into_tensor, and reduce_scatter_tensor.

The implementations call out-of-place ones and `prims.copy_` output into the user prepared buffer.

When `async_op=True`, a script would have an idiom like
```python
handle = dist.all_gahter_into_tensor(tensor_out, tensor_in, async_op=True)
...
handle.wait()
```
but thunder ignores `handle.wait()` since thunder has multiple passes/transforms that move `dist_prims.wait(future)` around.
So under the hood, if `async_op=True`, we call `dist_prims.wait` before `prims.copy_`.
This means that `handle` is a `TensorProxy` object in a trace, and this PR adds `TensorProxy.wait` as a no-op to avoid NotImplementedError from `handle.wait`.