### PR TITLE
cudagraphs before del

### DIFF
--- a/thunder/distributed/utils.py
+++ b/thunder/distributed/utils.py
@@ -222,8 +222,8 @@ def limit_in_flight_allgathers(
             case pack_for_fsdp_prim_impl.id:
                 pack_consumer = consumers.get(bsym.flat_proxy_outs[0], None)
                 check(
-                    pack_consumer is not None and len(pack_consumer) == 1,
-                    lambda: f"Pack operator should have one consumer",
+                    pack_consumer is not None and len(pack_consumer) in (1, 2),
+                    lambda: f"Pack's operand {bsym.flat_proxy_outs[0]} expected to be consumed by all-gather and del: {pack_consumer}",
                 )
                 # skip the pack operator corresponds to allgather
                 if pack_consumer[0].sym.id != all_gather_prim_impl.id:
@@ -244,9 +244,9 @@ def limit_in_flight_allgathers(
                         wait_consumer = consumers.get(bsym.flat_proxy_outs[0], None)
                         check(
                             wait_consumer is not None
-                            and len(wait_consumer) == 1
+                            and len(wait_consumer) in (1, 2)
                             and wait_consumer[0].sym.id == unpack_for_fsdp_prim_impl.id,
-                            lambda: f"The consumer of wait operator should be unpack operator",
+                            lambda: f"wait of {bsym.flat_proxy_outs[0]} expected to be consumed unpack and del: {wait_consumer}",
                         )
                         unpack_bsyms.append(wait_consumer[0])
                 bound_symbols.append(bsym)

--- a/thunder/executors/cudagraphex.py
+++ b/thunder/executors/cudagraphex.py
@@ -169,6 +169,12 @@ class CUDAGraphExecutor(FusionExecutor):
             curr_tracectx.clear_collection_names.add(bsym.args[0].name)
             return False
 
+        # We let DEL to get fused (but should not see them much), unless the deleted proxy is a CollectionProxy
+        # consumed by the `clear_mutable_collection` symbol
+        if bsym.sym.id == prims.PrimIDs.DEL and bsym.args[0].name in curr_tracectx.clear_collection_names:
+            return False
+        # }
+
         do_not_fuse_sym_set = {
             # Skip the very beginning and the very end of the trace
             prims.PrimIDs.UNPACK_TRIVIAL,

--- a/thunder/executors/passes.py
+++ b/thunder/executors/passes.py
@@ -236,33 +236,16 @@ def update_fusion_call_ctx(trace: TraceCtx) -> TraceCtx:
     return new_trace
 
 
-# TODO Review deleting non-proxies
-def del_last_used(trace: TraceCtx, *, clear_mutable_collections=False) -> TraceCtx:
-    """Mark last used intermediates to be deleted. This lets the Python garbage collector free
-        unused tensor memory.
-
-    Args:
-        trace: trace to be transformed
-        clear_mutable_collections: whether to clear collections
-    Returns:
-        list: transformed trace
-    """
-    start_time_ns = time.perf_counter_ns()
-
-    del_trace = from_trace(trace)
+def _del_last_used(bound_symbols, flattened_final_output, *, clear_mutable_collections=False):
     bsyms = deque()
-
-    outs = cutils.sequencify(trace.output)
-    flat_outs, _ = tree_flatten(outs)
-
     # TODO Replace with ProxySet (which does not exist at the time of this writing)
     handled = ProxyDict()
-    for out in flat_outs:
+    for out in flattened_final_output:
         if isinstance(out, Proxy):
             handled[out] = None
 
     bsym: BoundSymbol
-    for bsym in reversed(trace.bound_symbols):
+    for bsym in reversed(bound_symbols):
         if bsym.sym.id in comment_symbols:
             bsyms.appendleft(bsym)
             continue
@@ -291,7 +274,30 @@ def del_last_used(trace: TraceCtx, *, clear_mutable_collections=False) -> TraceC
 
         bsyms.appendleft(bsym)
 
-    del_trace.bound_symbols = list(bsyms)
+    return list(bsyms)
+
+
+# TODO Review deleting non-proxies
+def del_last_used(trace: TraceCtx, *, clear_mutable_collections=False) -> TraceCtx:
+    """Mark last used intermediates to be deleted. This lets the Python garbage collector free
+        unused tensor memory.
+
+    Args:
+        trace: trace to be transformed
+        clear_mutable_collections: whether to clear collections
+    Returns:
+        list: transformed trace
+    """
+    start_time_ns = time.perf_counter_ns()
+
+    del_trace = from_trace(trace)
+
+    outs = cutils.sequencify(trace.output)
+    flat_outs, _ = tree_flatten(outs)
+
+    del_trace.bound_symbols = _del_last_used(
+        trace.bound_symbols, flat_outs, clear_mutable_collections=clear_mutable_collections
+    )
 
     end_time_ns = time.perf_counter_ns()
     elapsed_time_ns = end_time_ns - start_time_ns

--- a/thunder/executors/passes.py
+++ b/thunder/executors/passes.py
@@ -250,6 +250,10 @@ def _del_last_used(bound_symbols, flattened_final_output, *, clear_mutable_colle
             bsyms.appendleft(bsym)
             continue
 
+        if bsym.sym.id == prims.PrimIDs.DEL:
+            # we will skip old dels and generate new ones
+            continue
+
         to_del = []
         for x in chain(bsym.flat_proxy_outs, bsym.flat_proxy_args):
             if x in handled:


### PR DESCRIPTION
The current del handling in the cudagraphs transforms runs into trouble when not fusing everything because dels go to the wrong place.

This is needed in order to exclude (even experimentally) things from the cudagraph.

However, it misses
- handling autograd's transform for execution (@IvanYashchuk any advice if we can move the delete last used to after autograd, i.e. to `thunder.jit.fn_`?)
- a testing strategy. This only shows when not merging everything (I manually excluded `bnb_matmul_nf4` by hardcoding a change to the executor and hit this, maybe allowing operators to say if they're cudagraph-unfusable?)

Also cc @nikitaved if he has comments.