### PR TITLE
torch.matmul - fix autocast rule (and update the error message)

### DIFF
--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -3729,7 +3729,7 @@ def matmul_meta(a: TensorProxy, b: TensorProxy, /) -> TensorProxy:
 
     utils.check(
         utils.same_shape(a.shape[:-2], b.shape[:-2]),
-        lambda: f"Expected the batch dimensions of a ({a.shape[:-2],}) and the batch dimensions of b ({b.shape[:-2]}) to be the same",
+        lambda: f"Expected the batch dimensions of a {a.shape[:-2]} and the batch dimensions of b {b.shape[:-2]} to be the same",
     )
 
     utils.check(

--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -3831,6 +3831,11 @@ def maybe_downcast_to(dtype, args):
 
 
 @register_autocast_rule("torch.matmul")
+def autocast_torch_matmul_rule(a, b, dtype):
+    """Autocast rule for matmul"""
+    return ltorch.matmul(*(maybe_downcast_to(dtype, (a, b))))
+
+
 @register_autocast_rule(prims.PrimIDs.MATMUL)
 def autocast_matmul_rule(a, b, dtype):
     """Autocast rule for matmul"""

--- a/thunder/tests/test_autocast.py
+++ b/thunder/tests/test_autocast.py
@@ -238,6 +238,9 @@ def test_autocast_convolution(dim, requires_grad):
 @pytest.mark.parametrize("device", ("cpu", "cuda"))
 @pytest.mark.parametrize("b_dtype", (torch.float, torch.bfloat16))
 def test_autocast_torch_matmul(requires_grad, device, b_dtype):
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("Skipping - CUDA is not available")
+
     def foo(a, b):
         output = torch.matmul(a, b)
         return output

--- a/thunder/tests/test_autocast.py
+++ b/thunder/tests/test_autocast.py
@@ -235,15 +235,17 @@ def test_autocast_convolution(dim, requires_grad):
 
 
 @pytest.mark.parametrize("requires_grad", [False, True])
-def test_autocast_torch_matmul(requires_grad):
+@pytest.mark.parametrize("device", ("cpu", "cuda"))
+@pytest.mark.parametrize("b_dtype", (torch.float, torch.bfloat16))
+def test_autocast_torch_matmul(requires_grad, device, b_dtype):
     def foo(a, b):
         output = torch.matmul(a, b)
         return output
 
-    a = torch.rand([3, 1, 2], dtype=torch.float, device="cpu", requires_grad=requires_grad)
-    b = torch.rand([2, 3], dtype=torch.bfloat16, device="cpu", requires_grad=requires_grad)
+    a = torch.rand([3, 1, 2], dtype=torch.float, device=device, requires_grad=requires_grad)
+    b = torch.rand([2, 3], dtype=b_dtype, device=device, requires_grad=requires_grad)
 
-    with torch.autocast("cpu", torch.bfloat16):
+    with torch.autocast(device, torch.bfloat16):
         expected = foo(a, b)
         actual = thunder.jit(foo)(a, b)
 


### PR DESCRIPTION
Fixes https://github.com/Lightning-AI/lightning-thunder/issues/826

Minimal Repro:
```python
import torch
import thunder

def foo(a, b):    
  return torch.matmul(a, b)

a = torch.rand([3, 1, 2], dtype=torch.float, device='cuda')
b = torch.rand([2, 3], dtype=torch.bfloat16, device='cuda')

with torch.autocast("cuda", torch.bfloat16):
  foo(a, b)
  jfoo = thunder.jit(foo)
  jfoo(a, b)

print(thunder.last_traces(jfoo)[-1])
```

Reason for failure - autocast rule for matmul before this PR called `prims.matmul`. However, this is incorrect as `ltorch.matmul` takes care of reshaping inputs to be compliant with the correct shapes expected by prims.matmul (and this step was skipped when autocast rule was applied).

Fix - Update autocast ltorch.matmul rule to call `ltorch.matmul` after casting the dtypes.

**NOTE** - Have also tweaked the error message from prim.matmul to remove extra parentheses. The new error message now reads - `Expected the batch dimensions of a (3,) and the batch dimensions of b () to be the same`.

Generated Trace for above snippet (with patch from this PR) - 
```python
# Constructed by Delete Last Used (took 0 milliseconds)
import torch
from thunder.executors.torchex import no_autocast

@torch.no_grad()
@no_autocast
def computation(a, b):
  # a: "cuda:0 f32[3, 1, 2]"
  # b: "cuda:0 bf16[2, 3]"
  [t0] = nvFusion0(a)
    # t0 = prims.convert_element_type(a, dtypes.bfloat16)  # t0: "cuda:0 bf16[3, 1, 2]"
  del a
  t2 = torch.matmul(t0, b)  # t2: "cuda:0 bf16[3, 1, 3]"
    # t2 = ltorch.matmul(t0, b)  # t2: "cuda:0 bf16[3, 1, 3]"
      # t5 = prims.broadcast_in_dim(b, (3, 2, 3), (1, 2))  # t5: "cuda:0 bf16[3, 2, 3]"
      # t2 = prims.matmul(t0, t5)  # t2: "cuda:0 bf16[3, 1, 3]"
  del t0, b
  return t2
```
