### PR TITLE
`unpack_trivial` name check

### DIFF
--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -1594,7 +1594,7 @@ def unpack_inputs(ctx, prologue_trace, pro_to_comp_inps, pro_to_epi_inps, args, 
     with tracectx(prologue_trace):
         for n, l in (("args", len(args)), ("kwargs", len(kwargs))):
             output = Proxy(name=n)
-            bsym = prims.unpack_trivial.bind(output, output=output)
+            bsym = prims.unpack_trivial.bind(output, output=output, name=n)
             prologue_trace.bound_symbols.append(bsym)
             bsym = prims.check_len.bind(output, l, output=None)
             prologue_trace.bound_symbols.append(bsym)

--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -667,6 +667,10 @@ def unpack_trivial_printer(
 
 # Removes the inputs from unpack_trivial, so it appears to have no input
 def _unpack_trivial_bind_postprocess(bsym: BoundSymbol) -> None:
+    utils.check(
+        bsym.kwargs["name"] is not None,
+        lambda: "Expected name keyword argument not to be None for unpack_trivial.bind().",
+    )
     bsym.args = ()
 
 
@@ -707,13 +711,17 @@ def unpack_function_obj_printer(
     return s
 
 
+def _unpack_function_obj_bind_postprocess(bsym: BoundSymbol) -> None:
+    bsym.args = ()
+
+
 unpack_function_obj = make_prim(
     PrimIDs.UNPACK_FUNCTION_OBJ,
     "unpack_function_obj",
     meta=unpack_function_obj_meta,
     python_printer=unpack_function_obj_printer,
     python_impl=unpack_function_obj_impl,
-    _bind_postprocess=_unpack_trivial_bind_postprocess,
+    _bind_postprocess=_unpack_function_obj_bind_postprocess,
 )
 
 
@@ -781,13 +789,17 @@ def unpack_cache_info_printer(
     return s
 
 
+def _unpack_cache_info_bind_postprocess(bsym: BoundSymbol) -> None:
+    bsym.args = ()
+
+
 unpack_cache_info = make_prim(
     PrimIDs.UNPACK_CACHE_INFO,
     "unpack_cache_info",
     meta=unpack_cache_info_meta,
     python_printer=unpack_cache_info_printer,
     python_impl=unpack_cache_info_impl,
-    _bind_postprocess=_unpack_trivial_bind_postprocess,
+    _bind_postprocess=_unpack_cache_info_bind_postprocess,
 )
 
 
@@ -1509,7 +1521,7 @@ def unpack(x: Any) -> Any:
             return unpack_dict(x)
         baseutils.check(False, lambda: f"unpack encountered an unsupported collection type {type(coll)}")
 
-    return unpack_trivial(x)
+    return unpack_trivial(x, name=x.name)
 
 
 #

--- a/thunder/core/transform_common.py
+++ b/thunder/core/transform_common.py
@@ -225,10 +225,6 @@ def cse_single_bsym(
     if bsym.sym.id in NON_FUNCTIONAL_OPS:
         return bsym
 
-    # the unpack_trivial all have no rhs
-    if bsym.sym == thunder.core.prims.unpack_trivial:
-        return bsym
-
     # We can replace any redundant `bsym.args` and `bsym.kwargs` if it is available in the current context.
     new_bsym = bsym.from_bsym_swap_proxies(
         swap_map=redundant_map,

--- a/thunder/transforms/quantization.py
+++ b/thunder/transforms/quantization.py
@@ -168,7 +168,9 @@ class BitsAndBytesLinearQuant4bit(Transform):
         prologue_trace.bound_symbols[-1:-1] = new_bsyms
 
         with tracectx(computation_trace):
-            new_bindings = [thunder.core.prims.unpack_trivial.bind(i, output=i) for i in new_compute_inputs]
+            new_bindings = [
+                thunder.core.prims.unpack_trivial.bind(i, output=i, name=i.name) for i in new_compute_inputs
+            ]
 
         new_computation_trace = thunder.core.trace.from_trace(computation_trace)
         new_computation_trace.args = (*new_computation_trace.args, *new_compute_inputs)


### PR DESCRIPTION
## What does this PR do?

Fixes the fix for CSE #870.

## Note

TLDR: always use  `unpack_trivial` with the kwarg `name` and/or always use `unpack_trivial.bind( ..., name="something")`.

CSE uses the Right Hand Side(RHS) of the symbols to perform its duty. When using `unpack_trivial` without specifying the variable name, it results in a RHS with `name=None`. Suffice to say that all the symbols that have this RHS are hashed to the same hash, therefore the CSE logic will treat them as duplicate and delete them.

With this PR I cleaned up a couple of prims that were reusing the same fn as `unpack_trivial` for bind post-processing and fixed the missing name in the quantization transform.
