### PR TITLE
remove make_callable_with_info

### DIFF
--- a/thunder/tests/framework.py
+++ b/thunder/tests/framework.py
@@ -170,13 +170,6 @@ class TestExecutor:
             traces = thunder.common.transform_for_execution(trace, executors_list=self.executors_list(), **kwargs)
         return traces[-1].python_callable()
 
-    # TODO Remove this
-    def make_callable_with_info(self, fn, **kwargs):
-        disable_preprocessing = kwargs.pop("disable_preprocessing", True)
-        return thunder.compile(
-            fn, executors_list=self.executors_list(), disable_preprocessing=disable_preprocessing, **kwargs
-        )
-
 
 # TODO Convert to singletons or just add to executor logic
 class nvFuserTestExecutor(TestExecutor):

--- a/thunder/tests/test_nvfuser.py
+++ b/thunder/tests/test_nvfuser.py
@@ -390,7 +390,7 @@ def test_cse_rematerialization(executor, device, _):
 # TODO Create a testing operator that can only be executed by PyTorch so that
 #   these tests don't rely on matmul not being executable by nvFuser
 # TODO Explicitly use the nvFuserExecutor in these tests
-#   (by creating executor.make_callable_with_info?)
+#   (by creating executor.make_callable?)
 @instantiate(executors=(nvFuserExecutor,), dtypes=(thunder.float32,))
 def test_nvfuser_toposort_basic(executor, device: str, dtype: dtypes.dtype):
     torch_dtype = ltorch.to_torch_dtype(dtype)


### PR DESCRIPTION
As the TODO asks - remove `make_callable_with_info` (which uses deprecated thunder.compile).