### PR TITLE
[in-place] Improve how to collect necessary `prims.copy_` to function args/kwargs

### DIFF
--- a/docs/source/reference/core/index.rst
+++ b/docs/source/reference/core/index.rst
@@ -18,3 +18,4 @@ thunder.core
     symbol
     trace
     transforms
+    transform_common

--- a/docs/source/reference/core/transform_common.rst
+++ b/docs/source/reference/core/transform_common.rst
@@ -1,0 +1,11 @@
+.. module:: thunder.core.transform_common
+
+Transform Common
+----------------
+
+.. currentmodule:: thunder.core.transform_common
+
+.. autosummary::
+    :toctree: generated/
+
+    functionalize_inplace_ops

--- a/thunder/core/transform_common.py
+++ b/thunder/core/transform_common.py
@@ -487,16 +487,14 @@ def _get_prod_bsym_with_arg(
     first_tensor = _get_first_tensor_arg(prod_bsym)
     if first_tensor is None:
         return None
-    if first_tensor in trace_args:
-        if inplace_or_view(prod_bsym):
+
+    if inplace_or_view(prod_bsym):
+        if first_tensor in trace_args:
             return prod_bsym
         else:
-            return None
-    else:
-        if inplace_or_view(prod_bsym):
             return _get_prod_bsym_with_arg(first_tensor, producer_map, trace_args)
-        else:
-            return None
+    else:
+        return None
 
 
 def collect_required_copy_bsyms_for_args(

--- a/thunder/core/transform_common.py
+++ b/thunder/core/transform_common.py
@@ -656,6 +656,7 @@ def functionalize_inplace_ops(
           # x: "cpu f32[3]"
           a = ltorch.sin(x)  # a: "cpu f32[3]"
             # a = prims.sin(x)  # a: "cpu f32[3]"
+
           t1 = ltorch.exp(a)  # t1: "cpu f32[3]"
             # t1 = ltorch.exp(a)  # t1: "cpu f32[3]"
               # t1 = prims.exp(a)  # t1: "cpu f32[3]"
@@ -685,12 +686,15 @@ def functionalize_inplace_ops(
           # x: "cpu f32[2, 2]"
           a = ltorch.view(x, -1)  # a: "cpu f32[4]"
             # a = ltorch.reshape(x, (-1,))  # a: "cpu f32[4]"
+
           t2 = ltorch.exp_(a)  # t2: "cpu f32[4]"
             # t1 = ltorch.exp(a)  # t1: "cpu f32[4]"
             # t2 = prims.copy_(t1, a)  # t2: "cpu f32[4]"
+
           t4 = ltorch.sin_(a)  # t4: "cpu f32[4]"
             # t3 = ltorch.sin(a)  # t3: "cpu f32[4]"
             # t4 = prims.copy_(t3, a)  # t4: "cpu f32[4]"
+
           t5 = ltorch.cos(a)  # t5: "cpu f32[4]"
             # t5 = prims.cos(a)  # t5: "cpu f32[4]"
           return t5
@@ -708,7 +712,6 @@ def functionalize_inplace_ops(
         # Constructed by Intermediate trace of `functionalize_inplace_ops`
         def computation(x):
           # x: "cpu f32[2, 2]"
-
           a = ltorch.view(x, -1)  # a: "cpu f32[4]"
             # a = ltorch.reshape(x, (-1,))  # a: "cpu f32[4]"
 

--- a/thunder/tests/test_inplace_functionalization.py
+++ b/thunder/tests/test_inplace_functionalization.py
@@ -375,6 +375,7 @@ def test_multiple_inplace_to_multiple_args(executor, device, _):
     z_ref = z.clone().detach()
 
     if executor == nvFuserExecutor:
+        # ref: https://github.com/NVIDIA/Fuser/issues/2564
         with pytest.raises(ValueError, match="not enough values to unpack"):
             res = jitted(xs, ys, z)
     else:

--- a/thunder/tests/test_inplace_functionalization.py
+++ b/thunder/tests/test_inplace_functionalization.py
@@ -358,6 +358,39 @@ def test_multiple_inplace_to_args(executor, device, _):
 @instantiate(
     dtypes=NOTHING,
 )
+def test_multiple_inplace_to_multiple_args(executor, device, _):
+
+    def f(xs, ys, z):
+        for i in range(len(xs)):
+            ys[i].add_(xs[i].exp_().sin_())
+            z.add_(ys[i])
+        return z
+
+    jitted = executor.make_callable(f)
+    xs = [make_tensor((2, 2), device=device, dtype=torch.float32) for _ in range(2)]
+    ys = [make_tensor((2, 2), device=device, dtype=torch.float32) for _ in range(2)]
+    z = make_tensor((2, 2), device=device, dtype=torch.float32)
+    xs_ref = [x.clone().detach() for x in xs]
+    ys_ref = [x.clone().detach() for x in ys]
+    z_ref = z.clone().detach()
+
+    if executor == nvFuserExecutor:
+        # ref: https://github.com/NVIDIA/Fuser/issues/2564
+        with pytest.raises(ValueError, match="not enough values to unpack"):
+            res = jitted(xs, ys, z)
+    else:
+        res = jitted(xs, ys, z)
+        res_ref = f(xs_ref, ys_ref, z_ref)
+
+        torch.testing.assert_close(actual=res, expected=res_ref)
+        torch.testing.assert_close(actual=z, expected=z_ref)
+        torch.testing.assert_close(actual=xs, expected=xs_ref)
+        torch.testing.assert_close(actual=ys, expected=ys_ref)
+
+
+@instantiate(
+    dtypes=NOTHING,
+)
 def test_single_tensor_adam_like(executor, device, _):
 
     def single_tensor_adam(

--- a/thunder/tests/test_inplace_functionalization.py
+++ b/thunder/tests/test_inplace_functionalization.py
@@ -374,18 +374,13 @@ def test_multiple_inplace_to_multiple_args(executor, device, _):
     ys_ref = [x.clone().detach() for x in ys]
     z_ref = z.clone().detach()
 
-    if executor == nvFuserExecutor:
-        # ref: https://github.com/NVIDIA/Fuser/issues/2564
-        with pytest.raises(ValueError, match="not enough values to unpack"):
-            res = jitted(xs, ys, z)
-    else:
-        res = jitted(xs, ys, z)
-        res_ref = f(xs_ref, ys_ref, z_ref)
+    res = jitted(xs, ys, z)
+    res_ref = f(xs_ref, ys_ref, z_ref)
 
-        torch.testing.assert_close(actual=res, expected=res_ref)
-        torch.testing.assert_close(actual=z, expected=z_ref)
-        torch.testing.assert_close(actual=xs, expected=xs_ref)
-        torch.testing.assert_close(actual=ys, expected=ys_ref)
+    torch.testing.assert_close(actual=res, expected=res_ref)
+    torch.testing.assert_close(actual=z, expected=z_ref)
+    torch.testing.assert_close(actual=xs, expected=xs_ref)
+    torch.testing.assert_close(actual=ys, expected=ys_ref)
 
 
 @instantiate(


### PR DESCRIPTION
## What does this PR do?

Improve how to collect bsyms of `copy_src` to the real `copy_dst`.

It turned out to be quite tricky to correctly set `stop_proxies` to
`thunder.core.utils.find_producer_symbols` especially when `copy_src` is
the result of some operation whose operands include at least two of
func's args.

This PR recursively traverse a trace / bound symbols from `copy_src` until (a) op returns a new tensor or (b) operand is function's args/kwargs.
If (a), the `copy_src` would not share the storage of function's args/kwargs. If (b) the `copy_src` is highly likely to share the storage with one of function's args/kwargs.

Also, this PR adds bsym update to avoid unwanted return values swap such as function's args is returned but it's replaced due to the functionalization's swap_map.