### PR TITLE
empty - fix - _empty_transform() got multiple values for argument 'device'

### DIFF
--- a/thunder/executors/torchex.py
+++ b/thunder/executors/torchex.py
@@ -572,30 +572,6 @@ def _squeeze_transform(a: TensorLike, /, dim: None | int | Sequence[int] = None)
     return squeeze(a, dim)
 
 
-def _empty_transform(
-    shape: Sequence[int],
-    device: None | DeviceLike = None,
-    dtype: None | dtypeLike = None,
-    out: None | TensorLike = None,
-    layout: torch.layout = torch.strided,
-    requires_grad: bool = False,
-    pin_memory: bool = False,
-    memory_format: torch.memory_format = torch.contiguous_format,
-):
-    torch_device: None | torch.device = to_torch_device(device)
-    torch_dtype: None | torch.dtype = to_torch_dtype(dtype)
-    return empty(
-        shape,
-        device=torch_device,
-        dtype=torch_dtype,
-        out=out,
-        layout=layout,
-        requires_grad=requires_grad,
-        pin_memory=pin_memory,
-        memory_format=memory_format,
-    )
-
-
 _register_implementation(
     prims.broadcast_in_dim, checker=_always_executable, execution_transform=_broadcast_in_dim_prim_transform
 )
@@ -631,7 +607,6 @@ _register_implementation(ltorch.unfold, unfold, checker=_always_executable)
 _register_implementation(ltorch.unsqueeze, unsqueeze, checker=_always_executable)
 _register_implementation(ltorch.view, view, checker=_always_executable)
 _register_implementation(ltorch.view_as, view_as, checker=_always_executable)
-_register_implementation(ltorch.empty, empty, checker=_always_executable, execution_transform=_empty_transform)
 _register_implementation(ltorch.all_tensor, all_tensor, checker=_always_executable)
 _register_implementation(ltorch.any_tensor, any_tensor, checker=_always_executable)
 

--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -5826,6 +5826,8 @@ def empty_sample_generator(op, device, dtype, requires_grad, **kwargs):
 
     for shape in cases:
         yield SampleInput(shape, device=device, dtype=dtype)
+        if len(shape) > 0:  # *() will lead to no shape being passed to `empty`.
+            yield SampleInput(*shape, device=device, dtype=dtype)
 
 
 def empty_error_generator(op, device, **kwargs):


### PR DESCRIPTION
Fixes #825 

Repro
```python
import torch
import thunder

def foo():
  return torch.empty(80, 384, 384, dtype = torch.float16, device = "cuda")

# TypeError: _empty_transform() got multiple values for argument 'device'
thunder.jit(foo)()

```

It currently fails as the `execution_transform` registered for `torchex` (for ltorch.empty) doesn't match the signature correctly and `device` is a positional argument.

https://github.com/Lightning-AI/lightning-thunder/blob/15fbd4e58f0ed3fc37db37719706a535bedaabf6/thunder/executors/torchex.py#L575-L596

**Fix** - we remove the implementation for `ltorch.empty` and just use the already implemented `prims.empty` implementation. I don't think we need to specially register implementation for `ltorch.empty` yet as our `ltorch.empty` currently has constraints for other arguments (and we won't gain any perf as `ltorch.empty` decomposes to `prims.empty`.)
https://github.com/Lightning-AI/lightning-thunder/blob/15fbd4e58f0ed3fc37db37719706a535bedaabf6/thunder/torch/__init__.py#L788-L798