### PR TITLE
CUDAGraphs as executor/transform/fusion pass

### DIFF
--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -630,9 +630,7 @@ def jit(
                 extraces.append(computation_trc)
 
                 if backward_trc is not None:
-                    backward_trc = cudagraphex.fusion_pass(
-                        backward_trc, num_static_inputs=len(backward_trc.args[0][0])
-                    )
+                    backward_trc = cudagraphex.fusion_pass(backward_trc, num_static_inputs=len(backward_trc.args[0][0]))
                     backward_traces.append(backward_trc)
 
             comp = computation_trc.python_callable()

--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -630,7 +630,9 @@ def jit(
                 extraces.append(computation_trc)
 
                 if backward_trc is not None:
-                    backward_trc = cudagraphex.fusion_pass(backward_trc, num_static_inputs=len(backward_trc.args[0][0]))
+                    backward_trc = cudagraphex.fusion_pass(
+                        backward_trc, num_static_inputs=len(backward_trc.args[0][0])
+                    )
                     backward_traces.append(backward_trc)
 
             comp = computation_trc.python_callable()

--- a/thunder/executors/cudagraphex.py
+++ b/thunder/executors/cudagraphex.py
@@ -1,0 +1,230 @@
+import time
+from collections.abc import Hashable, Callable, Sequence
+from dataclasses import dataclass, field
+from functools import lru_cache
+from typing import Any
+
+import torch
+
+from thunder import trace
+from thunder.core.transforms import eval_trace
+from thunder.extend import FusionExecutor, register_executor
+from thunder.core import utils, prims
+from thunder.core.proxies import Proxy, Variable, unvariableify
+from thunder.core.symbol import BoundSymbol, Symbol
+from thunder.core.trace import TraceCtx, from_trace, TraceProvenance
+from thunder.executors.utils import Region
+from thunder.executors.data_dependent_partition import fuse_bound_symbols, Node
+
+
+@dataclass(**utils.default_dataclass_params)
+class ArgsDescriptor:
+    dtypes: tuple
+    sizes: tuple
+    strides: tuple
+    non_tensor_args: tuple
+    args: list = field(hash=False, repr=False, compare=False)
+
+
+def to_arg_descriptor(*args):
+    def extract_descriptor(arg):
+        if isinstance(arg, torch.Tensor):
+            return arg.dtype, arg.size(), arg.stride(), None
+        else:
+            return type(arg), None, None, arg
+
+    dtypes, sizes, strides, non_tensor_args = zip(*map(extract_descriptor, args))
+    return ArgsDescriptor(dtypes, sizes, strides, non_tensor_args, args)
+
+
+@lru_cache
+def build_cuda_graph(
+    fn: Callable, args_descriptor: ArgsDescriptor, static_args_mask: tuple[bool, ...]
+    ) -> tuple[torch.cuda.CUDAGraph, Sequence[torch.Tensor | Any], Sequence[torch.Tensor | Any]]:
+
+    def get_static_buffer(x):
+        if isinstance(x, torch.Tensor):
+            return torch.empty_like(x)
+        return x
+
+    args = args_descriptor.args
+
+    # Warmup
+    torch.cuda.synchronize()
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        static_inputs = tuple(get_static_buffer(arg) if not is_static else arg for arg, is_static in zip(args, static_args_mask))
+        for _ in range(3):
+            fn(*static_inputs)
+    stream.synchronize()
+    torch.cuda.current_stream().wait_stream(stream)
+    torch.cuda.synchronize()
+
+    # Record
+    # NOTE: We are using default private pool here, but it is possibly better to
+    # use a custom pool for better memory management. See CUDA Graphs Tree in
+    # PyTorch's Inductor: torch/_inductor/cudagraph_trees.py
+    # Design doc: https://docs.google.com/document/d/1ZrxLGWz7T45MSX6gPsL6Ln4t0eZCSfWewtJ_qLd_D0E/view
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=stream):
+        static_outputs = fn(*static_inputs)
+
+    return graph, static_inputs, static_outputs
+
+
+class CUDAGraphCallable:
+    def __init__(self, fn: Callable, num_static_inputs: None | int = None):
+        self.fn = fn
+        self.num_static_inputs = num_static_inputs
+
+    def __call__(self, *args):
+        if self.num_static_inputs is not None:
+            static_inputs_mask = (True,) * self.num_static_inputs + (False,) * (len(args) - self.num_static_inputs)
+        else:
+            static_inputs_mask = tuple(isinstance(arg, torch.nn.Parameter) for arg in args)
+
+        args_descriptor = to_arg_descriptor(*args)
+
+        graph, static_inputs, static_outputs = build_cuda_graph(self.fn, args_descriptor, static_inputs_mask)
+
+        for static_input, arg in utils.safe_zip(static_inputs, args):
+            if id(static_input) != id(arg) and isinstance(static_input, torch.Tensor) and isinstance(arg, torch.Tensor):
+                static_input.copy_(arg)
+
+        graph.replay()
+
+        return static_outputs
+
+
+def make_callable(
+    fn_name: str,
+    bsyms: list[BoundSymbol],
+    inputs: list[Proxy],
+    outputs: list[Proxy],
+) -> Callable:
+    from inspect import Parameter, Signature
+
+    region_fn_params = (
+        Parameter(getattr(param, "name", f"arg{i}"), Parameter.POSITIONAL_ONLY)
+        for i, param in enumerate(inputs)
+    )
+
+    region_fn_signature = Signature(region_fn_params)
+
+    def region_fn():
+        pass
+
+    region_fn.__signature__ = region_fn_signature
+    region_fn.__name__ = fn_name
+
+    region_trace = TraceCtx(region_fn)
+    region_trace.bound_symbols = bsyms
+    region_trace.args = inputs
+    region_trace.kwargs = {}
+    region_trace.bound_symbols.append(prims.python_return.bind(outputs, output=()))
+
+    return region_trace.python_callable()
+
+
+class CUDAGraphExecutor(FusionExecutor):
+    def __init__(self, name: Hashable):
+        super().__init__(name, version=torch.version.cuda)
+
+        self.clear_collection_names = set()
+
+    def fuse(self, region: Region, fusion_counter: int, num_static_inputs: None | int = None) -> BoundSymbol:
+        inputs = [unvariableify(inp) for inp in sorted(region.inputs, key=lambda var: var.proxy.name)]
+        outputs = [unvariableify(out) for out in sorted(region.outputs, key=lambda var: var.proxy.name)]
+
+        fusion_name = f"CUDAGraph{fusion_counter}"
+        fusion_callable: Callable = make_callable(f"{fusion_name}_fn", region.bound_symbols, inputs, outputs)
+        fusion_callable = CUDAGraphCallable(fusion_callable, num_static_inputs)
+
+        fusion_sym = Symbol(fusion_name, meta=None, is_fusion=True, executor=self)
+        fusion_bsym = BoundSymbol(
+            fusion_sym, inputs, {}, outputs, region.bound_symbols,
+            _call_ctx={fusion_name: fusion_callable},
+        )
+
+        return fusion_bsym
+
+    def can_fuse(self, bsym: BoundSymbol):
+        # Related to backward traces.
+        # No CollectionProxies in fusions! {
+        # Arguments of `clear_mutable_collection` should not be fused
+        if bsym.sym.id == "clear_mutable_collection":
+            self.clear_collection_names.add(bsym.args[0].name)
+            return False
+
+        # We let DEL to get fused, unless the deleted proxy is a CollectionProxy
+        # consumed by the `clear_mutable_collection` symbol
+        if bsym.sym.id == prims.PrimIDs.DEL and bsym.args[0].name in self.clear_collection_names:
+            return False
+        # }
+
+        do_not_fuse_sym_set = {
+            # Skip the very beginning and the very end of the trace
+            prims.PrimIDs.UNPACK_TRIVIAL,
+            prims.PrimIDs.UNPACK_KEY,
+            prims.PrimIDs.UNPACK_EMPTY_DICT,
+            prims.PrimIDs.UNPACK_SEQUENCE,
+            prims.PrimIDs.RETURN,
+            # Data-dependent ops
+            prims.PrimIDs.ITEM,
+        }
+
+        if bsym.sym.id in do_not_fuse_sym_set:
+            return False
+
+        return True
+
+    def fusion_pass(self, trace: TraceCtx, num_static_inputs: None | int = None) -> TraceCtx:
+        start_time_ns: int = time.time_ns()
+
+        def _should_fuse(a: Node, b: Node):
+            # TODO: modify the logic to be able to potentially better handle
+            # islands around data-dependent ops once these are supported by Thunder.
+
+            def _can_fuse_node(n: Node):
+                if len(n.group_bsyms) > 1:
+                    return True
+
+                bsym: BoundSymbol = n.group_bsyms[0]
+                return self.can_fuse(bsym)
+
+            return _can_fuse_node(a) and _can_fuse_node(b)
+
+        bound_symbols_groups = fuse_bound_symbols(trace, _should_fuse)
+
+        producers, consumers = utils.producers_and_consumers(trace)
+
+        fusion_counter: int = 0
+        fused_bsyms = []
+        for bsyms in bound_symbols_groups:
+            # Trivial symbols that we do not want to fuse
+            if len(bsyms) == 1:
+                fused_bsyms.append(bsyms[0])
+                continue
+
+            if not self.can_fuse(bsyms[0]):
+                fused_bsyms.extend(bsyms)
+            else:
+                region = Region(producers, consumers, bsyms)
+                fusion_bsym: BoundSymbol = self.fuse(region, fusion_counter, num_static_inputs)
+                fusion_counter += 1
+                fused_bsyms.append(fusion_bsym)
+
+        fused_trace: TraceCtx = from_trace(trace)
+        fused_trace.bound_symbols = fused_bsyms
+
+        end_time_ns = time.time_ns()
+        elapsed_time_ns = (end_time_ns - start_time_ns)
+        elapsed_time_ms = elapsed_time_ns // 1000000
+        fused_trace.set_provenance(TraceProvenance(f"CUDAGraph fusion (took {elapsed_time_ms} milliseconds)"))
+
+        return fused_trace
+
+
+cudagraphex = CUDAGraphExecutor(name="cudagraph")
+register_executor(cudagraphex)

--- a/thunder/executors/data_dependent_partition.py
+++ b/thunder/executors/data_dependent_partition.py
@@ -260,12 +260,16 @@ def horizontal_merge(graph, merge_func: Callable):
         # takes the first node in the stack.
         cur = visit_stack.pop(0)
         bsyms_in_group = []
+        indices_in_group = []
 
         def update_candidate(schedule_op):
             nonlocal bsyms_in_group
+            nonlocal indices_in_group
             nonlocal candidate_map
             nonlocal visit_stack
             bsyms_in_group += schedule_op.group_bsyms
+            indices_in_group += schedule_op.group_indices
+
             # iterate through candidate_map and update predicate for schedule_op.children
             for candidate in schedule_op.children:
                 remaining_dependencies = candidate_map.setdefault(candidate, len(candidate.parents))
@@ -284,7 +288,11 @@ def horizontal_merge(graph, merge_func: Callable):
             else:
                 index += 1
 
-        topo_order_groups.append(bsyms_in_group)
+        # Sort bsyms_in_group wrt trace index order.
+        # This is needed in cases when there is a horizontal op order
+        topo_order_groups.append(
+            [bsyms_in_group[i] for i in sorted(range(len(bsyms_in_group)), key=lambda i: indices_in_group[i])]
+        )
 
     return topo_order_groups
 

--- a/thunder/executors/torch_autograd.py
+++ b/thunder/executors/torch_autograd.py
@@ -10,7 +10,6 @@ from thunder.core.pytree import tree_flatten
 from thunder.core.symbol import BoundSymbol
 from thunder.core.trace import TraceCtx, from_trace, set_tracectx, reset_tracectx
 from thunder.core.transform_common import replace_redundant_inputs
-from thunder.cudagraphs import CUDAGraphExecutor
 
 if TYPE_CHECKING:
     from thunder.core.trace import VariableInterface
@@ -94,9 +93,6 @@ class ThunderFunction(torch.autograd.Function):
         # reference to the saved tensors in the context
         ctx.maybe_clear_saved_tensors()  # Delete the reference to all saved tensors in the context
         grads = ctx.compiled_backward([saved_tensors_list, ctx.saved_other], args)
-
-        if isinstance(ctx.compiled_backward, CUDAGraphExecutor):
-            saved_tensors_list.clear()
 
         # Inside the compiled backward we must clear the saved_tensors_list
         assert not saved_tensors_list, "saved_tensors_list must be empty after calling compiled_backward"

--- a/thunder/tests/test_networks.py
+++ b/thunder/tests/test_networks.py
@@ -64,6 +64,12 @@ def test_nanogpt_complete_autograd(executor, device, dtype):
     assert_close(torch_grads, thunder_grads, atol=1e-1, rtol=1e-1)
 
 
+def _there_is_cudagraph_sym(trace):
+    # So far check for a single CUDAGraph fusion
+    bsyms = [bsym for bsym in trace.bound_symbols if bsym.sym.name.startswith("CUDAGraph")]
+    return len(bsyms) == 1
+
+
 @instantiate(dtypes=(thunder.float32,), devicetypes=(thunder.devices.DeviceType.CUDA,))
 @requiresCUDA
 def test_nanogpt_complete_cudagraphs(executor, device, dtype):
@@ -75,20 +81,18 @@ def test_nanogpt_complete_cudagraphs(executor, device, dtype):
     config = nanogpt_model.GPTConfig(dropout=0, block_size=512, n_layer=6, n_head=6, n_embd=768)
     gpt = nanogpt_model.GPT(config).to(device=device, dtype=tdtype)
 
-    idx = make((4, 64), dtype=torch.int64, low=0, high=255)
-    torch_result = gpt(idx)
-
     tom = executor.make_callable(gpt, use_cudagraphs=True, disable_torch_autograd=True)
 
-    thunder_result = tom(idx)
-    assert_close(torch_result, thunder_result)
+    for _ in range(2):
+        idx = make((4, 64), dtype=torch.int64, low=0, high=255)
+        torch_result = gpt(idx)
+
+        thunder_result = tom(idx)
+        assert_close(torch_result, thunder_result)
 
     # Check we really run CUDAGraphExecutor {
     assert tom._lc_cd.use_cudagraphs == True
-
-    from thunder.cudagraphs import CUDAGraphExecutor
-
-    assert type(tom._lc_cs.last_executed) == CUDAGraphExecutor
+    assert _there_is_cudagraph_sym(thunder.last_traces(tom)[-1])
     # }
 
 
@@ -101,18 +105,27 @@ def test_nanogpt_complete_cuda_graphs_autograd(executor, device, dtype):
     # NOTE Sets dropout to zero for reproducibility
     config = nanogpt_model.GPTConfig(dropout=0, block_size=512, n_layer=6, n_head=6, n_embd=768)
     gpt = nanogpt_model.GPT(config).to(device=device, dtype=tdtype)
-
-    x = make_tensor((4, 64), dtype=torch.int64, low=0, high=255, device=device)
-    targets = make_tensor((4, 64), dtype=torch.int64, low=0, high=255, device=device)
-    torch_result = gpt(x, targets=targets)
-    torch_grads = torch.autograd.grad(torch_result[1], gpt.parameters())
-
     cmodel = executor.make_callable(gpt, use_cudagraphs=True)
-    thunder_result = cmodel(x, targets=targets)
-    thunder_grads = torch.autograd.grad(thunder_result[1], gpt.parameters())
 
-    assert_close(torch_result, thunder_result)
-    assert_close(torch_grads, thunder_grads)
+    # Multiple runs to test whether static buffers are properly updated
+    for i in range(3):
+        x = make_tensor((4, 64), dtype=torch.int64, low=0, high=255, device=device)
+        targets = make_tensor((4, 64), dtype=torch.int64, low=0, high=255, device=device)
+
+        torch_result = gpt(x, targets=targets)
+        torch_grads = torch.autograd.grad(torch_result[1], gpt.parameters())
+
+        thunder_result = cmodel(x, targets=targets)
+        thunder_grads = torch.autograd.grad(thunder_result[1], gpt.parameters())
+
+        assert_close(torch_result, thunder_result)
+        assert_close(torch_grads, thunder_grads)
+
+    # Check we really run CUDAGraphExecutor {
+    assert cmodel._lc_cd.use_cudagraphs == True
+    assert _there_is_cudagraph_sym(thunder.last_traces(cmodel)[-1])
+    assert _there_is_cudagraph_sym(thunder.last_backward_traces(cmodel)[-1])
+    # }
 
 
 @instantiate(dtypes=(thunder.float32,))


### PR DESCRIPTION
As per title. Fixes https://github.com/Lightning-AI/lightning-thunder/issues/635.

Also, it fixes the following subtle bugs:

- `CUDAGraphExecutor` - does not properly update static buffers when the same graph is invoked on inputs with meta-data that allows to fetch cached graphs, but with different storage data. The area of concern - training and the backward pass.
- `horizontal_merge` in the fusion logic - that one, when grouping bound symbols, does not consider precedence between ops horizontally. It is not an issue with nvfusions, but it could cause issues when deciding whether to place something like `del x` after `op(x)` in a custom FusionExecutor. The fix sorts bsyms in each group wrt trace position (which is expected to be toposorted prior to any fusions) and, hence, restores the inter-/intra-bsym groups topological order.