### PR TITLE
grad transform to properly identify proxy on saved_for_backward

### DIFF
--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -3737,11 +3737,14 @@ def forward_and_backward_from_trace(trace: Trace, torch_autograd=False) -> Forwa
     flat_saves, _ = tree_flatten(saved_for_backward)
 
     def backward_fn(saved_for_backward, cotangents):
-        flat_saves_proxified, saves_spec  = tree_flatten(saved_for_backward)
-        flat_filtered = [proxified if isinstance(entry, Proxy) else entry for proxified, entry in zip(flat_saves_proxified, flat_saves)]
+        flat_saves_proxified, saves_spec = tree_flatten(saved_for_backward)
+        flat_filtered = [
+            proxified if isinstance(entry, Proxy) else entry
+            for proxified, entry in zip(flat_saves_proxified, flat_saves)
+        ]
         saved_for_backward = tree_unflatten(flat_filtered, saves_spec)
         env = reconstruct_forward_env_for_backward(trace, saved_for_backward)
-        
+
         if torch_autograd:
             cotangents = tree_unflatten(cotangents, output_spec)
         out = backward_pass(env, trace, cotangents)

--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -3737,6 +3737,7 @@ def forward_and_backward_from_trace(trace: Trace, torch_autograd=False) -> Forwa
     flat_saves, _ = tree_flatten(saved_for_backward)
 
     def backward_fn(saved_for_backward, cotangents):
+        # trace converts all saved_for_backward into proxy, we want to restore number scalars afterwards.
         flat_saves_proxified, saves_spec = tree_flatten(saved_for_backward)
         flat_filtered = [
             proxified if isinstance(entry, Proxy) else entry
@@ -3756,7 +3757,6 @@ def forward_and_backward_from_trace(trace: Trace, torch_autograd=False) -> Forwa
             out = tree_flatten(out)[0]
         return out
 
-    print("-- saved for backward ", saved_for_backward)
     backward_trace = construct_trace(rename_proxies=False)(backward_fn, saved_for_backward, cotangents)
 
     # We are done with constructing the forward and backward passes at this

--- a/thunder/tests/test_examine_memory.py
+++ b/thunder/tests/test_examine_memory.py
@@ -161,7 +161,7 @@ def test_nanogpt_block(executor, device, dtype):
         expected_return_calculated_mem = get_return_memory(fw_extrace.bound_symbols[-1]) - 4 * 2 * 1024 * 768
         assert expected_return_calculated_mem == sum(fw_alloc_mem[1].values())
 
-        assert bw_alloc_mem[0] == 361881600
+        assert bw_alloc_mem[0] == 361783296
         assert sum(bw_alloc_mem[1].values()) == get_return_memory(bw_extrace.bound_symbols[-1])
     if isinstance(executor, TorchTestExecutor):
         assert fw_alloc_mem[0] == 362863616

--- a/thunder/tests/test_grad.py
+++ b/thunder/tests/test_grad.py
@@ -1633,10 +1633,10 @@ def test_grad_transform_saved_for_backward_proxy():
     torch.autograd.backward(out, torch.rand_like(out), retain_graph=True)
     dynamic_trace = thunder.last_backward_traces(dynamic_jit)[-1]
     # dynamic trace should save `c` as proxy for backward
-    assert(any(map(lambda x: isinstance(x, Proxy), tree_flatten(dynamic_trace.args[0])[0])))
+    assert any(map(lambda x: isinstance(x, Proxy), tree_flatten(dynamic_trace.args[0])[0]))
 
     out = static_jit(a, c)
     torch.autograd.backward(out, torch.rand_like(out), retain_graph=True)
     static_trace = thunder.last_backward_traces(static_jit)[-1]
     # static trace should bake `c` as scalar number, so it won't show up in backward as proxy
-    assert(not any(map(lambda x: isinstance(x, Proxy), tree_flatten(static_trace.args[0])[0])))
+    assert not any(map(lambda x: isinstance(x, Proxy), tree_flatten(static_trace.args[0])[0]))

--- a/thunder/tests/test_grad.py
+++ b/thunder/tests/test_grad.py
@@ -1615,3 +1615,24 @@ def test_make_forward_backward_symbol_caching_with_executor():
 
     # This should call the core implementation.
     thunder.jit(foo)(a)
+
+def test_grad_transform_saved_for_backward_proxy():
+
+    def foo(a, c):
+        return a * c
+
+    a = make_tensor((2, 2), device=device, dtype=torch_dtype, requires_grad=False)
+    c = 2.0
+    
+    dynamic_jit = thunder.jit(foo, cache="symbolic values")
+    static_jit = thunder.jit(foo)
+
+    dynamic_jit(a, c)
+    dynamic_trace = thunder.last_backward_traces(dynamic_jit)[-1]
+    # dynamic trace should save `c` as proxy for backward
+    assert(any(map(tree_map(dynamic_trace[-1].args[0]), lambda x : isinstance(x, Proxy))))
+
+    static_jit(a, c)
+    static_trace = thunder.last_backward_traces(static_jit)[-1]
+    # static trace should bake `c` as scalar number, so it won't show up in backward as proxy
+    assert(not any(map(tree_map(static_trace[-1].args[0]), lambda x : isinstance(x, Proxy))))

--- a/thunder/tests/test_grad.py
+++ b/thunder/tests/test_grad.py
@@ -1616,6 +1616,7 @@ def test_make_forward_backward_symbol_caching_with_executor():
     # This should call the core implementation.
     thunder.jit(foo)(a)
 
+
 def test_grad_transform_saved_for_backward_proxy():
 
     def foo(a, c):
@@ -1623,16 +1624,16 @@ def test_grad_transform_saved_for_backward_proxy():
 
     a = make_tensor((2, 2), device=device, dtype=torch_dtype, requires_grad=False)
     c = 2.0
-    
+
     dynamic_jit = thunder.jit(foo, cache="symbolic values")
     static_jit = thunder.jit(foo)
 
     dynamic_jit(a, c)
     dynamic_trace = thunder.last_backward_traces(dynamic_jit)[-1]
     # dynamic trace should save `c` as proxy for backward
-    assert(any(map(tree_map(dynamic_trace[-1].args[0]), lambda x : isinstance(x, Proxy))))
+    assert any(map(tree_map(dynamic_trace[-1].args[0]), lambda x: isinstance(x, Proxy)))
 
     static_jit(a, c)
     static_trace = thunder.last_backward_traces(static_jit)[-1]
     # static trace should bake `c` as scalar number, so it won't show up in backward as proxy
-    assert(not any(map(tree_map(static_trace[-1].args[0]), lambda x : isinstance(x, Proxy))))
+    assert not any(map(tree_map(static_trace[-1].args[0]), lambda x: isinstance(x, Proxy)))


### PR DESCRIPTION
Fixes #541

backward trace needs to correctly use number proxy and scalar number in `save_for_backward`. Right now it's not the case where `thunder.trace` used to construct backward trace converts all inputs to proxies.

This PR restores proper proxy-ness by examine the `save_for_backward` returned by forward trace.