### PR TITLE
use short device str for type_str

### DIFF
--- a/thunder/core/proxies.py
+++ b/thunder/core/proxies.py
@@ -1302,7 +1302,7 @@ class TensorProxy(Proxy, TensorProxyInterface):
         return f'<{type(self).__name__}(name="{self.name}", dtype={self.dtype}, shape={self.shape})>'
 
     def type_string(self):
-        return f"{self.device} {self.dtype.shortname()}{list(self.shape)}"
+        return f"{self.device.device_str()} {self.dtype.shortname()}{list(self.shape)}"
 
     # NOTE __getattr__ is overridden to support language-specific methods
     def __getattr__(self, attr: str, /):

--- a/thunder/tests/test_core.py
+++ b/thunder/tests/test_core.py
@@ -2871,3 +2871,21 @@ def test_proxy_repr():
         assert p.__repr__() == '<NumberProxy(name="number")>'
         assert t.__repr__() == '<TensorProxy(name="tensor", dtype=thunder.dtypes.float16, shape=(1,))>'
         assert c.__repr__() == '<CollectionProxy(name="collection")>'
+
+
+def test_type_string():
+    def fn(x):
+        return 2 * x
+
+    jfn = thunder.jit(fn)
+
+    a = torch.randn(2, 2)
+
+    jfn(a)
+
+    tr = thunder.last_traces(jfn)[0]
+
+    assert tr.bound_symbols[1].sym == ltorch.mul
+    (pystr,) = tr.bound_symbols[1].python(0)
+
+    assert pystr == 'result = ltorch.mul(2, x)  # result: "cpu f32[2, 2]"'


### PR DESCRIPTION
```
result = ltorch.mul(2, x)  # result: "cpu f32[2, 2]"
```

instead of

```
result = ltorch.mul(2, x)  # result: "thunder.devices.Device(type='cpu') f32[2, 2]"
```
