### PR TITLE
remove add_executors_list definition as it is already imported from extend.add_executors_list

### DIFF
--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -232,19 +232,6 @@ def _get_cache_info():
     return _cache_info_ctx.get()
 
 
-def add_executor_lists(
-    exc_list: None | Sequence[Executor | str], other_exc_list: None | Sequence[Executor | str]
-) -> Sequence[Executor]:
-    new_exc_list = []
-    exc_list = resolve_executors(exc_list)
-    other_exc_list = resolve_executors(other_exc_list)
-    for exc in itertools.chain(exc_list, other_exc_list):
-        if not exc in new_exc_list:
-            new_exc_list.append(exc)
-
-    return new_exc_list
-
-
 @run_once
 def _recursive_jit_call_warning() -> None:
     warnings.warn(


### PR DESCRIPTION
Minor clean-up

It is already imported here - https://github.com/Lightning-AI/lightning-thunder/blob/323d7df47c47b09db168e9ac3c8e1df5a4cd6c58/thunder/__init__.py#L168

Also, `itertools` is not imported in `thunder/__init__.py` so this (removed) definition will fail.