### PR TITLE
Avoid BoundSymbol repeating itself in its subsymbols after functionalization

### DIFF
--- a/thunder/core/transform_common.py
+++ b/thunder/core/transform_common.py
@@ -848,6 +848,12 @@ def functionalize_inplace_ops(
         new_bsyms.append(new_functional_bsym)
         bsym_inplace_to_functional[new_bsym] = new_functional_bsym
 
+        if (
+            len(new_functional_bsym.subsymbols) == 1
+            and new_functional_bsym.rhs == new_functional_bsym.subsymbols[0].rhs
+        ):
+            new_functional_bsym.subsymbols = new_functional_bsym.subsymbols[0].subsymbols
+
     required_copy_bsyms, swap_map_for_return = collect_required_copy_bsyms_for_args(
         intermediate_trace,
         removed_copy_bsyms,

--- a/thunder/tests/test_inplace_functionalization.py
+++ b/thunder/tests/test_inplace_functionalization.py
@@ -463,10 +463,12 @@ def test_inplace_to_arg_return_value(executor, device, _):
 def test_no_self_repeat_in_subsymbols(executor, device, _):
 
     def f(a, b, c):
+        a.add_(b, alpha=c)
         return a.add_(b, alpha=c)
 
     def functional_f(a, b, c):
-        return a.add(b, alpha=c)
+        d = a.add(b, alpha=c)
+        return d.add(b, alpha=c)
 
     a = make_tensor((2, 2), device=device, dtype=torch.float32)
     b = make_tensor((2, 2), device=device, dtype=torch.float32)

--- a/thunder/tests/test_inplace_functionalization.py
+++ b/thunder/tests/test_inplace_functionalization.py
@@ -455,3 +455,30 @@ def test_inplace_to_arg_return_value(executor, device, _):
     b_out = jitted(a, b)
     torch.testing.assert_close(b_out, b__out)
     assert b.data_ptr() == b_out.data_ptr()
+
+
+@instantiate(
+    dtypes=NOTHING,
+)
+def test_no_self_repeat_in_subsymbols(executor, device, _):
+
+    def f(a, b, c):
+        return a.add_(b, alpha=c)
+
+    def functional_f(a, b, c):
+        return a.add(b, alpha=c)
+
+    a = make_tensor((2, 2), device=device, dtype=torch.float32)
+    b = make_tensor((2, 2), device=device, dtype=torch.float32)
+    c = make_tensor((1,), device=device, dtype=torch.float32)
+
+    a_out_ref = executor.make_callable(functional_f)(a, b, c)
+
+    jitted = executor.make_callable(f)
+    a_out = jitted(a, b, c)
+    torch.testing.assert_close(a_out, a_out_ref)
+
+    traces = thunder.last_traces(jitted)
+    for t in filter(lambda t: t._provenance is not None and "Functionalize in-place ops" in t._provenance.pss, traces):
+        for bsym in filter(lambda b: b.subsymbols, t.bound_symbols):
+            assert bsym.rhs != bsym.subsymbols[0].rhs, bsym


### PR DESCRIPTION
## What does this PR do?

Fixes #801.

For some in-place ops, functionalization would create a new boundsymbol whose first subsymbol is identical. As in the linked issue, this redundant nest seems to bother nvfuser region creation. This PR adds a simple check and edit to avoid such situation.