### PR TITLE
Disable bookend by default. 

### DIFF
--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -803,9 +803,10 @@ the metadata operation is awkward enough to force the output tensor to be
 instantiated) this heuristic actually leads to worse code.
 """
             enable_bookend: None | bool = get_compile_option("nv_enable_bookend", bookend_help)
-            # Set default value.
             if enable_bookend is None:
-                enable_bookend = False
+                # Set the default value. Before 0.2.10, bookending was needed
+                # to hide https://github.com/NVIDIA/Fuser/issues/2395.
+                enable_bookend = nvfuser_version() < LooseVersion("0.2.10")
             assert isinstance(enable_bookend, bool)
 
             if enable_bookend:

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -805,7 +805,7 @@ instantiated) this heuristic actually leads to worse code.
             enable_bookend: None | bool = get_compile_option("nv_enable_bookend", bookend_help)
             # Set default value.
             if enable_bookend is None:
-                enable_bookend = True
+                enable_bookend = False
             assert isinstance(enable_bookend, bool)
 
             if enable_bookend:

--- a/thunder/tests/framework.py
+++ b/thunder/tests/framework.py
@@ -14,7 +14,6 @@ import torch
 from torch._dynamo import is_inductor_supported
 from torch.testing import assert_close
 
-from looseversion import LooseVersion
 from lightning_utilities.core.imports import package_available
 
 from thunder.core.pytree import tree_flatten, tree_unflatten, tree_map
@@ -192,7 +191,7 @@ class nvFuserTestExecutor(TestExecutor):
         return [executors.get_nvfuser_executor()]
 
     def version(self):
-        return executors.get_nvfuser_executor().version()
+        return executors.get_nvfuser_executor().version
 
 
 # TODO Convert to singletons or just add to executor logic

--- a/thunder/tests/test_examine_memory.py
+++ b/thunder/tests/test_examine_memory.py
@@ -149,16 +149,16 @@ def test_nanogpt_block(executor, device, dtype):
 
     if isinstance(executor, nvFuserTestExecutor):
         assert fw_alloc_mem[0] == 267426816
-        # t67 is the expand result of ln_2_weight, and they are both return values in trace
-        # but for calculation we assume they share memory, so expect to subtract the size of t67
-        expected_return_calculated_mem = get_return_memory(fw_extrace.bound_symbols[-1]) - 4 * 2 * 1024 * 768
+        expected_return_calculated_mem = get_return_memory(fw_extrace.bound_symbols[-1])
         assert expected_return_calculated_mem == sum(fw_alloc_mem[1].values())
 
-        assert bw_alloc_mem[0] == 361783296
+        assert bw_alloc_mem[0] == 412112896
         assert sum(bw_alloc_mem[1].values()) == get_return_memory(bw_extrace.bound_symbols[-1])
     if isinstance(executor, TorchTestExecutor):
         assert fw_alloc_mem[0] == 362863616
-        # same reason as above, expect to -t38+t37-t65-t67
+        # Expect the memory to -t38+t37-t65-t67.
+        # t67 is the expand result of ln_2_weight, and they are both return values in trace
+        # but for calculation we assume they share memory, so expect to subtract the size of t67.
         expected_return_calculated_mem = (
             get_return_memory(fw_extrace.bound_symbols[-1]) - 23 * 1024 * 1024 - 4 * 2 * 1024 * 768 * 2
         )

--- a/thunder/tests/test_inplace_functionalization.py
+++ b/thunder/tests/test_inplace_functionalization.py
@@ -364,6 +364,14 @@ def test_multiple_inplace_to_args(executor, device, _):
     dtypes=NOTHING,
 )
 def test_multiple_views_before_inplace_to_base(executor, device, _):
+    from thunder.tests.framework import nvFuserTestExecutor
+
+    if type(executor) is nvFuserTestExecutor:
+        pytest.skip(
+            "nvFuser doesn't enforce the order between `z=x.view(-1)` and "
+            "`x.add_(1)`, so the behavior is undefined due to this "
+            "race condition."
+        )
 
     # ref: https://github.com/pytorch/pytorch/blob/29e2e2a/test/test_functionalization.py#L159-L169
     def f(x):

--- a/thunder/tests/test_inplace_functionalization.py
+++ b/thunder/tests/test_inplace_functionalization.py
@@ -370,7 +370,7 @@ def test_multiple_views_before_inplace_to_base(executor, device, _):
         pytest.skip(
             "nvFuser doesn't enforce the order between `z=x.view(-1)` and "
             "`x.add_(1)`, so the behavior is undefined due to this "
-            "race condition."
+            "race condition. See https://github.com/NVIDIA/Fuser/issues/2839."
         )
 
     # ref: https://github.com/pytorch/pytorch/blob/29e2e2a/test/test_functionalization.py#L159-L169

--- a/thunder/tests/test_nvfuser_remat.py
+++ b/thunder/tests/test_nvfuser_remat.py
@@ -330,7 +330,7 @@ def test_find_cut_dropout(executor, device, _):
     ext_producer_outputs = find_external_producer_outputs(utils.consumers(trace), (), producer, consumer)
     cut = find_cut(ext_producer_outputs, producer, consumer)
     assert cut[0] == producer.args[0].name
-    # Note cut[1]/producer.output[0] is the boolean mask for dropout. It should
+    # Note cut[1]/producer.output[1] is the boolean mask for dropout. It should
     # be chosen over the float32 mask. See this issue: "The Recomputation
     # Algorithm on Dropout choses a float32 mask to save"
     producer_output_names = tuple(o.name for o in producer.output)

--- a/thunder/tests/test_nvfuser_remat.py
+++ b/thunder/tests/test_nvfuser_remat.py
@@ -330,7 +330,7 @@ def test_find_cut_dropout(executor, device, _):
     ext_producer_outputs = find_external_producer_outputs(utils.consumers(trace), (), producer, consumer)
     cut = find_cut(ext_producer_outputs, producer, consumer)
     assert cut[0] == producer.args[0].name
-    # Note cut[1]/producer.output[1] is the boolean mask for dropout. It should
+    # Note cut[1] is the boolean mask for dropout. It should
     # be chosen over the float32 mask. See this issue: "The Recomputation
     # Algorithm on Dropout choses a float32 mask to save"
     producer_output_names = tuple(o.name for o in producer.output)


### PR DESCRIPTION
https://github.com/Lightning-AI/lightning-thunder/pull/974 hided the RoPE regression that used to block this PR, so the benchmark numbers look mostly neutral. 

```
$ pwd
/opt/pytorch/nvfuser

$ python tools/benchmark_thunder.py --storage ~/workspace main:main wjy/bookend:main
$ pytest-benchmark --storage ~/workspace compare 0017 0018 --group-by name
```

https://gist.github.com/wujingyue/a87080535d5f482f954b3ec8e835a66a

0017 -- without this PR
0018 -- with this PR

For `test_nanogpt_layer_norm[forward-thunder]`, 0018 wins by 13%. Other differences (namely,
`test_litgpt_qkv_split_rope[Mistral-7B-v0.1-forward-bs2-thunder]`, `test_litgpt_qkv_split_rope[Mistral-7B-v0.1-inference-bs2-thunder]`, `test_litgpt_qkv_split_rope[phi-2-forward-bs2-thunder]`, and `test_litgpt_qkv_split_rope[Mistral-7B-v0.1-inference-bs1-thunder]`) are noise and disappeared the second time I ran them. 

cc @tfogal