### PR TITLE
Adjust the if condition to warn only for relevant input params

### DIFF
--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -211,7 +211,7 @@ class Benchmark_litGPT:
                 self.global_batch_size % self.micro_batch_size * world_size == 0
             ), f"Global Batch Size {self.global_batch_size} should be a multiple Micro Batch Size {self.micro_batch_size} * World Size {world_size}."
 
-        if self.checkpoint_activations:
+        if self.checkpoint_activations and "thunder" in self.compile:
             warnings.warn(
                 "Activations checkpointing is configured, but Thunder does not support checkpointing. Checkpointing will be ignored."
             )


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

## What does this PR do?

As a follow-up for the [reported issue](https://github.com/Lightning-AI/lightning-thunder/issues/737), this PR adds a more constrained condition for warning about activation checkpointing. It makes sure the warning is shown only for relevant input configuration.

The reason for this change is that if we use activation checkpointing for `eager` or `inductor`, we get in the logs:
```
Activations checkpointing is configured, but Thunder does not support checkpointing. Checkpointing will be ignored.
```
which confused us as we thought we had a bug and run Thunder instead of the above mentioned compiler backends.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
