### PR TITLE
sort: a prim with grad support

### DIFF
--- a/thunder/clang/__init__.py
+++ b/thunder/clang/__init__.py
@@ -1978,3 +1978,14 @@ def topk(
     dim = utils.canonicalize_dim(a.ndim, dim)
 
     return prims.topk(a, k, dim, bool(largest), bool(sorted), out=out)
+
+
+@clangop()
+def sort(
+    a: TensorLike, /, dim: None | int = None, descending: bool = False, stable: bool = False, *, out=None
+) -> (TensorProxy, TensorProxy):
+    if dim is None:
+        dim = a.ndim - 1 if a.ndim > 0 else 0
+    dim = utils.canonicalize_dim(a.ndim, dim)
+
+    return prims.sort(a, dim, descending, stable, out=out)

--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -243,6 +243,8 @@ class PrimIDs(Enum):
     ARGMAX = auto()
     ARGMIN = auto()
     TOPK = auto()
+    # Sort and dim permutations prims
+    SORT = auto()
     # Scatter and gather prims (Experimental!)
     GATHER = auto()
     INDEX_ADD = auto()
@@ -3376,6 +3378,25 @@ def topk_meta(
 
 
 topk = make_prim(PrimIDs.TOPK, "topk", meta=topk_meta, tags=(OpTags.REDUCTION_OP,))
+
+
+def sort_meta(
+    a: TensorProxy, /, dim: int, descending: Number, sorted: Number, *, out: None | TensorProxy
+) -> (TensorProxy, TensorProxy):
+    utils.check(
+        out is None,
+        lambda: "Only `out` which is None is currently supported",
+    )
+
+    utils.check_type(a, TensorProxy)
+    utils.check_type(dim, (int, IntegerProxy))
+    utils.check(pytype(descending) is bool, lambda: f"Expected {descending=} to be a boolean type")
+    utils.check(pytype(sorted) is bool, lambda: f"Expected {sorted=} to be a boolean type")
+
+    return TensorProxy(like=a), TensorProxy(like=a, dtype=dtypes.int64)
+
+
+sort = make_prim(PrimIDs.SORT, "sort", meta=sort_meta)
 
 
 def transpose_meta(a: TensorProxy, /, permutation: tuple[int, ...]) -> TensorProxy:

--- a/thunder/executors/torchex.py
+++ b/thunder/executors/torchex.py
@@ -1119,6 +1119,14 @@ argmin = _register_torch_operation("argmin")
 topk = _register_torch_operation("topk")
 
 
+#
+# Sort and dim permutations operations
+#
+
+
+sort = _register_torch_operation("sort")
+
+
 # NOTE The following transforms are necessary because thunder uses the parameter name 'dims' while PyTorch
 #   uses 'dim'
 def _amax_prim_transform(a: TensorProxy, /, dims: Sequence[int]) -> TensorProxy:
@@ -1193,6 +1201,29 @@ _register_implementation(ltorch.var_mean, var_mean, checker=_always_executable)
 _register_implementation(ltorch.argmax, argmax, checker=_always_executable)
 _register_implementation(ltorch.argmin, argmin, checker=_always_executable)
 _register_implementation(ltorch.topk, topk, checker=_always_executable, execution_transform=_topk_transform)
+
+
+#
+# Sort and dim permutations operations
+#
+
+
+# NOTE this transform translates number proxies to boolean values
+# and handles dim = None
+def _sort_transform(
+    a: TensorProxy, /, dim: int | None = None, descending: bool = False, stable: bool = False, *, out=None
+):
+    if dim is None:
+        dim = a.ndim - 1 if a.ndim > 0 else 0
+
+    # NOTE: args past `a` are passed as kwargs to avoid issues with multiple `torch.sort` overloadings
+    return sort(a, dim=dim, descending=bool(descending), stable=bool(stable), out=out)
+
+
+_register_implementation(prims.sort, checker=_always_executable, execution_transform=_sort_transform)
+
+_register_implementation(ltorch.sort, checker=_always_executable, execution_transform=_sort_transform)
+
 
 #
 # Scatter and gather operations

--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -5477,6 +5477,68 @@ opinfos.extend(reduction_ops)
 
 
 #
+# Sort and dim permutations operations
+#
+dim_perm_ops = []
+
+
+def sort_sample_generator(op, device, dtype, requires_grad, **kwargs):
+    make = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)
+
+    # shape, dim
+    cases = (
+        ((),),
+        ((), 0),
+        ((3, 0),),
+        ((4, 4), 1),
+        ((4, 1, 6), -1),
+        ((4, 1, 6), 0),
+        ((4, 7, 5, 1), -3),
+        ((4, 2, 5, 1),),
+    )
+
+    for shape, *dim in cases:
+        if dim:
+            dim = dim[0]
+        else:
+            dim = -1
+
+        for descending, stable in itertools.product((True, False), repeat=2):
+            yield SampleInput(make(shape), dim=dim, descending=descending, stable=stable)
+
+
+sort_opinfo = OpInfo(
+    clang.sort,
+    name="sort",
+    supports_grad=True,
+    # Without the fixed seed this generator does not guarantee
+    # to produce inputs at which sort is differentiable
+    # (i.e. when sort(x, ...).indices == sort(x + dx, ...).indices).
+    # TODO: (@nikitaved): potentially modify these inputs to
+    # fix the issue.
+    sample_input_generator=sort_sample_generator,
+    torch_reference=torch.sort,
+    dtypes=(datatypes.bool8, datatypes.signedinteger, datatypes.unsignedinteger, datatypes.floating),
+    test_directives=(
+        DecorateInfo(
+            custom_comparator(partial(assert_close, atol=1e-6, rtol=1e-6)),
+            "test_vjp_correctness",
+        ),
+        DecorateInfo(
+            pytest.mark.skip(reason="PyTorch does not yet support boolean types in sort for CUDA"),
+            "test_core_vs_torch_consistency",
+            dtypes=(datatypes.bool8,),
+            devicetypes=(devices.DeviceType.CUDA,),
+        ),
+    ),
+)
+dim_perm_ops.append(sort_opinfo)
+
+
+opinfos.extend(dim_perm_ops)
+
+
+#
 # Tensor Creation OpInfos
 #
 tensor_creation_ops = []

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -2716,6 +2716,13 @@ def topk(
     return clang.topk(a, k, dim, largest, sorted, out=out)
 
 
+@torchsymbol(torch.sort, is_method=True)
+def sort(
+    a: TensorLike, /, dim: None | int = None, descending: bool = False, stable: bool = False, *, out=None
+) -> (TensorLike, TensorLike):
+    return clang.sort(a, dim, descending, stable, out=out)
+
+
 #
 # Scatter and gather-related operations
 #


### PR DESCRIPTION
This enables sort/stable sort in Thunder.

This is also a required piece to be able to remove data-dependent `where` in NeMo (cc @tfogal) .
