### PR TITLE
quick patch on nvfuser getnv/reshape to handle sequence with NumberProxy

### DIFF
--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -117,7 +117,7 @@ def getnv(x: Any, fd: FusionDefinition, lc_to_nv_map: dict) -> Any:
     if isinstance(x, (Number, dtypes.dtype, type, Device)):
         return _define_constant(fd, x)
     if isinstance(x, Sequence):
-        return tuple((getnv(i, fd, lc_to_nv_map) for i in x))
+        return tuple(getnv(i, fd, lc_to_nv_map) for i in x)
 
     utils.check(False, lambda: f"Cannot translate {x} of type {type(x)} to an nvFuser object")
 

--- a/thunder/tests/test_jit_general.py
+++ b/thunder/tests/test_jit_general.py
@@ -1090,3 +1090,32 @@ def test_isinstance_parameter():
     actual = thunder.jit(m)(x)
 
     torch.testing.assert_close(actual, expected)
+
+
+@pytest.mark.parametrize(
+    "device",
+    ("cpu", "cuda"),
+)
+def test_cache_symbolic_values_reshape(device):
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+    a = torch.randn((4, 8, 6), device=device)
+
+    def foo(t, batch_size):
+        return t.reshape(batch_size, -1).sum(-1)
+
+    jfoo = thunder.jit(foo, cache="symbolic values", nv_enable_bookend=False)
+    expected = foo(a, 32)
+    actual = jfoo(a, 32)
+
+    assert_close(expected, actual)
+    assert thunder.cache_misses(jfoo) == 1
+    assert thunder.cache_hits(jfoo) == 0
+
+    expected = foo(a, 16)
+    actual = jfoo(a, 16)
+
+    assert_close(expected, actual)
+    assert thunder.cache_misses(jfoo) == 1
+    assert thunder.cache_hits(jfoo) == 1


### PR DESCRIPTION
1. recursively go through `getnv` on sequence to retrieve dynamic scalar for nvfuser.
2. update reshape parsing in nvfuser executor to allow NumberProxy in new shape.