### PR TITLE
`test_autocast_torch_matmul`: fix flakiness

### DIFF
--- a/thunder/tests/test_autocast.py
+++ b/thunder/tests/test_autocast.py
@@ -255,7 +255,7 @@ def test_autocast_torch_matmul(requires_grad, device, b_dtype):
     torch.testing.assert_close(actual, expected)
 
     if requires_grad:
-        go = torch.randn_like(expected)
+        go = torch.ones_like(expected) / expected.numel()
         eager_grads = torch.autograd.grad(expected, [a, b], go)
         jit_grads = torch.autograd.grad(actual, [a, b], go)
 


### PR DESCRIPTION
Fixes https://github.com/Lightning-AI/lightning-thunder/issues/850.

Passes the following:
```python
pytest --show-progress --verbose thunder/tests/test_autocast.py -k test_autocast_torch_matmul --count 10000 -n 30
...
__________________________________________________________________________ 80000 of 80000 completed, 80000 Pass, 0 Fail, 0 Skip, 0 XPass, 0 XFail, 0 Error, 0 ReRun __________________________________________________________________________

```
