### PR TITLE
Add missing interpolate() parameters

### DIFF
--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -4543,6 +4543,9 @@ def interpolate(
     size: None | int | Sequence[int] = None,
     scale_factor: float | Sequence[float] | None = None,
     mode: str = "nearest",
+    align_corners: bool = False,
+    recompute_scale_factor: bool | None = None,
+    antialias: bool = False
 ) -> TensorLike:
     utils.check(
         mode == "nearest",
@@ -4552,6 +4555,12 @@ def interpolate(
 
     utils.check(a.ndim >= 3, lambda: f"Expected {a.ndim=} >= 3")
     utils.check(a.numel() > 0, lambda: f"Expected {a.numel=} to be greater than 0")
+    utils.check(align_corners == False,
+                lambda: f"'align_corners=True' is not yet supported.")
+    utils.check(recompute_scale_factors == False,
+                lambda: f"'recompute_scale_factors=True' is not yet supported.")
+    utils.check(antialias == False,
+                lambda: f"'antialias=True' is not yet supported.")
 
     utils.check(
         (size is not None) ^ (scale_factor is not None),


### PR DESCRIPTION
## What does this PR do?

Adds missing arguments for [interpolate](https://pytorch.org/docs/stable/generated/torch.nn.functional.interpolate.html).

## PR review

Anyone in the community is free to review the PR once the tests have passed.