### PR TITLE
Update dtype repr in trace

### DIFF
--- a/thunder/core/codeutils.py
+++ b/thunder/core/codeutils.py
@@ -227,7 +227,10 @@ def prettyprint(
         unflattened_str = unflattened_str.replace(f"'{_quote_marker}", "")
         return unflattened_str
     if isinstance(x, dtypes.dtype):
-        return m(f"{str(x)}")
+        # str(x) -> thunder.dtypes.foo
+        # For consistency with previous repr,
+        # remove `thunder.` from the representation.
+        return m(f"{str(x).replace('thunder.', '')}")
     if isinstance(x, devices.Device):
         return m(f'devices.Device("{x.device_str()}")')
     if type(x) is type:

--- a/thunder/core/codeutils.py
+++ b/thunder/core/codeutils.py
@@ -227,7 +227,7 @@ def prettyprint(
         unflattened_str = unflattened_str.replace(f"'{_quote_marker}", "")
         return unflattened_str
     if isinstance(x, dtypes.dtype):
-        return m(f"dtypes.{str(x)}")
+        return m(f"{str(x)}")
     if isinstance(x, devices.Device):
         return m(f'devices.Device("{x.device_str()}")')
     if type(x) is type:

--- a/thunder/tests/test_core.py
+++ b/thunder/tests/test_core.py
@@ -2889,3 +2889,22 @@ def test_type_string():
     (pystr,) = tr.bound_symbols[1].python(0)
 
     assert pystr == 'result = ltorch.mul(2, x)  # result: "cpu f32[2, 2]"'
+
+
+def test_dtype_in_trace():
+    def fn(x):
+        return x.to(torch.float16)
+
+    jfn = thunder.jit(fn)
+
+    x = torch.randn(
+        3,
+    )
+
+    jfn(x)
+
+    tr = thunder.last_traces(jfn)[0]
+    assert tr.bound_symbols[1].sym == ltorch.to
+    (pystr,) = tr.bound_symbols[1].subsymbols[0].python(0)
+
+    assert "convert_element_type(x, thunder.dtypes.float16)" in pystr

--- a/thunder/tests/test_core.py
+++ b/thunder/tests/test_core.py
@@ -2907,4 +2907,4 @@ def test_dtype_in_trace():
     assert tr.bound_symbols[1].sym == ltorch.to
     (pystr,) = tr.bound_symbols[1].subsymbols[0].python(0)
 
-    assert "convert_element_type(x, thunder.dtypes.float16)" in pystr
+    assert "convert_element_type(x, dtypes.float16)" in pystr


### PR DESCRIPTION
Currently, dtype argument in a trace is printed as  `dtypes.thunder.dtypes.float16` which looks a bit odd (and potentially lead to errors). This PR updates it back to `dtypes.float16`

See example below for full repro.

```python
import thunder
import torch

def foo(x):
    return x.to(torch.float16)

x = torch.randn(3, 3)
jfoo = thunder.jit(foo)
jfoo(x)
print(thunder.last_traces(jfoo)[-1])
```

Output
```python
# Constructed by Delete Last Used (took 0 milliseconds)
from torch import Tensor
import torch
from thunder.executors.torchex import no_autocast

@torch.no_grad()
@no_autocast
def computation(x):
  # x: "cpu f32[3, 3]"
  t0 = Tensor.to(x, copy=False, dtype=torch.float16)  # t0: "cpu f16[3, 3]"
    # t0 = ltorch.to(x, None, None, device=None, dtype=torch.float16, copy=False, memory_format=None)  # t0: "cpu f16[3, 3]"
      # t0 = prims.convert_element_type(x, dtypes.thunder.dtypes.float16)  # t0: "cpu f16[3, 3]"
  del x
  return t0
```