### PR TITLE
fix TE - Compute and Comms overlap

### DIFF
--- a/thunder/distributed/utils.py
+++ b/thunder/distributed/utils.py
@@ -84,8 +84,9 @@ def sort_communication_ops(execution_trace):
                 case wait_prim_impl.id | unpack_for_fsdp_prim_impl.id:
                     return len(order_in_trace)
                 case reduce_scatter_prim_impl.id | all_reduce_prim_impl.id:
-                    # Prefer larger communication ops over smaller ones
-                    return -node.bsym.args[0].numel
+                    # We want to keep the `reduce` close to it's producer
+                    # (which is close to the original place in the trace).
+                    return order_in_trace[node.bsym]
                 case all_gather_prim_impl.id:
                     return len(order_in_trace) + order_in_trace[node.bsym]
                 case _:


### PR DESCRIPTION
Fixes: https://github.com/Lightning-AI/lightning-thunder/issues/557

As described in this [comment](https://github.com/Lightning-AI/lightning-thunder/pull/592#issuecomment-2194239897), in this fix we don't alter the location of `reduce` ops as they are already close to their producers.

Model Details:
```
Model name: Llama-2-7b-hf
Seq Length: 4096
Micro BS: 1
Global BS: 8
Number of Layers: 32
Number of parameters: 0.84B
Distributed Mode: fsdp
Sharding Mode: zero3
Bucketing: none
```

Before Patch:
```
iter 42: loss 4.6562, iter time: 301.01ms, t: 4096
iter 43: loss 4.6250, iter time: 300.18ms, t: 4096
iter 44: loss 4.6562, iter time: 300.28ms, t: 4096
Compiler: thunder_inductor_cat_transformerengine_cudnn
Average iter time: 301.41 ms
Memory used: 52.91 GB
Tokens/s: 108694.18
Tokens/s/GPU: 13586.77
TFLOP/s: 5009.16
```

After Patch:
```
iter 42: loss 4.6562, iter time: 287.37ms, t: 4096
iter 43: loss 4.6250, iter time: 285.28ms, t: 4096
iter 44: loss 4.6562, iter time: 288.41ms, t: 4096
Compiler: thunder_inductor_cat_transformerengine_cudnn
Average iter time: 285.22 ms
Memory used: 52.92 GB
Tokens/s: 114889.69
Tokens/s/GPU: 14361.21
TFLOP/s: 5294.68
```

Also, the profile now shows some overlap in comms and compute in the backward.

![image](https://github.com/Lightning-AI/lightning-thunder/assets/19503980/b595b2ee-57cc-4c8a-9c76-3a4aae862434)

