### PR TITLE
`namespace` became keyword only in 0.12.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,6 +3,6 @@ looseversion ==1.3.0
 lightning-utilities >=0.7.0
 numpy >=1.23.0,<2  # not yet ready for numpy 2
 igraph >=0.10.4
-optree >=0.9.2,<=0.11.0
+optree >=0.9.2
 opt_einsum >= 3.3.0
 mpmath <1.4.0  # todo: teporarl pin for `NameError: name '_C' is not defined`

--- a/thunder/core/pytree.py
+++ b/thunder/core/pytree.py
@@ -71,7 +71,7 @@ def register_pytree_node_dataclass(cls):
 
     _flatten = lambda obj: tree_flatten(unpack(obj), namespace=OPTREE_NAMESPACE)
     _unflatten = lambda spec, children: cls(**spec.unflatten(children))
-    optree.register_pytree_node(cls, _flatten, _unflatten, OPTREE_NAMESPACE)
+    optree.register_pytree_node(cls, _flatten, _unflatten, namespace=OPTREE_NAMESPACE)
     return cls
 
 


### PR DESCRIPTION
with the reference of https://github.com/metaopt/optree/blob/a0d1d6225f516ea3a2eeae1b14bfb48cce1a73de/optree/registry.py#L120-L122

rel:
- https://github.com/Lightning-AI/lightning-thunder/actions/runs/9803707365/job/27070254289?pr=714 
- https://github.com/Lightning-AI/lightning-thunder/pull/715