### PR TITLE
[WIP] support inferring dtype with torch.get_default_dtype for factory functions

### DIFF
--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -382,6 +382,9 @@ def jit(
         # this could be replaced by the respective querying in the prologues
         cache_info = _get_cache_info()
 
+        # default dtype (for factory functions)
+        cache_info["default_dtype"] = pytorch.get_default_dtype()
+
         # autocast related operations
         is_autocast_enabled = False
         if pytorch.is_autocast_enabled() or pytorch.is_autocast_cpu_enabled():

--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -1614,6 +1614,8 @@ def unpack_inputs(ctx, prologue_trace, pro_to_comp_inps, pro_to_epi_inps, args, 
                     clang.check_string_value(p, v)
                 elif isinstance(v, (int, bool, float)):
                     clang.check_number_type_and_value(p, v)
+                elif isinstance(v, torch.dtype):
+                    clang.check_literal_like(p, v)
                 else:
                     raise NotImplementedError(f"cache info of type {type(v).__name__}")
 

--- a/thunder/tests/framework.py
+++ b/thunder/tests/framework.py
@@ -7,6 +7,7 @@ from itertools import product
 from typing import List, Optional
 from collections.abc import Callable, Sequence, Iterable
 import packaging.version
+import contextlib
 
 import pytest
 import torch
@@ -581,3 +582,13 @@ class custom_comparator:
 
     def __call__(self, test_template):
         return test_template
+
+
+@contextlib.contextmanager
+def set_default_dtype_ctx(dtype):
+    saved_dtype = torch.get_default_dtype()
+    torch.set_default_dtype(dtype)
+    try:
+        yield
+    finally:
+        torch.set_default_dtype(saved_dtype)

--- a/thunder/tests/test_core.py
+++ b/thunder/tests/test_core.py
@@ -2943,3 +2943,53 @@ def test_dtype_in_trace():
     (pystr,) = tr.bound_symbols[1].subsymbols[0].python(0)
 
     assert "convert_element_type(x, dtypes.float16)" in pystr
+
+
+def test_factory_functions_default_dtype():
+
+    def fn(x):
+        o = torch.ones(x.shape)
+        return o.dtype
+
+    x = torch.randn(3, 3)
+    jfn = thunder.jit(fn)
+    actual_dtype = jfn(x)
+
+    assert actual_dtype == thunder.dtypes.float32
+
+    # Check with a different default dtype.
+    default_dtype = torch.get_default_dtype()
+    try:
+        torch.set_default_dtype(torch.float16)
+        actual_dtype = jfn(x)
+        assert actual_dtype == thunder.dtypes.float16
+    finally:
+        torch.set_default_dtype(default_dtype)
+
+    assert thunder.cache_misses(jfn) == 2
+
+
+def test_change_default_dtype_in_jitted_fn():
+
+    def fn(x):
+        torch.set_default_dtype(torch.float16)
+        o = torch.ones(x.shape)
+        return o.dtype
+
+    jfn = thunder.jit(fn)
+    with pytest.raises(RuntimeError, match="Default dtype is changed during the execution of jitted function"):
+        jfn(torch.randn(3, 3))
+
+
+def test_arange_default_dtype():
+    def fn():
+        return torch.arange(start=1, end=2, step=0.5).dtype
+
+    jfn = thunder.jit(fn)
+    assert jfn() == thunder.dtypes.float32
+
+    def fn():
+        return torch.arange(start=1, end=3, step=1).dtype
+
+    jfn = thunder.jit(fn)
+    assert jfn() == thunder.dtypes.int64

--- a/thunder/tests/test_core.py
+++ b/thunder/tests/test_core.py
@@ -1310,7 +1310,7 @@ def test_boundsymbol_hash_eq_examples(executor, device, dtype: dtypes.dtype):
 
     # Returns the bound symbols for a function and args.
     def compile_bsyms(fn, args):
-        fn = executor.make_callable_with_info(fn)
+        fn = executor.make_callable(fn)
         _ = fn(*args)
         traces = thunder.last_traces(fn)
         return traces[0].bound_symbols
@@ -2990,6 +2990,8 @@ def test_change_default_dtype_in_jitted_fn():
 
 
 def test_arange_default_dtype():
+    # If any of start, end, or stop are floating-point, the dtype is inferred to be the default dtype, see get_default_dtype().
+    # Otherwise, the dtype is inferred to be torch.int64.
     def fn():
         return torch.arange(start=1, end=2, step=0.5).dtype
 

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -85,6 +85,24 @@ _torch_to_thunder_function_map: dict[Callable, Callable] = {}
 _inplace_to_out_of_place: dict[Callable, tuple[Callable, int]] = {}
 
 
+# Helpers for factory functions to get default dtypes.
+def get_default_dtype():
+    # `thunder.jit` will create cache info and stash the default dtype
+    # observed at the beginning of jitting.
+    cache_info = thunder._get_cache_info()
+
+    # Currently, changing dtype during the jitted function is unsupported.
+    utils.check(
+        cache_info["default_dtype"] == torch.get_default_dtype(),
+        lambda: "Default dtype is changed during the execution of jitted function. This is currently unsupported.",
+    )
+    return torch.get_default_dtype()
+
+
+def maybe_get_default_dtype(dtype):
+    return dtype or get_default_dtype()
+
+
 # A wrapper that executes the operations within the torch language context
 # NOTE because this module defines the torch language context, a reference to itself
 #   is acquired by inspecting the __module__ attribute of the is_available function defined
@@ -536,6 +554,14 @@ def arange(
         device = "cpu"
 
     device = to_device(device)
+    # If any of start, end, or stop are floating-point, the dtype is inferred to be the default dtype, see get_default_dtype().
+    # Otherwise, the dtype is inferred to be torch.int64.
+    if dtype is None:  # infer the dtype
+        if any(map(lambda x: isinstance(x, float), (start, end, step))):
+            dtype = maybe_get_default_dtype(dtype)
+        else:
+            dtype = torch.int64
+
     dtype = to_dtype(dtype)
 
     if end is None:
@@ -552,7 +578,7 @@ def full(
         device = "cpu"
 
     device = to_device(device)
-    dtype = to_dtype(dtype)
+    dtype = to_dtype(maybe_get_default_dtype(dtype))
 
     return clang.full(shape, fill_value, device=device, dtype=dtype)
 
@@ -617,7 +643,7 @@ def uniform(
     dtype: dtypeLike,
 ) -> TensorLike:
     device = to_device(device)
-    dtype = to_dtype(dtype)
+    dtype = to_dtype(maybe_get_default_dtype(dtype))
 
     return clang.uniform(shape, minval, maxval, device=device, dtype=dtype)
 
@@ -674,7 +700,7 @@ def uniform_philox(
     offset: int | TensorProxy,
 ) -> TensorLike:
     device = to_device(device)
-    dtype = to_dtype(dtype)
+    dtype = to_dtype(maybe_get_default_dtype(dtype))
 
     return clang.uniform_philox(shape, minval, maxval, device=device, dtype=dtype, seed=seed, offset=offset)
 
@@ -702,12 +728,7 @@ def randn(
         device = "cpu"
     device = to_device(device)
 
-    # For now we default to `float32`,
-    # however, we should add a default dtype or
-    # rely on `torch.get_default_dtype`.
-    if dtype is None:
-        dtype = torch.float
-    dtype = to_dtype(dtype)
+    dtype = to_dtype(maybe_get_default_dtype(dtype))
     shape = utils.extract_shape_from_varargs(shape)
     return prims.randn(shape, device=device, dtype=dtype)
 
@@ -795,9 +816,7 @@ def empty(
 
     # For now we default to `float32`,
     # however, we should add a default dtype or rely on `torch.get_default_dtype`.
-    if dtype is None:
-        dtype = torch.float
-    dtype = to_dtype(dtype)
+    dtype = to_dtype(maybe_get_default_dtype(dtype))
 
     # For now we default to "cpu",
     # however, we should add a default device or rely on `torch.get_default_device`.

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -554,6 +554,7 @@ def arange(
         device = "cpu"
 
     device = to_device(device)
+    # From torch docs - https://pytorch.org/docs/stable/generated/torch.arange.html
     # If any of start, end, or stop are floating-point, the dtype is inferred to be the default dtype, see get_default_dtype().
     # Otherwise, the dtype is inferred to be torch.int64.
     if dtype is None:  # infer the dtype
@@ -625,6 +626,9 @@ def tensor(
     utils.check(not pin_memory, lambda: "pin_memory=True is not supported within thunder.jit", NotImplementedError)
 
     if isinstance(seq_or_number, (Number, NumberProxy)):
+        # Infer dtype from value (as `full` will use default dtype if dtype=None).
+        if dtype is None:
+            dtype = dtypes.numbertype_to_dtype(dtypes.to_dtype(seq_or_number))
         return full((), seq_or_number, dtype=dtype, device=device)
 
     return clang.tensor_from_sequence(seq_or_number, dtype=dtype, device=device)


### PR DESCRIPTION
Fixes: #750

Changes - 
1. Stash `torch.get_default_dtype` in `cache_info`. Also, this adds a check to the prologue trace to verify that jitted fn is called with same default dtype - see example prologue below.
2. Factory functions infer the dtype based on `torch.get_default_dtype` from cache_info (if dtype is not passed explicitly)
3. We don't support changing the default dtype in the `jitted fn` as reordering and fusion can lead to issue - it is a loud error for now (we can revisit in follow-up if required).

Repro:
```python
import torch
import thunder

def foo(x: torch.Tensor) -> torch.Tensor:
    o = torch.zeros(x.shape, device=x.device)
    return o

jfoo = thunder.jit(foo)
o = jfoo(torch.randn(3, 3))
print(o.dtype)
print(thunder.last_prologue_traces(jfoo)[0])
print()
print(thunder.last_traces(jfoo)[0])
```

Prologue Trace
```python
import thunder
import thunder.core.prims as prims
import torch
from thunder.executors.torchex import no_autocast

@torch.no_grad()
@no_autocast
def prologue(*args, **kwargs):
  # args: "Any"
  prims.check_len(args, 1)
  # kwargs: "Any"
  prims.check_len(kwargs, 0)
  t_0: "cpu f32[3, 3]" = args[0]
  prims.check_tensor_metadata(t_0, (3, 3), 'cpu', torch.float32, False)
  cache_info: "Any" = thunder._get_cache_info()
  cache_info_default_dtype: "<class 'torch.dtype'>" = cache_info['default_dtype']
  # NOTE - We bake the torch.dtype in trace (check_tensor_metadata also does the same).
  prims.check_literal_like(cache_info_default_dtype, torch.float32)
  cache_info_is_autocast_enabled: "bool False" = cache_info['is_autocast_enabled']
  prims.check_number_type_and_value(cache_info_is_autocast_enabled, False)
  cache_info_no_grad_sync: "bool False" = cache_info['no_grad_sync']
  prims.check_number_type_and_value(cache_info_no_grad_sync, False)
  return ((), ())
```

Computation Trace
```python
import thunder
import thunder.core.devices as devices
import thunder.torch as ltorch
import torch
from thunder.executors.torchex import no_autocast

@torch.no_grad()
@no_autocast
def computation():
  # /home/kkalambarkar/lightning-thunder/scratchpad/test.py:64:             o = torch.zeros(x.shape, device=x.device)
  o = ltorch.zeros((3, 3), device=devices.Device("cpu"), dtype=None)  # o: "cpu f32[3, 3]"
    # o = ltorch.full((3, 3), 0, device=devices.Device("cpu"), dtype=None)  # o: "cpu f32[3, 3]"
      # o = prims.full((3, 3), 0, device=devices.Device("cpu"), dtype=dtypes.float32)  # o: "cpu f32[3, 3]"
  return o

```