### PR TITLE
Exception types for interpolate()

### DIFF
--- a/thunder/tests/test_ops.py
+++ b/thunder/tests/test_ops.py
@@ -199,3 +199,45 @@ def test_core_vs_numpy_consistency(op: OpInfo, device: str, dtype: dtypes.dtype,
         )
         if result is not None:
             return result
+
+def test_notimplemented_interpolate_align():
+    def foo():
+        t0 = torch.randn((22, 288, 15, 20), dtype=torch.float16)
+        t1 = torch.nn.functional.interpolate(
+            t0,
+            scale_factor=2.0,
+            mode='nearest',
+            align_corners=True
+        )
+        return t1
+    with pytest.raises(NotImplementedError, match="not yet support"):
+        tfoo = thunder.jit(foo)
+        tfoo()
+
+def test_notimplemented_interpolate_recompute_scale():
+    def foo():
+        t0 = torch.randn((22, 288, 15, 20), dtype=torch.float16)
+        t1 = torch.nn.functional.interpolate(
+            t0,
+            scale_factor=2.0,
+            mode='nearest',
+            recompute_scale_factor=True
+        )
+        return t1
+    with pytest.raises(NotImplementedError, match="not yet support"):
+        tfoo = thunder.jit(foo)
+        tfoo()
+
+def test_notimplemented_interpolate_antialias():
+    def foo():
+        t0 = torch.randn((22, 288, 15, 20), dtype=torch.float16)
+        t1 = torch.nn.functional.interpolate(
+            t0,
+            scale_factor=2.0,
+            mode='nearest',
+            antialias=True,
+        )
+        return t1
+    with pytest.raises(NotImplementedError, match="not yet support"):
+        tfoo = thunder.jit(foo)
+        tfoo()

--- a/thunder/tests/test_ops.py
+++ b/thunder/tests/test_ops.py
@@ -200,33 +200,28 @@ def test_core_vs_numpy_consistency(op: OpInfo, device: str, dtype: dtypes.dtype,
         if result is not None:
             return result
 
+
 def test_notimplemented_interpolate_align():
     def foo():
         t0 = torch.randn((22, 288, 15, 20), dtype=torch.float16)
-        t1 = torch.nn.functional.interpolate(
-            t0,
-            scale_factor=2.0,
-            mode='nearest',
-            align_corners=True
-        )
+        t1 = torch.nn.functional.interpolate(t0, scale_factor=2.0, mode="nearest", align_corners=True)
         return t1
+
     with pytest.raises(NotImplementedError, match="not yet support"):
         tfoo = thunder.jit(foo)
         tfoo()
 
+
 def test_notimplemented_interpolate_recompute_scale():
     def foo():
         t0 = torch.randn((22, 288, 15, 20), dtype=torch.float16)
-        t1 = torch.nn.functional.interpolate(
-            t0,
-            scale_factor=2.0,
-            mode='nearest',
-            recompute_scale_factor=True
-        )
+        t1 = torch.nn.functional.interpolate(t0, scale_factor=2.0, mode="nearest", recompute_scale_factor=True)
         return t1
+
     with pytest.raises(NotImplementedError, match="not yet support"):
         tfoo = thunder.jit(foo)
         tfoo()
+
 
 def test_notimplemented_interpolate_antialias():
     def foo():
@@ -234,10 +229,11 @@ def test_notimplemented_interpolate_antialias():
         t1 = torch.nn.functional.interpolate(
             t0,
             scale_factor=2.0,
-            mode='nearest',
+            mode="nearest",
             antialias=True,
         )
         return t1
+
     with pytest.raises(NotImplementedError, match="not yet support"):
         tfoo = thunder.jit(foo)
         tfoo()

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -4591,12 +4591,21 @@ def interpolate(
 
     utils.check(a.ndim >= 3, lambda: f"Expected {a.ndim=} >= 3")
     utils.check(a.numel() > 0, lambda: f"Expected {a.numel=} to be greater than 0")
-    utils.check(align_corners == None, lambda: f"'align_corners' is not yet supported.")
+    utils.check(
+        align_corners == None,
+        lambda: f"Thunder does not yet support 'align_corners'.",
+        exception_type=NotImplementedError,
+    )
     utils.check(
         recompute_scale_factor is None or recompute_scale_factor == False,
-        lambda: f"'recompute_scale_factor=True' is not yet supported.",
+        lambda: f"Thunder does not yet support 'recompute_scale_factor=True'.",
+        exception_type=NotImplementedError,
     )
-    utils.check(antialias == False, lambda: f"'antialias=True' is not yet supported.")
+    utils.check(
+        antialias == False,
+        lambda: f"Thunder does not yet support 'antialias=True'.",
+        exception_type=NotImplementedError,
+    )
 
     utils.check(
         (size is not None) ^ (scale_factor is not None),


### PR DESCRIPTION
Follow-ups from #679:

* Use NotImplementedError for the exception type.
* Add some negative tests for this to ensure something runs in CI.