### PR TITLE
fix torch.autocast re-enable on prims

### DIFF
--- a/thunder/core/symbol.py
+++ b/thunder/core/symbol.py
@@ -251,6 +251,14 @@ class Symbol:
             )
 
         baseutils.check(not trace._complete, lambda: f"Trying to add {self} to a trace that is complete!")
+
+        # Import here to avoid cyclical import issues.
+        from thunder.core.transforms import maybe_apply_autocast
+
+        # See NOTE: torch.autocast support - for more details on why we apply autocast here.
+        if (autocast_impl := maybe_apply_autocast(self)) is not None:
+            return autocast_impl(*args, **kwargs)
+
         result: Any
         subsymbols = []
         if self.is_prim:

--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -4011,11 +4011,11 @@ def autocast(func: Callable, dtype: dtypes.dtype):
 
 
 # State to enable and disable autocast (while interpreter is generating the computation trace).
-autocast_enabled = True
+_autocast_enabled = True
 
 
 def is_autocast_enabled():
-    return autocast_enabled
+    return _autocast_enabled
 
 
 # NOTE: Disable Autocast
@@ -4024,13 +4024,13 @@ def is_autocast_enabled():
 # Without disabling autocast we will have infinite recursion.
 @contextmanager
 def disable_autocast():
-    global autocast_enabled
-    default = autocast_enabled
-    autocast_enabled = False
+    global _autocast_enabled
+    default = _autocast_enabled
+    _autocast_enabled = False
     try:
         yield
     finally:
-        autocast_enabled = default
+        _autocast_enabled = default
 
 
 def maybe_apply_autocast(sym):

--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -1,5 +1,5 @@
 from collections import namedtuple
-from contextlib import nullcontext
+from contextlib import nullcontext, contextmanager
 from dataclasses import dataclass, replace
 from enum import auto, Enum
 from itertools import chain, compress
@@ -18,6 +18,7 @@ from collections import deque
 import os
 import dataclasses
 
+import thunder
 import thunder.core.utils as utils
 from thunder.core import dtypes, prims
 import thunder.core.devices as devices
@@ -4007,3 +4008,59 @@ def autocast(func: Callable, dtype: dtypes.dtype):
         return eval_trace(trace, *args, **kwargs, symbol_mapper=partial(autocast_symbol_mapper, dtype=dtype))
 
     return wrapper
+
+
+# State to enable and disable autocast (while interpreter is generating the computation trace).
+autocast_enabled = True
+
+
+def is_autocast_enabled():
+    return autocast_enabled
+
+
+# NOTE: Disable Autocast
+# Once the autocast rule has been applied, we disable autocast as the autocast_rule usually converts the inputs
+# and calls the same symbol.
+# Without disabling autocast we will have infinite recursion.
+@contextmanager
+def disable_autocast():
+    global autocast_enabled
+    default = autocast_enabled
+    autocast_enabled = False
+    try:
+        yield
+    finally:
+        autocast_enabled = default
+
+
+def maybe_apply_autocast(sym):
+    # NOTE: torch.autocast support
+    # In PyTorch eager, enabling autocast allows mixed inputs to operator like `linear`
+    # which expect dtypes to be same. This works in PyTorch eager, as dispatcher applies the
+    # conversion first and then passes the converted input to the operator.
+    # To mimick similar behavior, here we replace the `sym` for all operators which have
+    # autocast rule, to apply the autocast conversion rule if autocast was enabled.
+
+    # Cache info may not be available in case of legacy `thunder.compile`
+    # which is still used for cases.
+    try:
+        cache_info = thunder._get_cache_info()
+    except LookupError:
+        cache_info = {}
+
+    if (
+        cache_info.get("is_autocast_enabled", False)  # If user has actually enabled autocast in their code
+        and is_autocast_enabled()  # we are not under `disable_autocast`
+        and (autocast_impl := _maybe_get_autocast_rule_for_symbol(sym)) is not None
+    ):  # symbol has autocast impl.
+
+        @wraps(sym)
+        def wrapper(*args, **kwargs):
+            # See NOTE: Disable Autocast
+            with disable_autocast():
+                thunder_autocast_dtype = _get_downcast_dtype_from_str(cache_info["autocast_thunder_dtype"])
+                return partial(autocast_impl, dtype=thunder_autocast_dtype)(*args, **kwargs)
+
+        return wrapper
+
+    return None

--- a/thunder/tests/test_autocast.py
+++ b/thunder/tests/test_autocast.py
@@ -10,6 +10,7 @@ import thunder.torch as ltorch
 from thunder.core import dtypes
 from thunder.executors.torchex import no_autocast
 from thunder.tests.framework import instantiate, TorchExecutor
+import thunder.torch
 
 
 # TODO This test currently ignores the "should_autocast" argument enumerated in it
@@ -187,6 +188,8 @@ def test_autocast_mixed_dtype_inputs_on_prims():
         jit_out = jfoo(x, w)
 
     assert jit_out.dtype == torch.bfloat16
+    exec_trace = thunder.last_traces(jfoo)[0]
+    assert any(bsym.sym.id == thunder.prims.PrimIDs.CONVERT_ELEMENT_TYPE for bsym in exec_trace.bound_symbols)
 
 
 @pytest.mark.parametrize("dim", [1, 2, 3])

--- a/thunder/tests/test_autocast.py
+++ b/thunder/tests/test_autocast.py
@@ -10,7 +10,6 @@ import thunder.torch as ltorch
 from thunder.core import dtypes
 from thunder.executors.torchex import no_autocast
 from thunder.tests.framework import instantiate, TorchExecutor
-import thunder.torch
 
 
 # TODO This test currently ignores the "should_autocast" argument enumerated in it

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -161,52 +161,22 @@ class torchsymbol:
         else:
             sym = Symbol(name=fn.__name__, meta=_fn, id=id, is_prim=self.is_prim, tags=self.tags)
 
-        # NOTE: torch.autocast support
-        # In PyTorch eager, enabling autocast allows mixed inputs to operator like `linear`
-        # which expect dtypes to be same. This works in PyTorch eager, as dispatcher applies the
-        # conversion first and then passes the converted input to the operator.
-        # To mimick similar behavior, here we replace the `sym` for all operators which have
-        # autocast rule, to apply the conversion rule if autocast was enabled.
-        autocast_impl: Callable | None = _maybe_get_autocast_rule_for_symbol(sym)
-
-        # `mapping_fn` is used to map `torch` -> `thunder.torch`
-        # If autocast is enabled - it will also take care of casting the inputs
-        # as per autocast rule else it will be just the symbol.
-        mapping_fn = sym
-        if autocast_impl is not None:
-
-            @wraps(sym)
-            def maybe_autocast(*args, **kwargs):
-                # Cache info may not be available in case of legacy `thunder.compile`
-                # which is still used for cases.
-                try:
-                    cache_info = thunder._get_cache_info()
-                except LookupError:
-                    cache_info = {}
-
-                if cache_info.get("is_autocast_enabled", False):
-                    thunder_autocast_dtype = _get_downcast_dtype_from_str(cache_info["autocast_thunder_dtype"])
-                    return partial(autocast_impl, dtype=thunder_autocast_dtype)(*args, **kwargs)
-                return sym(*args, **kwargs)
-
-            mapping_fn = maybe_autocast
-
         if self.is_method:
             method_name: str = self.method_name if self.method_name is not None else fn.__name__
-            register_method(method_name, mapping_fn)
+            register_method(method_name, sym)
             torch_method: None | Callable = getattr(torch.Tensor, method_name, None)
             if torch_method is not None:
-                _torch_to_thunder_function_map[torch_method] = mapping_fn
+                _torch_to_thunder_function_map[torch_method] = sym
         elif self.is_property:
             method_name: str = self.method_name if self.method_name is not None else fn.__name__
-            register_property(method_name, mapping_fn)
+            register_property(method_name, sym)
             torch_property = getattr(torch.Tensor, method_name, None)
             if torch_property is not None:
-                _torch_to_thunder_function_map[torch_property] = mapping_fn
+                _torch_to_thunder_function_map[torch_property] = sym
 
         if self.torchfns is not None:
             for torchfn in self.torchfns:
-                _torch_to_thunder_function_map[torchfn] = mapping_fn
+                _torch_to_thunder_function_map[torchfn] = sym
 
         if self.tags and prims.OpTags.IN_PLACE in self.tags:
             if self.id is not None:


### PR DESCRIPTION
Fixes #725 

Changes
* Have mainly moved the logic of applying autocast rule from `torchsymbol` to `Symbol.call`. Though the utility to apply this rule lives in `transforms.py`.
* Added a `disable_autocast` ctx manager to disable re-applying autocast rule on the symbol.

Maybe moving forward if we see similar cases where we want to preprocess a symbol while generating the first trace, we can have a more general dispatch mechanism where we apply multiple of such transformations (though this would require us to be careful about the order of application). As per offline discussion with Ivan, this could be useful extension point for inserting the dist_prims.synchronize in distributed setting.

cc: @IvanYashchuk 