### PR TITLE
Explicitly define the RNG state tensor CPU tensor to avoid failure in CUDA device context

### DIFF
--- a/thunder/executors/torchex.py
+++ b/thunder/executors/torchex.py
@@ -447,8 +447,8 @@ def _get_and_update_rng_state_impl(seed, offset, device):
     # We follow the nvFuser way here. pytorch_new_offset = (nvfuser_offset + 1) * 4
     # See Note [Divide offset by 4] https://github.com/NVIDIA/Fuser/blob/729f36c/csrc/rng.cpp#L54
     new_offset = (offset + 1) * 4
-    seed_portion = torch.tensor([seed]).view(torch.uint8)
-    offset_portion = torch.tensor([new_offset]).view(torch.uint8)
+    seed_portion = torch.tensor([seed], device="cpu").view(torch.uint8)
+    offset_portion = torch.tensor([new_offset], device="cpu").view(torch.uint8)
     new_state = torch.cat([seed_portion, offset_portion])
     torch.cuda.set_rng_state(new_state, device)
     return seed, offset


### PR DESCRIPTION
## What does this PR do?

I didn't explicitly specify the state to be a cpu tensor when using torch.tensor in the rng state, it leads to failure when using the cuda device context manager. It can be fixed by setting the tensor to be a cpu tensor

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
