### PR TITLE
factory functions - fix handling of default device

### DIFF
--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -374,6 +374,9 @@ def jit(
         # default dtype (for factory functions)
         cache_info["default_dtype"] = pytorch.get_default_dtype()
 
+        # default device (for factory functions)
+        cache_info["default_device"] = pytorch.get_default_device()
+
         # autocast related operations
         is_autocast_enabled = False
         if pytorch.is_autocast_enabled() or pytorch.is_autocast_cpu_enabled():

--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -1629,7 +1629,7 @@ def unpack_inputs(ctx, prologue_trace, pro_to_comp_inps, pro_to_epi_inps, args, 
                     clang.check_string_value(p, v)
                 elif isinstance(v, (int, bool, float)):
                     clang.check_number_type_and_value(p, v)
-                elif isinstance(v, torch.dtype):
+                elif isinstance(v, (torch.dtype, torch.device)):
                     clang.check_literal_like(p, v)
                 else:
                     raise NotImplementedError(f"cache info of type {type(v).__name__}")

--- a/thunder/tests/test_core.py
+++ b/thunder/tests/test_core.py
@@ -3041,7 +3041,8 @@ def test_change_default_device_in_jitted_fn():
 
 @requiresCUDA
 @pytest.mark.xfail(
-    reason="When using device as context in PyTorch, it doesn't reflect in torch.get_default_device - see https://github.com/pytorch/pytorch/issues/131328"
+    reason="When using device as context in PyTorch, it doesn't reflect in torch.get_default_device - see https://github.com/pytorch/pytorch/issues/131328",
+    strict=True,
 )
 def test_change_default_device_with_ctx():
     def fn(x):

--- a/thunder/tests/test_core.py
+++ b/thunder/tests/test_core.py
@@ -3040,14 +3040,15 @@ def test_change_default_device_in_jitted_fn():
 
 
 @requiresCUDA
+@pytest.mark.xfail(
+    reason="When using device as context in PyTorch, it doesn't reflect in torch.get_default_device - see https://github.com/pytorch/pytorch/issues/131328"
+)
 def test_change_default_device_with_ctx():
     def fn(x):
         o = torch.ones(x.shape)
         return o.device
 
-    x = torch.randn(
-        3,
-    )
+    x = torch.randn(3)
 
     with torch.device("cuda"):
         jfn = thunder.jit(fn)

--- a/thunder/tests/test_core.py
+++ b/thunder/tests/test_core.py
@@ -2996,6 +2996,65 @@ def test_change_default_dtype_in_jitted_fn():
         torch.set_default_dtype(default_dtype)
 
 
+@requiresCUDA
+def test_factory_functions_default_device():
+
+    def fn(x):
+        o = torch.ones(x.shape)
+        return o.device
+
+    x = torch.randn(3, 3)
+    jfn = thunder.jit(fn)
+    actual_device = jfn(x)
+
+    assert fn(x) == jfn(x)
+    assert actual_device == torch.device("cpu")
+
+    # Check with a different default device.
+    org_device = torch.get_default_device()
+    torch.set_default_device("cuda")
+    try:
+        actual_device = jfn(x)
+        assert actual_device == fn(x)
+    finally:
+        torch.set_default_device(org_device)
+
+    assert thunder.cache_misses(jfn) == 2
+
+
+@requiresCUDA
+def test_change_default_device_in_jitted_fn():
+    default_device = torch.get_default_device()
+    try:
+
+        def fn(x):
+            torch.set_default_device("cuda")
+            o = torch.ones(x.shape)
+            return o.device
+
+        jfn = thunder.jit(fn)
+        with pytest.raises(RuntimeError, match="Default device is changed during the execution of jitted function"):
+            jfn(torch.randn(3, 3))
+    finally:
+        torch.set_default_device(default_device)
+
+
+@requiresCUDA
+def test_change_default_device_with_ctx():
+    def fn(x):
+        o = torch.ones(x.shape)
+        return o.device
+
+    x = torch.randn(
+        3,
+    )
+
+    with torch.device("cuda"):
+        jfn = thunder.jit(fn)
+        actual_device = jfn(x)
+        assert actual_device == fn(x)
+
+
 def test_arange_default_dtype():
     # If any of start, end, or stop are floating-point, the dtype is inferred to be the default dtype, see get_default_dtype().
     # Otherwise, the dtype is inferred to be torch.int64.


### PR DESCRIPTION
Fixes https://github.com/Lightning-AI/lightning-thunder/issues/621

Changes are similar to https://github.com/Lightning-AI/lightning-thunder/pull/775

* Stash torch.get_default_device in cache_info. Also, this adds a check to the prologue trace to verify that jitted fn is called with same default device- see example prologue below.
* Factory functions infer the device based on torch.get_default_device from cache_info (if device is not passed explicitly)
* We don't support changing the default device in the jitted fn as reordering and fusion can lead to issue - it is a loud error for now (we can revisit in follow-up if required).

Repro:
```python
import torch
import thunder

def foo(x):
    return torch.ones(x.shape).device

x = torch.randn(3)

torch.set_default_device("cuda")
print(foo(x))
jfoo = thunder.jit(foo)
print(jfoo(x))

print(thunder.last_prologue_traces(jfoo)[-1])
print(thunder.last_traces(jfoo)[-1])
```

Prologue Trace:
```python
# Constructed by Transform for execution (took 1 milliseconds)
import torch
from thunder.executors.torchex import no_autocast

@torch.no_grad()
@no_autocast
def prologue(*args, **kwargs):
  # args: "Any"
  check_len(args, 1)
    # prims.check_len(args, 1)
  # kwargs: "Any"
  check_len(kwargs, 0)
    # prims.check_len(kwargs, 0)
  t_0: "cpu f32[3]" = args[0]
  check_tensor_metadata(t_0, (3,), 'cpu', torch.float32, False)
    # prims.check_tensor_metadata(t_0, (3,), 'cpu', torch.float32, False)
  cache_info: "Any" = thunder._get_cache_info()
  cache_info_default_dtype: "<class 'torch.dtype'>" = cache_info['default_dtype']
  check_literal_like(cache_info_default_dtype, torch.float32)
    # prims.check_literal_like(cache_info_default_dtype, torch.float32)
  cache_info_default_device: "<class 'torch.device'>" = cache_info['default_device']
  check_literal_like(cache_info_default_device, torch.device("cuda:0"))
    # prims.check_literal_like(cache_info_default_device, torch.device("cuda:0"))
  cache_info_is_autocast_enabled: "bool False" = cache_info['is_autocast_enabled']
  check_number_type_and_value(cache_info_is_autocast_enabled, False)
    # prims.check_number_type_and_value(cache_info_is_autocast_enabled, False)
  cache_info_no_grad_sync: "bool False" = cache_info['no_grad_sync']
  check_number_type_and_value(cache_info_no_grad_sync, False)
    # prims.check_number_type_and_value(cache_info_no_grad_sync, False)
  return ((), ())
```

Comp Trace
```python
# Constructed by Delete Last Used (took 0 milliseconds)
import torch
from thunder.executors.torchex import no_autocast

@torch.no_grad()
@no_autocast
def computation():
  return torch.device("cuda:0")
```