### PR TITLE
index_copy: differentiable prim

### DIFF
--- a/thunder/clang/__init__.py
+++ b/thunder/clang/__init__.py
@@ -1179,6 +1179,12 @@ def index_add(a: TensorProxy, indices: TensorProxy, value: TensorProxy, dim: int
 
 
 @clangop()
+def index_copy(a: TensorProxy, indices: TensorProxy, value: TensorProxy, dim: int) -> TensorProxy:
+    dim = utils.canonicalize_dim(a.ndim, dim)
+    return prims.index_copy(a, indices, value, dim)
+
+
+@clangop()
 def take(a: TensorProxy, indices: TensorProxy, dim: int) -> TensorProxy:
     dim = utils.canonicalize_dim(a.ndim, dim)
     return prims.take(a, indices, dim)

--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -249,6 +249,7 @@ class PrimIDs(Enum):
     GATHER = auto()
     SCATTER = auto()
     INDEX_ADD = auto()
+    INDEX_COPY = auto()
     INDEX_PUT = auto()
     SCATTER_ADD = auto()
     TAKE = auto()
@@ -3240,6 +3241,17 @@ def index_add_meta(a: TensorProxy, /, index: TensorProxy, value: TensorProxy, di
 
 
 index_add = make_prim(PrimIDs.INDEX_ADD, "index_add", meta=index_add_meta)
+
+
+def index_copy_meta(a: TensorProxy, /, index: TensorProxy, value: TensorProxy, dim: int) -> TensorProxy:
+    utils.check(
+        dtypes.to_dtype(index) is dtypes.int64,
+        lambda: f"index_copy: only indices of type int64 are supported",
+    )
+    return index_add_meta(a, index, value, dim)
+
+
+index_copy = make_prim(PrimIDs.INDEX_COPY, "index_copy", meta=index_add_meta)
 
 
 def index_put_meta(

--- a/thunder/executors/torchex.py
+++ b/thunder/executors/torchex.py
@@ -1231,6 +1231,7 @@ _register_implementation(ltorch.sort, checker=_always_executable, execution_tran
 
 gather = _register_torch_operation("gather")
 index_add = _register_torch_operation("index_add")
+index_copy = _register_torch_operation("index_copy")
 index_put = _register_torch_operation("index_put")
 scatter = _register_torch_operation("scatter")
 scatter_add = _register_torch_operation("scatter_add")
@@ -1241,6 +1242,11 @@ take_along_dim = _register_torch_operation("take_along_dim")
 # NOTE PyTorch has a different order for and names of the parameters
 def _index_add_prim_transform(a: TensorProxy, /, index: TensorProxy, value: TensorProxy, dim: int) -> TensorProxy:
     return index_add(a, dim, index, value)
+
+
+# NOTE PyTorch has a different order for and names of the parameters
+def _index_copy_prim_transform(a: TensorProxy, /, index: TensorProxy, value: TensorProxy, dim: int) -> TensorProxy:
+    return index_copy(a, dim, index, value)
 
 
 def _index_put_prim_transform(
@@ -1325,6 +1331,7 @@ def _take_along_axis_prim_transform(a: TensorProxy, /, index: TensorProxy, dim: 
 
 _register_implementation(prims.gather, checker=_always_executable, execution_transform=_gather_prim_transform)
 _register_implementation(prims.index_add, checker=_always_executable, execution_transform=_index_add_prim_transform)
+_register_implementation(prims.index_copy, checker=_always_executable, execution_transform=_index_copy_prim_transform)
 _register_implementation(prims.index_put, checker=_always_executable, execution_transform=_index_put_prim_transform)
 _register_implementation(prims.scatter, checker=_always_executable, execution_transform=_scatter_prim_transform)
 _register_implementation(prims.scatter_add, checker=_always_executable, execution_transform=_scatter_add_prim_transform)
@@ -1335,6 +1342,7 @@ _register_implementation(
 
 _register_implementation(ltorch.gather, checker=_always_executable, execution_transform=_gather_transform)
 _register_implementation(ltorch.index_add, index_add, checker=_always_executable)
+_register_implementation(ltorch.index_copy, index_copy, checker=_always_executable)
 _register_implementation(ltorch.index_put, index_put, checker=_always_executable)
 _register_implementation(ltorch.index_select, index_select, checker=_always_executable)
 _register_implementation(ltorch.scatter, checker=_always_executable, execution_transform=_scatter_transform)

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -2764,6 +2764,16 @@ def index_add_(a: TensorLike, /, dim: int, index: TensorLike, source: TensorLike
     return prims.copy_(index_add(a, dim, index, source), a)
 
 
+@torchsymbol(torch.index_copy)
+def index_copy(a: TensorLike, /, dim: int, index: TensorLike, source: TensorLike) -> TensorLike:
+    return clang.index_copy(a, index, source, dim)
+
+
+@torchsymbol(torch.Tensor.index_copy_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
+def index_copy_(a: TensorLike, /, dim: int, index: TensorLike, source: TensorLike) -> TensorLike:
+    return prims.copy_(index_copy(a, dim, index, source), a)
+
+
 @torchsymbol(torch.index_select, is_method=True)
 def index_select(a: TensorLike, /, dim: int, index: TensorLike) -> TensorLike:
     return clang.take(a, index, dim)


### PR DESCRIPTION
As per title. Partially fixes https://github.com/Lightning-AI/lightning-thunder/issues/316.
We have `index_add`, but it is not differentiable.
