### PR TITLE
Implement TransformerEngine benchmarking for lit-gpt

### DIFF
--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -234,7 +234,7 @@ class Benchmark_litGPT:
 
         if self.use_te_fp8_autocast:
             te_precision = TransformerEnginePrecision(weights_dtype=torch.bfloat16, replace_layers=True)
-            self.model =  te_precision.convert_module(self.model)
+            self.model = te_precision.convert_module(self.model)
 
         # Setup the distributed algorithm choices
         self.model = self.setup_distributed(self.model)

--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -185,12 +185,11 @@ class Benchmark_litGPT:
                     f"[WARNING] Bucketing mode is set to {self.bucketing_mode}. --fsdp_bucket_params will be ignored."
                 )
 
-        if not transformer_engine_available and is_transformer_engine(low_precision_mode):
-            raise ImportError(
-                "Selected benchmark config is for TransformerEngine but could not import the TransformerEngine library!"
-            )
-
         if is_transformer_engine(low_precision_mode):
+            if not transformer_engine_available:
+                raise ImportError(
+                    "Selected benchmark config is for TransformerEngine but could not import the TransformerEngine library!"
+                )
             check_fp8_compute_capability()
 
         if "thunder" in self.compile and is_transformer_engine(self.low_precision_mode):

--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -46,10 +46,12 @@ def is_transformer_engine(low_precision_mode: str) -> bool:
 
 def get_context_manager(low_precision_mode: str, compile_mode: str) -> AbstractContextManager:
     if is_transformer_engine(low_precision_mode) and "thunder" not in compile_mode:
+
         @contextlib.contextmanager
         def fp8_autocast_context():
             with te.fp8_autocast(enabled=True):
                 yield
+
         return fp8_autocast_context
     else:
         return nullcontext

--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -2,8 +2,8 @@ import os
 import time
 import warnings
 from typing import Any
-from contextlib import nullcontext, AbstractContextManager
 import contextlib
+from contextlib import nullcontext, AbstractContextManager
 
 import torch
 import functools
@@ -52,10 +52,7 @@ def get_context_manager(low_precision_mode: str, compile_mode: str) -> AbstractC
                 yield
         return fp8_autocast_context
     else:
-        @contextlib.contextmanager
-        def null_context():
-            yield
-        return null_context
+        return nullcontext
 
 
 def get_converted_model(low_precision_mode: str, compile_mode: str, model: Any) -> Any:

--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -125,7 +125,6 @@ class Benchmark_litGPT:
         self.checkpoint_activations = checkpoint_activations
         self.micro_batch_size = micro_batch_size
         self.low_precision_mode = low_precision_mode
-        
 
         # Clarify benchmark assumptions
         if self.sharding_size is not None:
@@ -162,7 +161,7 @@ class Benchmark_litGPT:
                 print(
                     f"[WARNING] Bucketing mode is set to {self.bucketing_mode}. --fsdp_bucket_params will be ignored."
                 )
-        
+
         if "thunder" in self.compile and is_transformer_engine(self.low_precision_mode):
             self.compile += "_transformerengine"
 
@@ -201,7 +200,7 @@ class Benchmark_litGPT:
         print(f"Loading model with {self.config.__dict__}")
         self.model = self.init_model()
         print(f"Time to instantiate model: {time.perf_counter() - t0:.02f} seconds.")
-        
+
         # fp8-delayed-te precision for thunder is handled through compile
         if is_transformer_engine(low_precision_mode) and "thunder" not in self.compile:
             te_precision = TransformerEnginePrecision(weights_dtype=torch.bfloat16, replace_layers=True)

--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -208,7 +208,7 @@ class Benchmark_litGPT:
             raise ImportError(
                 "Selected benchmark config is for TransformerEngine but could not import the TransformerEngine library!"
             )
-        
+
         if is_transformer_engine(low_precision_mode):
             check_fp8_compute_capability()
 

--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -203,11 +203,11 @@ class Benchmark_litGPT:
         if is_transformer_engine(low_precision_mode) and "thunder" not in self.compile:
             te_precision = TransformerEnginePrecision(weights_dtype=torch.bfloat16, replace_layers=True)
             converted_model = te_precision.convert_module(self.model)
-            
+
             def call_model_with_fp8autocast(*args, **kwargs):
                 with te.fp8_autocast(enabled=True):
                     return converted_model(*args, **kwargs)
-            
+
             self.model.__call__ = call_model_with_fp8autocast
 
         # Setup the distributed algorithm choices

--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -27,6 +27,7 @@ from lightning.fabric.utilities import Throughput
 try:
     import transformer_engine.pytorch as te
     from lightning.fabric.plugins.precision.transformer_engine import TransformerEnginePrecision
+
     transformer_engine_available = True
 except ImportError:
     transformer_engine_available = False
@@ -189,9 +190,11 @@ class Benchmark_litGPT:
                 print(
                     f"[WARNING] Bucketing mode is set to {self.bucketing_mode}. --fsdp_bucket_params will be ignored."
                 )
-                
+
         if not transformer_engine_available and is_transformer_engine(low_precision_mode):
-            raise ImportError("Selected benchmark config is for TransformerEngine but could not import the TransformerEngine library!")
+            raise ImportError(
+                "Selected benchmark config is for TransformerEngine but could not import the TransformerEngine library!"
+            )
 
         if "thunder" in self.compile and is_transformer_engine(self.low_precision_mode):
             self.compile += "_transformerengine"


### PR DESCRIPTION
As mentioned in the [conversation](https://github.com/Lightning-AI/lightning-thunder/issues/658), the aim of this PR is to enable benchmarking `lit-gpt` through `TransformerEngine`. 

<details>
  <summary><b>Before submitting</b></summary>
- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

This PR adds a new CLI argument `low_precision_mode`, which can be set and the model is executed through respective low_precision_mode accordingly. Currently, only `TransformerEngine` delayed is supported.

Fixes https://github.com/Lightning-AI/lightning-thunder/issues/658 or at least makes it possible to benchmark it.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
