### PR TITLE
Fix `import thunder` in the absence of einops and distributed build of PyTorch

### DIFF
--- a/thunder/executors/torchex.py
+++ b/thunder/executors/torchex.py
@@ -2104,6 +2104,7 @@ _register_implementation(prims.item, item, checker=_always_executable)
 
 
 has_einops = importlib.util.find_spec("einops") is not None
+has_einops &= importlib.util.find_spec("einops._backends") is not None
 if has_einops:
     import einops
     from einops._backends import TorchBackend

--- a/thunder/executors/torchex.py
+++ b/thunder/executors/torchex.py
@@ -2104,7 +2104,8 @@ _register_implementation(prims.item, item, checker=_always_executable)
 
 
 has_einops = importlib.util.find_spec("einops") is not None
-has_einops &= importlib.util.find_spec("einops._backends") is not None
+if has_einops:
+    importlib.util.find_spec("einops._backends") is not None
 if has_einops:
     import einops
     from einops._backends import TorchBackend

--- a/thunder/executors/torchex.py
+++ b/thunder/executors/torchex.py
@@ -2105,7 +2105,7 @@ _register_implementation(prims.item, item, checker=_always_executable)
 
 has_einops = importlib.util.find_spec("einops") is not None
 if has_einops:
-    importlib.util.find_spec("einops._backends") is not None
+    has_einops = importlib.util.find_spec("einops._backends") is not None
 if has_einops:
     import einops
     from einops._backends import TorchBackend

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -5296,7 +5296,7 @@ else:
     def all_reduce_(
         a: TensorLike,
         /,
-        op: DistributedReduceOpLike = torch.distributed.ReduceOp.SUM,
+        op: DistributedReduceOpLike = "torch.distributed.ReduceOp.SUM",
         group: torch.distributed.ProcessGroup | None = None,
         async_op: bool = False,
     ) -> None:


### PR DESCRIPTION
Two small changes to make Thunder importable on my Windows computer without distributed and without einops installed.