### PR TITLE
test_change_default_device_with_ctx seems to flakily pass

### DIFF
--- a/thunder/tests/test_core.py
+++ b/thunder/tests/test_core.py
@@ -3046,7 +3046,6 @@ def test_change_default_device_in_jitted_fn():
 @requiresCUDA
 @pytest.mark.xfail(
     reason="When using device as context in PyTorch, it doesn't reflect in torch.get_default_device - see https://github.com/pytorch/pytorch/issues/131328",
-    strict=True,
 )
 def test_change_default_device_with_ctx():
     def fn(x):


### PR DESCRIPTION
Ref https://github.com/Lightning-AI/lightning-thunder/issues/853

`test_change_default_device_with_ctx` seems to flakily pass and fails otherwise - removing `strict=True`. Will investigate more into this.