### PR TITLE
don't use inspect.signature, prefer code object

### DIFF
--- a/thunder/core/interpreter.py
+++ b/thunder/core/interpreter.py
@@ -6255,7 +6255,7 @@ def _setup_frame_and_run_python_function(
     has_varkwargs = (fn.__code__.co_flags & inspect.CO_VARKEYWORDS) > 0
 
     # for the function signature varargs, we just need keep track of the
-    # number of provided positional args in args, but to to pupulate the
+    # number of provided positional args in args, but to to populate the
     # function signature varkwargs, we need to track
     # which provided kwargs have been "consumed" by the signature.
 


### PR DESCRIPTION
Fixes #803 

The reason this is needed is that inspect uses the (global) sentinel `inspect._empty` to signify absence of (e.g. default) values. But this means that we cannot properly inspect things in the inspect module itself, and libraries do this (e.g. transformers when running BERT).
  
This patch avoiding signature makes the problem of signatures inside inspect being potentially misleading go away.
