### PR TITLE
Remove some nanoGPT cases from benchmarks/targets.py, they are replaced by LitGPT

### DIFF
--- a/thunder/benchmarks/__init__.py
+++ b/thunder/benchmarks/__init__.py
@@ -1204,7 +1204,7 @@ class LitGPTGeluBenchmark(Benchmark, metaclass=UserFacingBenchmarkMeta):
         config: str | LitGPTConfig,
         batchdims: Sequence[int],
         device: str,
-        dtype: dtypes.dtype ,
+        dtype: dtypes.dtype,
         requires_grad: bool,
     ) -> None:
         super().__init__()

--- a/thunder/benchmarks/targets.py
+++ b/thunder/benchmarks/targets.py
@@ -306,7 +306,7 @@ sdpa_executors_ids = (
 
 
 # Sample command to run this benchmark:
-# pytest thunder/benchmarks/targets.py -k "test_litgpt_sdpa_grad" --benchmark-group-by='param:config,param:bs' --benchmark-columns='min,max,mean,stddev,median'
+# pytest thunder/benchmarks/targets.py -k "test_litgpt_sdpa" --benchmark-group-by='param:config,param:bs,param:compute_type'
 @pytest.mark.parametrize(
     "executor,",
     sdpa_executors,

--- a/thunder/benchmarks/targets.py
+++ b/thunder/benchmarks/targets.py
@@ -271,6 +271,8 @@ def test_nanogpt_cross_entropy(benchmark, executor: None | Callable, compute_typ
     benchmark_for_compute_type(compute_type, benchmark, fn, args, kwargs)
 
 
+# TODO: Upgrade this benchmark to use LitGPT and config, batch size parametrization
+# https://github.com/Lightning-AI/lightning-thunder/issues/740
 @pytest.mark.parametrize(
     "executor,",
     (executors + cudnn_layernorm_executors),

--- a/thunder/benchmarks/targets.py
+++ b/thunder/benchmarks/targets.py
@@ -477,6 +477,8 @@ def test_llama2_mlp_7b(benchmark, executor: Callable, compute_type: ComputeType)
     benchmark_for_compute_type(compute_type, benchmark, fn, args, kwargs)
 
 
+# TODO: Upgrade this benchmark to use LitGPT and config, batch size parametrization
+# https://github.com/Lightning-AI/lightning-thunder/issues/743
 @pytest.mark.parametrize(
     "executor,",
     executors,

--- a/thunder/benchmarks/targets.py
+++ b/thunder/benchmarks/targets.py
@@ -1,7 +1,7 @@
 import os
 from collections.abc import Callable
 from enum import auto, Enum
-from typing import Sequence
+from collections.abc import Sequence
 
 import pytest
 import torch
@@ -165,6 +165,7 @@ cudnn_layernorm_executors_ids = (
     "thunder+cudnn_layernorm+nvfuser",
 )
 
+
 def get_unique_configs(config_options: Sequence[str]):
     """
     Get the unique configurations based on the given config options.
@@ -176,10 +177,7 @@ def get_unique_configs(config_options: Sequence[str]):
     unique_config_names = {}
     for config_name in config_names:
         config = LitGPTConfig.from_name(config_name)
-        key = tuple(
-            getattr(config, k)
-            for k in config_options
-        )
+        key = tuple(getattr(config, k) for k in config_options)
         if config_name in IMPORTANT_CONFIGS:
             unique_config_names[key] = config_name
         unique_config_names.setdefault(key, config_name)
@@ -219,7 +217,11 @@ def get_configs_for_gelu():
 )
 def test_litgpt_gelu(benchmark, executor: Callable, bs: int, compute_type: ComputeType, config: str):
     gelu_bench: Benchmark = LitGPTGeluBenchmark(
-        config=config, batchdims=(bs,), device="cuda:0", dtype=thunder.bfloat16, requires_grad=is_requires_grad(compute_type)
+        config=config,
+        batchdims=(bs,),
+        device="cuda:0",
+        dtype=thunder.bfloat16,
+        requires_grad=is_requires_grad(compute_type),
     )
 
     args, kwargs = gelu_bench.make_batch()

--- a/thunder/benchmarks/targets.py
+++ b/thunder/benchmarks/targets.py
@@ -361,6 +361,8 @@ def test_nanogpt_mlp(benchmark, executor: Callable, compute_type: ComputeType):
     benchmark_for_compute_type(compute_type, benchmark, fn, args, kwargs)
 
 
+# TODO: Upgrade this benchmark to use LitGPT and config, batch size parametrization
+# https://github.com/Lightning-AI/lightning-thunder/issues/743
 # NOTE The CSA module is linear -> sdpa -> dropout
 @pytest.mark.parametrize(
     "executor,",

--- a/thunder/benchmarks/targets.py
+++ b/thunder/benchmarks/targets.py
@@ -433,7 +433,7 @@ def test_llama2_mlp_7b(benchmark, executor: Callable, compute_type: ComputeType)
 def test_llama2_causal_self_attention_7b(benchmark, executor: Callable, compute_type: ComputeType):
     bench: Benchmark = LitGPTCausalSelfAttentionBenchmark(
         config="Llama-2-7b-hf",
-        batchdims=(16,),
+        batchdims=(2,),
         device="cuda:0",
         dtype=thunder.bfloat16,
         requires_grad=is_requires_grad(compute_type),

--- a/thunder/benchmarks/targets.py
+++ b/thunder/benchmarks/targets.py
@@ -410,7 +410,7 @@ def test_llama_2_7b_hf(benchmark, executor: Callable, compute_type: ComputeType)
 def test_llama2_mlp_7b(benchmark, executor: Callable, compute_type: ComputeType):
     bench: Benchmark = LlamaMLPBenchmark(
         config="Llama-2-7b-hf",
-        batchdims=(16,),
+        batchdims=(2,),
         device="cuda:0",
         dtype=thunder.bfloat16,
         requires_grad=is_requires_grad(compute_type),

--- a/thunder/benchmarks/targets.py
+++ b/thunder/benchmarks/targets.py
@@ -22,7 +22,6 @@ from thunder.benchmarks import (
     NanoGPTBenchmark,
     NanoGPTBlockBenchmark,
     NanoGPTCrossEntropyBenchmark,
-    NanoGPTCSABenchmark,
     LitGPTGeluBenchmark,
     NanoGPTLayerNormBenchmark,
     thunder_apex_executor,
@@ -330,29 +329,6 @@ def test_litgpt_sdpa(benchmark, executor: Callable, bs, compute_type, config):
     bench: Benchmark = LitGPTSDPABenchmark(
         config=config,
         batchdims=(bs,),
-        device="cuda:0",
-        dtype=thunder.bfloat16,
-        requires_grad=is_requires_grad(compute_type),
-    )
-
-    args, kwargs = bench.make_batch()
-    fn = executor(bench.fn())
-
-    benchmark_for_compute_type(compute_type, benchmark, fn, args, kwargs)
-
-
-# TODO: Upgrade this benchmark to use LitGPT and config, batch size parametrization
-# https://github.com/Lightning-AI/lightning-thunder/issues/743
-# NOTE The CSA module is linear -> sdpa -> dropout
-@pytest.mark.parametrize(
-    "executor,",
-    executors,
-    ids=executors_ids,
-)
-@parametrize_compute_type
-def test_nanogpt_csa(benchmark, executor: Callable, compute_type: ComputeType):
-    bench: Benchmark = NanoGPTCSABenchmark(
-        config="gpt2-xl",
         device="cuda:0",
         dtype=thunder.bfloat16,
         requires_grad=is_requires_grad(compute_type),

--- a/thunder/benchmarks/targets.py
+++ b/thunder/benchmarks/targets.py
@@ -342,6 +342,8 @@ def test_litgpt_sdpa(benchmark, executor: Callable, bs, compute_type, config):
     benchmark_for_compute_type(compute_type, benchmark, fn, args, kwargs)
 
 
+# TODO: Upgrade this benchmark to use LitGPT and config, batch size parametrization
+# https://github.com/Lightning-AI/lightning-thunder/issues/742
 @pytest.mark.parametrize(
     "executor,",
     executors,

--- a/thunder/benchmarks/targets.py
+++ b/thunder/benchmarks/targets.py
@@ -20,7 +20,6 @@ from thunder.benchmarks import (
     LitGPTSDPABenchmark,
     LlamaMLPBenchmark,
     NanoGPTBenchmark,
-    NanoGPTBlockBenchmark,
     NanoGPTCrossEntropyBenchmark,
     LitGPTGeluBenchmark,
     NanoGPTLayerNormBenchmark,
@@ -332,24 +331,6 @@ def test_litgpt_sdpa(benchmark, executor: Callable, bs, compute_type, config):
         device="cuda:0",
         dtype=thunder.bfloat16,
         requires_grad=is_requires_grad(compute_type),
-    )
-
-    args, kwargs = bench.make_batch()
-    fn = executor(bench.fn())
-
-    benchmark_for_compute_type(compute_type, benchmark, fn, args, kwargs)
-
-
-# NOTE NanoGPT's block module is layernorm -> csa -> layernorm -> mlp
-@pytest.mark.parametrize(
-    "executor,",
-    executors,
-    ids=executors_ids,
-)
-@parametrize_compute_type
-def test_nanogpt_block(benchmark, executor: Callable, compute_type: ComputeType):
-    bench: Benchmark = NanoGPTBlockBenchmark(
-        config="gpt2-xl", device="cuda:0", dtype=thunder.bfloat16, requires_grad=is_requires_grad(compute_type)
     )
 
     args, kwargs = bench.make_batch()

--- a/thunder/benchmarks/targets.py
+++ b/thunder/benchmarks/targets.py
@@ -26,7 +26,6 @@ from thunder.benchmarks import (
     LitGPTGeluBenchmark,
     NanoGPTLayerNormBenchmark,
     NanoGPTMLPBenchmark,
-    NanoGPTSDPABenchmark,
     thunder_apex_executor,
     thunder_apex_nvfuser_executor,
     thunder_cudnn_executor,
@@ -283,22 +282,6 @@ def test_nanogpt_layer_norm(benchmark, executor: None | Callable, compute_type: 
         pytest.skip("Executor is unavailable")
 
     bench: Benchmark = NanoGPTLayerNormBenchmark(
-        config="gpt2-xl", device="cuda:0", dtype=thunder.bfloat16, requires_grad=is_requires_grad(compute_type)
-    )
-
-    args, kwargs = bench.make_batch()
-    fn = executor(bench.fn())
-
-    benchmark_for_compute_type(compute_type, benchmark, fn, args, kwargs)
-
-
-@pytest.mark.parametrize("executor,", (executors + cudnn_executors), ids=(executors_ids + cudnn_executors_ids))
-@parametrize_compute_type
-def test_nanogpt_sdpa(benchmark, executor: None | Callable, compute_type: ComputeType):
-    if executor is None:
-        pytest.skip("Executor is unavailable")
-
-    bench: Benchmark = NanoGPTSDPABenchmark(
         config="gpt2-xl", device="cuda:0", dtype=thunder.bfloat16, requires_grad=is_requires_grad(compute_type)
     )
 

--- a/thunder/benchmarks/targets.py
+++ b/thunder/benchmarks/targets.py
@@ -25,7 +25,6 @@ from thunder.benchmarks import (
     NanoGPTCSABenchmark,
     LitGPTGeluBenchmark,
     NanoGPTLayerNormBenchmark,
-    NanoGPTMLPBenchmark,
     thunder_apex_executor,
     thunder_apex_nvfuser_executor,
     thunder_cudnn_executor,
@@ -334,25 +333,6 @@ def test_litgpt_sdpa(benchmark, executor: Callable, bs, compute_type, config):
         device="cuda:0",
         dtype=thunder.bfloat16,
         requires_grad=is_requires_grad(compute_type),
-    )
-
-    args, kwargs = bench.make_batch()
-    fn = executor(bench.fn())
-
-    benchmark_for_compute_type(compute_type, benchmark, fn, args, kwargs)
-
-
-# TODO: Upgrade this benchmark to use LitGPT and config, batch size parametrization
-# https://github.com/Lightning-AI/lightning-thunder/issues/742
-@pytest.mark.parametrize(
-    "executor,",
-    executors,
-    ids=executors_ids,
-)
-@parametrize_compute_type
-def test_nanogpt_mlp(benchmark, executor: Callable, compute_type: ComputeType):
-    bench: Benchmark = NanoGPTMLPBenchmark(
-        config="gpt2-xl", device="cuda:0", dtype=thunder.bfloat16, requires_grad=is_requires_grad(compute_type)
     )
 
     args, kwargs = bench.make_batch()

--- a/thunder/benchmarks/targets.py
+++ b/thunder/benchmarks/targets.py
@@ -474,6 +474,8 @@ def test_llama_2_7b_hf(benchmark, executor: Callable, compute_type: ComputeType)
     benchmark_for_compute_type(compute_type, benchmark, fn, args, kwargs)
 
 
+# TODO: Upgrade this benchmark to use LitGPT and config, batch size parametrization
+# https://github.com/Lightning-AI/lightning-thunder/issues/742
 @pytest.mark.parametrize(
     "executor,",
     executors,

--- a/thunder/benchmarks/targets.py
+++ b/thunder/benchmarks/targets.py
@@ -387,18 +387,6 @@ def test_nanogpt_gpt2xl(benchmark, executor: Callable, compute_type: ComputeType
 
 @pytest.mark.parametrize("executor,", (executors + cudnn_executors), ids=(executors_ids + cudnn_executors_ids))
 @parametrize_compute_type
-def test_open_llama_7b(benchmark, executor: Callable, compute_type: ComputeType):
-    cfg: LitGPTConfig = LitGPTConfig.from_name("open_llama_7b")
-    b = LitGPTBenchmark(cfg, device="cuda:0", dtype=torch.bfloat16, requires_grad=is_requires_grad(compute_type))
-
-    args, kwargs = b.make_batch()
-    fn = executor(b.fn())
-
-    benchmark_for_compute_type(compute_type, benchmark, fn, args, kwargs)
-
-
-@pytest.mark.parametrize("executor,", (executors + cudnn_executors), ids=(executors_ids + cudnn_executors_ids))
-@parametrize_compute_type
 def test_llama_2_7b_hf(benchmark, executor: Callable, compute_type: ComputeType):
     cfg: LitGPTConfig = LitGPTConfig.from_name("Llama-2-7b-hf")
     b = LitGPTBenchmark(

--- a/thunder/benchmarks/targets.py
+++ b/thunder/benchmarks/targets.py
@@ -266,23 +266,6 @@ def test_nanogpt_sdpa(benchmark, executor: None | Callable, compute_type: Comput
     benchmark_for_compute_type(compute_type, benchmark, fn, args, kwargs)
 
 
-@pytest.mark.parametrize(
-    "executor,",
-    executors,
-    ids=executors_ids,
-)
-@parametrize_compute_type
-def test_llama2_7b_sdpa(benchmark, executor: Callable, compute_type: ComputeType):
-    bench: Benchmark = LitGPTSDPABenchmark(
-        config="Llama-2-7b-hf", device="cuda:0", dtype=thunder.bfloat16, requires_grad=is_requires_grad(compute_type)
-    )
-
-    args, kwargs = bench.make_batch()
-    fn = executor(bench.fn())
-
-    benchmark_for_compute_type(compute_type, benchmark, fn, args, kwargs)
-
-
 sdpa_executors = (
     torch_executor,
     torch_compile_executor,


### PR DESCRIPTION
At the beginning of the project, we focused on measuring improvements for the nanoGPT model implementation. We switched to LitGPT long ago and it's time to remove some of the benchmark cases.

The batch size for `test_llama2_mlp_7b` and `test_llama2_mlp_7b` was decreased to 2 because it's a common max batch size that can be used in real training run.

`test_open_llama_7b` was removed and it was never working because the batch size is too large. There should be a parametrized benchmark for all litgpt configs instead of separate benchmark functions per config.

nanoGPT Gelu benchmark was upgraded to use LitGPT configurations instead.

cc @crcrpar