### PR TITLE
interpreter - Fix error when function is called with invalid arg.

### DIFF
--- a/thunder/core/interpreter.py
+++ b/thunder/core/interpreter.py
@@ -6639,7 +6639,7 @@ def _setup_frame_and_run_python_function(
         locals_dict[code.co_varnames[idx]] = unconsumed_kwargs
     elif unconsumed_kwargs:
 
-        return do_raise(TypeError(f"{fn}() got unexpected keyword arguments: {',',join(unconsumed_kwargs)}"))
+        return do_raise(TypeError(f"{fn}() got unexpected keyword arguments: {','.join(unconsumed_kwargs)}"))
 
     # And that's it! We have all local vars in locals_dict.
 

--- a/thunder/tests/test_interpreter.py
+++ b/thunder/tests/test_interpreter.py
@@ -3296,3 +3296,12 @@ def test_metaclass(jit):
 
     fn()
     jit(fn)()
+
+
+def test_incorrect_args():
+    def fn(x):
+        return x
+
+    jfn = thunder.jit(fn)
+    with pytest.raises(TypeError, match="got unexpected keyword arguments: incorrect_arg"):
+        jfn(3, incorrect_arg=3)


### PR DESCRIPTION
```python
def fn(x):
        return x

jfn = thunder.jit(fn)
jfn(3, incorrect_arg=3)
```

Errors with 
```python
raise InterpreterError(msg) from e
E               thunder.core.interpreter.InterpreterError: Encountered exception NameError: name 'join' is not defined while tracing <function test_incorrect_args.<locals>.fn at 0x7c50c5ff4820>
```