### PR TITLE
CUDAGraphs: fix issues with buffer initializations

### DIFF
--- a/thunder/executors/cudagraphex.py
+++ b/thunder/executors/cudagraphex.py
@@ -44,7 +44,7 @@ def build_cuda_graph(
 
     def get_static_buffer(x):
         if isinstance(x, torch.Tensor):
-            return torch.empty_like(x)
+            return torch.empty_like(x).copy_(x)
         return x
 
     args = args_descriptor.args

--- a/thunder/extend/__init__.py
+++ b/thunder/extend/__init__.py
@@ -354,6 +354,7 @@ def get_all_executors() -> tuple[Executor, ...]:
     # manually import all native executors to let them register themselves
     from thunder.executors import (
         apex_entropyex,
+        cudagraphex,
         cudnn_layernormex,
         cudnnex,
         nvfuserex,

--- a/thunder/tests/test_cudagraphs_executor.py
+++ b/thunder/tests/test_cudagraphs_executor.py
@@ -1,0 +1,25 @@
+import pytest
+
+import torch
+from torch.testing import assert_close
+
+import thunder
+from thunder.executors.cudagraphex import cudagraphex
+from thunder.tests.framework import requiresCUDA
+
+
+@requiresCUDA
+def test_warmup_runs_with_correct_buffers():
+    """
+    Tests whether newly-created buffers are being properly initialized.
+    Otherwise we should expect failures because of incorrect values.
+    """
+
+    weights = torch.tensor([0, 10, 3, 0], device="cuda", dtype=torch.float)
+
+    def f(x):
+        return torch.multinomial(x, num_samples=3, replacement=True)
+
+    jf = thunder.jit(f, use_cudagraphs=True)
+    jf(weights)
+    jf(weights)

--- a/thunder/tests/test_extend.py
+++ b/thunder/tests/test_extend.py
@@ -136,6 +136,7 @@ def test_get_all_executors_includes_all_native_executors():
         "torchcompile_cat",
         "python",
         "transformer_engine",
+        "cudagraphex",
     }
     if package_available("triton"):
         # `triton` maybe installed on a system without GPU.


### PR DESCRIPTION
We forget to properly init buffers prior to warm-up runs.
That was not caught by our tests because the GPT model, apparently, does not run kernels conditioned on inputs' values.

Thank you, @apaz-cli , @lantiga , for your help in finding this issue!