### PR TITLE
autocast: support mixed dtypes

### DIFF
--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -391,7 +391,7 @@ def jit(
                 autocast_cpu_dtype=str(autocast_cpu_dtype),
             )
             autocast_thunder_dtype = autocast_cpu_dtype if pytorch.is_autocast_cpu_enabled() else autocast_gpu_dtype
-            cd.autocast_thunder_dtype = autocast_thunder_dtype
+            cache_info.update(autocast_thunder_dtype=str(autocast_thunder_dtype))
 
         cache_info["is_autocast_enabled"] = is_autocast_enabled
         cd.is_autocast_enabled = is_autocast_enabled

--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -391,8 +391,10 @@ def jit(
                 autocast_cpu_dtype=str(autocast_cpu_dtype),
             )
             autocast_thunder_dtype = autocast_cpu_dtype if pytorch.is_autocast_cpu_enabled() else autocast_gpu_dtype
+            cd.autocast_thunder_dtype = autocast_thunder_dtype
 
         cache_info["is_autocast_enabled"] = is_autocast_enabled
+        cd.is_autocast_enabled = is_autocast_enabled
 
         is_ddp_enabled = getattr(fn, "use_ddp", False)
         is_fsdp_enabled = getattr(fn, "use_fsdp", False)
@@ -570,14 +572,6 @@ def jit(
 
             computation_trc = dce(computation_trc)
             computation_traces.append(computation_trc)
-
-            if is_autocast_enabled:
-                from thunder.core.transforms import autocast
-
-                computation_trc = trace(compile_data=cd)(
-                    autocast(computation_trc.python_callable(), dtype=autocast_thunder_dtype), *inps
-                )
-                computation_traces.append(computation_trc)
 
             backward_trc = None
             if not cd.disable_torch_autograd_support:

--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -394,7 +394,6 @@ def jit(
             cache_info.update(autocast_thunder_dtype=str(autocast_thunder_dtype))
 
         cache_info["is_autocast_enabled"] = is_autocast_enabled
-        cd.is_autocast_enabled = is_autocast_enabled
 
         is_ddp_enabled = getattr(fn, "use_ddp", False)
         is_fsdp_enabled = getattr(fn, "use_fsdp", False)

--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -3772,6 +3772,10 @@ def autocast_scaled_dot_product_attention(
     return scaled_dot_product_attention(q, k, v, attn_mask, dropout_p, is_causal, scale=scale)
 
 
+def _maybe_get_autocast_rule_for_symbol(sym: Symbol):
+    return autocast_impls.get(sym.id)
+
+
 def autocast_symbol_mapper(bound_symbol: BoundSymbolInterface, dtype: dtypes.dtype):
     """Return the callable implementing the autocast rule for the symbol.
 
@@ -3781,7 +3785,7 @@ def autocast_symbol_mapper(bound_symbol: BoundSymbolInterface, dtype: dtypes.dty
     Returns:
         Callable: The callable implementing the autocast rule for the symbol.
     """
-    autocast_impl: Callable | None = autocast_impls.get(bound_symbol.sym.id)
+    autocast_impl: Callable | None = _maybe_get_autocast_rule_for_symbol(bound_symbol.sym)
     return bound_symbol.sym if autocast_impl is None else partial(autocast_impl, dtype=dtype)
 
 

--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -3727,6 +3727,21 @@ def register_autocast_rule(op):
     return decorator
 
 
+_allowed_downcast_types = {dtypes.float16, dtypes.bfloat16}
+_allowed_downcast_types_str_to_dtype_map = {str(dtype): dtype for dtype in _allowed_downcast_types}
+
+
+def _check_valid_autocast_dtype(dtype):
+    if dtype not in _allowed_downcast_types:
+        raise ValueError(
+            f"autocast: `dtype` is expected to be either `thunder.float16` or `thunder.bfloat16`, but {dtype}"
+        )
+
+
+def _get_downcast_dtype_from_str(str_dtype):
+    return _allowed_downcast_types_str_to_dtype_map[str_dtype]
+
+
 def maybe_downcast_to(dtype, args):
     allowed_downcast_types = (dtypes.float16, dtypes.bfloat16, dtypes.float32)
 
@@ -3814,8 +3829,7 @@ def autocast(func: Callable, dtype: dtypes.dtype):
 
     if not isinstance(dtype, dtypes.dtype):
         raise ValueError(f"`dtype` is expected to be `thunder.dtype.dtype` but {type(dtype)}")
-    if dtype not in {dtypes.float16, dtypes.bfloat16}:
-        raise ValueError(f"`dtype` is expected to be either `thunder.float16` or `thunder.bfloat16`, but {dtype}")
+    _check_valid_autocast_dtype(dtype)
 
     @wraps(func)
     def wrapper(*args, **kwargs):

--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -3759,12 +3759,12 @@ def autocast_scaled_dot_product_attention(
     query,
     key,
     value,
-    attn_mask,
-    dropout_p,
-    is_causal,
+    attn_mask=None,
+    dropout_p=0.0,
+    is_causal=False,
     *,
     dtype,
-    scale,
+    scale=None,
 ):
     from thunder.torch import scaled_dot_product_attention
 

--- a/thunder/tests/test_autocast.py
+++ b/thunder/tests/test_autocast.py
@@ -153,3 +153,19 @@ def test_torch_compile_autocast():
     actual = cfn(a, b)
     expected = a + b
     torch.testing.assert_close(actual, expected)
+
+
+def test_autocast_mixed_dtype_inputs():
+    def foo(x, w):
+        return torch.nn.functional.linear(x, w, bias=None)
+
+    # Mixed input types.
+    x, w = torch.randn(16, 16, dtype=torch.bfloat16), torch.randn(16, 16)
+
+    jfoo = thunder.jit(foo)
+
+    with torch.autocast("cpu", torch.bfloat16):
+        eager_out = foo(x, w)
+        jit_out = jfoo(x, w)
+
+    torch.testing.assert_close(eager_out, jit_out)

--- a/thunder/tests/test_autocast.py
+++ b/thunder/tests/test_autocast.py
@@ -157,7 +157,7 @@ def test_torch_compile_autocast():
 
 def test_autocast_mixed_dtype_inputs():
     def foo(x, w):
-        return torch.nn.functional.linear(x, w, bias=None)
+        return torch.nn.functional.linear(x, w)
 
     # Mixed input types.
     x, w = torch.randn(16, 16, dtype=torch.bfloat16), torch.randn(16, 16)

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -137,7 +137,7 @@ class torchsymbol:
         else:
             sym = Symbol(name=fn.__name__, meta=_fn, id=id, is_prim=self.is_prim, tags=self.tags)
 
-        # NOTE: torch - autocast support
+        # NOTE: torch.autocast support
         # In PyTorch eager, enabling autocast allows mixed inputs to operator like `linear`
         # which expect dtypes to be same. This works in PyTorch eager, as dispatcher applies the
         # conversion first and then passes the converted input to the operator.

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -137,7 +137,7 @@ class torchsymbol:
         else:
             sym = Symbol(name=fn.__name__, meta=_fn, id=id, is_prim=self.is_prim, tags=self.tags)
 
-        # NOTE: Autocast support
+        # NOTE: torch - autocast support
         # In PyTorch eager, enabling autocast allows mixed inputs to operator like `linear`
         # which expect dtypes to be same. This works in PyTorch eager, as dispatcher applies the
         # conversion first and then passes the converted input to the operator.


### PR DESCRIPTION
Fixes: https://github.com/Lightning-AI/lightning-thunder/issues/678

In PyTorch eager, enabling autocast allows mixed inputs to operator like `linear` which expect dtypes to be same. This works in PyTorch eager, as dispatcher applies the conversion first and then passes the converted input to the operator.

To mimick similar behavior, here we update the mapping of `torch` -> `thunder.torch` for all operators which have autocast rule, to apply the conversion rule and call the mapped function if autocast was enabled otherwise to directly map the function.