### PR TITLE
benchmark - ignore activation checkpoint with thunder

### DIFF
--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -215,6 +215,7 @@ class Benchmark_litGPT:
             warnings.warn(
                 "Activations checkpointing is configured, but Thunder does not support checkpointing. Checkpointing will be ignored."
             )
+            self.checkpoint_activations = False
         self.skip_data_sync = skip_data_sync
 
         # Profiling Args


### PR DESCRIPTION
Fixes - https://github.com/Lightning-AI/lightning-thunder/issues/582

Activation checkpointing is not supported with `thunder` and the benchmarking script already throws a warning. In this PR, we set the `self.checkpoint_activations=False` when compiling with thunder (to avoid going through the activation checkpointing path which leads to errors due to the same - see #582).