### PR TITLE
topk: remove grad tests skip

### DIFF
--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -5462,13 +5462,6 @@ topk_opinfo = OpInfo(
     error_input_generator=topk_error_generator,
     torch_reference=torch.topk,
     dtypes=(datatypes.signedinteger, datatypes.unsignedinteger, datatypes.floating),
-    test_directives=(
-        DecorateInfo(
-            # See https://github.com/Lightning-AI/lightning-thunder/issues/120
-            pytest.mark.skip(reason="Cannot handle inputs/outputs which do not require grads"),
-            "test_vjp_correctness",
-        ),
-    ),
 )
 reduction_ops.append(topk_opinfo)
 


### PR DESCRIPTION
As per title. The underlying issue was fixed by @kshitij12345 , so we can enable grad tests for `topk`.