### PR TITLE
torch.device - correct signature

### DIFF
--- a/thunder/tests/test_core.py
+++ b/thunder/tests/test_core.py
@@ -2712,6 +2712,12 @@ def test_torch_device():
 
     _test(foo2, device_strs_and_idxs)
 
+    def foo2_1(dev_and_idx):
+        dev_type, idx = dev_and_idx
+        return torch.ones(3, 3, device=torch.device(type=dev_type, index=idx))
+
+    _test(foo2_1, device_strs_and_idxs)
+
     # Test with `torch.device` as input
     torch_devices = (torch.device("cpu"), torch.device("cuda"), torch.device("meta"))
 

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -5039,30 +5039,30 @@ def softmax(a: TensorLike, dim: int, dtype: None | dtypeLike = None, _stacklevel
     return _softmax(a, dim=dim, dtype=dtype)
 
 
-def torch_device(device_or_str: DeviceLike, /, index: int | None = None) -> devices.Device:
-    if isinstance(device_or_str, (devices.Device, torch.device)):
+def torch_device(type: DeviceLike, index: int | None = None) -> devices.Device:
+    if isinstance(type, (devices.Device, torch.device)):
         # PyTorch behavior:
         # >>> torch.device(torch.device("cuda"), 0)
         # TypeError: device(): argument 'type' (position 1) must be str, not torch.device
         utils.check(index is None, lambda: f"device(): `index` is only allowed when `device` is a `str`.")
-        return to_device(device_or_str)
+        return to_device(type)
 
     # NOTE: device_or_str is `str`
     if index is not None:
         # PyTorch behavior:
         # >>> torch.device("cuda:0", 0)
         # RuntimeError: type (string) must not include an index because index was passed explicitly: cuda:0
-        has_device_idx = len(device_or_str.split(":")) > 1
+        has_device_idx = len(type.split(":")) > 1
         utils.check(
             not has_device_idx,
-            lambda: f"device string must not include an index because index was passed explicitly: {device_or_str}",
+            lambda: f"device string must not include an index because index was passed explicitly: {type}",
         )
         if isinstance(index, NumberProxy):
             index.make_static_constrained()
             prims.sink(index)
             index = index.value
 
-    return devices.Device(device_or_str, index)
+    return devices.Device(type, index)
 
 
 # We don't use @torchsymbol as we don't want `torch.device()` to appear in trace as a symbol.


### PR DESCRIPTION
Fixes https://github.com/Lightning-AI/lightning-thunder/issues/782

First argument of torch.device is `type` which can be positional or keyword.

Ref to torch.device doc - https://pytorch.org/docs/stable/tensor_attributes.html#torch.device