### PR TITLE
[in-place][functionalization] Correct `.from_bsym_swap_proxies` on `new_bsym`, not `bsym`

### DIFF
--- a/thunder/core/transform_common.py
+++ b/thunder/core/transform_common.py
@@ -505,7 +505,7 @@ def functionalize_inplace_ops(
                     reshape_bsym = prims.reshape.bind(view, unvariableify(var_orig).shape, output=view_of_orig_shape)
                     cur_orig_to_view_swap_map[var_orig] = view_of_orig_shape
                     bsyms.append(reshape_bsym)
-        new_bsym = bsym.from_bsym_swap_proxies(cur_orig_to_view_swap_map, skip_output=True)
+        new_bsym = new_bsym.from_bsym_swap_proxies(cur_orig_to_view_swap_map, skip_output=True)
 
         # in-place functionalizable ops has `prims.copy_` as the last subsymbol.
         if not is_functionalizable(new_bsym):


### PR DESCRIPTION
## What does this PR do?

Fixes #652.

The wrong `.from_bsym_swap_proxies` call on `bsym` had discarded the signature change made in https://github.com/Lightning-AI/lightning-thunder/blob/1aaa463323dfe875ee75da9a3454779b69cb665c/thunder/core/transform_common.py#L490