### PR TITLE
make quantization work with meta

### DIFF
--- a/thunder/core/module.py
+++ b/thunder/core/module.py
@@ -100,7 +100,7 @@ class ThunderModule(pytorch.nn.Module):
 
     def load_original_state_dict(self, state_dict):
         # this loads the state dict incrementally to not exhaust memory
-        module_names = {n for n, _ in self.named_modules()}
+        module_names = {n for n, _ in self._model.named_modules()}
         sd_per_module = collections.defaultdict(dict)
         for k, v in state_dict.items():
             prefix, sep, _ = k.rpartition(".")
@@ -115,7 +115,7 @@ class ThunderModule(pytorch.nn.Module):
                 sd_part = transform.transform_state_dict_for_submodule(self, submodule_name, sd_part)
             for k, v in sd_part.items():
                 full_k = prefix + k
-                if k in self._overrides_parameters:
+                if full_k in self._overrides_parameters:
                     p = self._overrides_parameters[full_k]
                     if p.dtype == v.dtype and p.shape == v.shape:
                         with pytorch.no_grad():
@@ -126,7 +126,7 @@ class ThunderModule(pytorch.nn.Module):
                                 v.to(p.device), requires_grad=p.requires_grad
                             )
 
-                elif k in self._overrides_buffers:
+                elif full_k in self._overrides_buffers:
                     if p.dtype == v.dtype and p.shape == v.shape:
                         with pytorch.no_grad():
                             self._overrides_buffers[full_k].copy_(v)

--- a/thunder/transforms/quantization.py
+++ b/thunder/transforms/quantization.py
@@ -57,11 +57,20 @@ class BitsAndBytesLinearQuant4bit(Transform):
             self.quantized_submodule_names.add(name)
             weight_name = f"{name}.weight"
             w = tm.get_parameter(weight_name)
-            # device!, double quant support
-            qw, qs = bitsandbytes.functional.quantize_4bit(w.to("cuda"), quant_type="nf4")
-            tm._overrides_parameters[weight_name] = qw
-            tm._overrides_parameters[f"{weight_name}.absmax"] = qs.absmax
-            tm._overrides_parameters[f"{weight_name}.code"] = qs.code
+            # TODO: double quant support
+
+            if w.device.type == "meta":
+                w_work = torch.zeros_like(w, device="cuda")
+            elif w.device.type != "cuda":
+                with torch.no_grad():
+                    w_work = w.to("cuda")
+            else:
+                w_work = w
+
+            qw, qs = bitsandbytes.functional.quantize_4bit(w_work, quant_type="nf4")
+            tm._overrides_parameters[weight_name] = qw.to(w.device)
+            tm._overrides_parameters[f"{weight_name}.absmax"] = qs.absmax.to(w.device)
+            tm._overrides_parameters[f"{weight_name}.code"] = qs.code.to(w.device)
             self.quant_states[weight_name] = {"dtype": qs.dtype, "shape": qs.shape, "blocksize": qs.blocksize}
 
         for n, submodule in model._model.named_modules():
@@ -78,13 +87,21 @@ class BitsAndBytesLinearQuant4bit(Transform):
         assert w.dtype == qs_dict["dtype"]
         assert w.shape == qs_dict["shape"]
 
-        qw, qs = bitsandbytes.functional.quantize_4bit(w.to("cuda"), block_size=qs_dict["blocksize"], quant_type="nf4")
+        if w.device.type == "meta":
+            w_work = torch.zeros_like(w, device="cuda")
+        elif w.device.type != "cuda":
+            with torch.no_grad():
+                w_work = w.to("cuda")
+        else:
+            w_work = w
+
+        qw, qs = bitsandbytes.functional.quantize_4bit(w_work, blocksize=qs_dict["blocksize"], quant_type="nf4")
 
         # double quant support...
         state_dict = state_dict.copy()
-        state_dict[weight_name] = qw
-        state_dict[f"{weight_name}.absmax"] = qs.absmax
-        state_dict[f"{weight_name}.code"] = qs.code
+        state_dict["weight"] = qw.to(w.device)
+        state_dict["weight.absmax"] = qs.absmax.to(w.device)
+        state_dict["weight.code"] = qs.code.to(w.device)
 
         return state_dict
 


### PR DESCRIPTION
... also fix things found by testing

Highlight: This works with a model that has parameters on `meta`:

```python
    jm = thunder.jit(
        m,
        executors=(bitsandbytes_executor,),
        transforms=[
            BitsAndBytesLinearQuant4bit(),
            MaterializationTransform("cuda", init=init_from_sd),
        ],
    )
```