### PR TITLE
Add nvFuser fusion region repro util and update DebugTransform

### DIFF
--- a/docs/source/basic/inspecting_traces.rst
+++ b/docs/source/basic/inspecting_traces.rst
@@ -189,7 +189,7 @@ which prints::
     }
   }
 
-Moreover, if you are just interested in running a specific nvFuser segment, Thunder offers an handy helper fuction. The ``get_nvFuser_repro()`` function takes a trace and a fusion name as input and returns it's repro script::
+Moreover, if you are just interested in running a specific nvFuser segment, Thunder offers an handy helper function. The ``get_nvFuser_repro()`` function takes a trace and a fusion name as input and returns it's repro script::
 
   from thunder.examine import get_nvFuser_repro
 

--- a/docs/source/basic/inspecting_traces.rst
+++ b/docs/source/basic/inspecting_traces.rst
@@ -189,7 +189,7 @@ which prints::
     }
   }
 
-Moreover, if you are just interested in running a specific nvFuser region without Thunder, you can use an handy helper function. The ``get_nvfuser_repro()`` function takes a trace and a fusion name as input and returns it's repro script::
+Moreover, if you are just interested in running a specific nvFuser region without Thunder, you can use a handy helper function. The ``get_nvfuser_repro()`` function takes a trace and a fusion name as input and returns it's repro script::
 
   from thunder.examine import get_nvfuser_repro
   ...

--- a/docs/source/basic/inspecting_traces.rst
+++ b/docs/source/basic/inspecting_traces.rst
@@ -207,7 +207,7 @@ This will print the following::
   # nvfuser version: 0.2.8
   import torch
   from nvfuser import FusionDefinition, DataType
-  
+
   def nvfuser_fusion_id0(fd : FusionDefinition) -> None :
       T0 = fd.define_tensor(shape=[-1, -1], contiguity=[True, True], dtype=DataType.Float, is_cpu=False, stride_order=[1, 0])
       T1 = fd.define_tensor(shape=[-1, -1], contiguity=[True, True], dtype=DataType.Float, is_cpu=False, stride_order=[1, 0])
@@ -215,10 +215,10 @@ This will print the following::
       T3 = fd.ops.mul(T2, T1)
       fd.add_output(T3)
       fd.add_output(T2)
-  
+
   with FusionDefinition() as fd:
       nvfuser_fusion_id0(fd)
-  
+
   inputs = [
       torch.randn((4,), dtype=torch.float32, device='cuda:0').as_strided((2, 2), (2, 1)),
       torch.randn((4,), dtype=torch.float32, device='cuda:0').as_strided((2, 2), (2, 1)),

--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -472,7 +472,7 @@ def noop(cfn: Callable) -> Callable:
 # The comment fusions transform. Just adds a comment before and after each fusion.
 #   This is an example of a post-optimization transform.
 class _CommentFusionsTransform(Transform):
-    def transform_trace_post_optimization(trace: Trace, **kwargs) -> Trace:
+    def transform_trace_post_optimization(self, trace: Trace, **kwargs) -> Trace:
         start_time_ns = time.perf_counter_ns()
         commented_trace = from_trace(trace)
 

--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -498,7 +498,7 @@ class _CommentFusionsTransform(Transform):
 
 
 def comment_fusions(cfn: Callable) -> Callable:
-    return add_ransform(cfn, _CommentFusionsTransform)
+    return add_transform(cfn, _CommentFusionsTransform)
 
 
 #

--- a/thunder/dev_utils/debug_transform.py
+++ b/thunder/dev_utils/debug_transform.py
@@ -38,6 +38,7 @@ class DebugTransform(thunder.core.transforms.Transform):
                 continue
 
             if self.pre_callback is not None:
+
                 def _pre_call_ctx(bsym, *args, **kwargs):
                     out = self.pre_callback(bsym, *args, **kwargs)
                     thunder.core.utils.check_type(out, str)
@@ -50,6 +51,7 @@ class DebugTransform(thunder.core.transforms.Transform):
             new_bsyms.append(bsym)
 
             if self.post_callback is not None:
+
                 def _post_call_ctx(bsym, *args, **kwargs):
                     out = self.post_callback(bsym, *args, **kwargs)
                     thunder.core.utils.check_type(out, str)

--- a/thunder/dev_utils/debug_transform.py
+++ b/thunder/dev_utils/debug_transform.py
@@ -1,51 +1,72 @@
-from thunder.core.trace import TraceCtx as Trace, from_trace, TraceProvenance
-import thunder
+from collections.abc import Callable
 from functools import partial
-from thunder.core.symbol import Symbol
+import time
+
+from thunder.core.trace import TraceCtx, from_trace, TraceProvenance
+import thunder
+from thunder.core.symbol import Symbol, BoundSymbol
 from thunder.dev_utils.utils import NON_COMPUTATION_PRIMS
 
 
-# NOTE: `computation_bsym, debug_bsym, callback` are mandatory keyword-only arguments.
-def debug_impl(*args, computation_bsym, debug_bsym, callback, **kwargs):
-    output = callback(computation_bsym, *args, **kwargs)
-    thunder.core.utils.check_type(output, str)
-    debug_bsym.header = output
+def create_debug_boundsymbol(name: str, bsym: BoundSymbol, call_ctx: Callable):
+    debug_sym = Symbol(name, lambda *_: None, is_prim=True)
+    debug_bsym = debug_sym.bind(*bsym.args, output=None, _call_ctx={name: partial(call_ctx, bsym)}, **bsym.kwargs)
+    return debug_bsym
 
 
 class DebugTransform(thunder.core.transforms.Transform):
-    def __init__(self, callback):
-        self.callback = callback
+    def __init__(
+        self,
+        *,
+        pre_callback: Callable[[tuple[BoundSymbol, ...]], str] | None,
+        post_callback: Callable[[tuple[BoundSymbol, ...]], str] | None,
+        guard: Callable[[], bool] | None = None,
+    ):
+        self.pre_callback = pre_callback
+        self.post_callback = post_callback
+        self.guard = guard if guard is not None else lambda _: True
 
-    def transform_trace_post_optimization(self, trace: Trace, **kwargs) -> Trace:
+    def transform_trace_post_optimization(self, trace: TraceCtx, **kwargs) -> TraceCtx:
+        start_time_ns = time.perf_counter_ns()
         debug_trace = from_trace(trace)
-        cnt = 1
-        for bound_symbol in trace.bound_symbols:
-            if bound_symbol.sym.id in NON_COMPUTATION_PRIMS:
-                # Just append the symbol.
-                debug_trace.bound_symbols.append(bound_symbol)
+        debug_counter = 1
+
+        new_bsyms: list[BoundSymbol] = []
+        for bsym in trace.bound_symbols:
+            sym_name = bsym.sym.name
+
+            if bsym.sym.id in NON_COMPUTATION_PRIMS:
+                new_bsyms.append(bsym)
                 continue
 
-            # we need unique name for each symbol.
-            debug_sym_name = f"debug_{bound_symbol.sym.name}_{cnt}"
+            if self.guard(bsym) and self.pre_callback is not None:
 
-            def bind_postprocess(bsym) -> None:
-                # This dict is then used by trace.python_ctx() to resolve the
-                # BoundSymbol to the actual function.
-                bsym._call_ctx = {
-                    debug_sym_name: partial(
-                        debug_impl, computation_bsym=bound_symbol, debug_bsym=bsym, callback=self.callback
-                    )
-                }
+                def _pre_call_ctx(bsym, *args, **kwargs):
+                    out = self.pre_callback(bsym, *args, **kwargs)
+                    thunder.core.utils.check_type(out, str)
+                    pre_debug_bsym.header = out
 
-            # Create a new debug symbol for this bsym.
-            debug_sym = Symbol(
-                debug_sym_name, lambda *args, **kwargs: None, is_prim=True, _bind_postprocess=bind_postprocess
-            )
-            debug_bsym = debug_sym.bind(*bound_symbol.args, output=None, **bound_symbol.kwargs)
+                pre_debug_name = f"debug_pre_{sym_name}{debug_counter}"
+                pre_debug_bsym = create_debug_boundsymbol(pre_debug_name, bsym, _pre_call_ctx)
+                new_bsyms.append(pre_debug_bsym)
 
-            debug_trace.bound_symbols.append(debug_bsym)
-            debug_trace.bound_symbols.append(bound_symbol)
-            cnt += 1
+            new_bsyms.append(bsym)
 
-        debug_trace.set_provenance(TraceProvenance("Debug Transform"))
+            if self.guard(bsym) and self.post_callback is not None:
+
+                def _post_call_ctx(bsym, *args, **kwargs):
+                    out = self.post_callback(bsym, *args, **kwargs)
+                    thunder.core.utils.check_type(out, str)
+                    post_debug_bsym.header = out
+
+                post_debug_name = f"debug_post_{sym_name}{debug_counter}"
+                post_debug_bsym = create_debug_boundsymbol(post_debug_name, bsym, _post_call_ctx)
+                new_bsyms.append(post_debug_bsym)
+
+        debug_trace.bound_symbols = new_bsyms
+        elapsed_time_ns = time.perf_counter_ns() - start_time_ns
+
+        debug_trace.set_provenance(TraceProvenance(f"Debug trace (took {elapsed_time_ns * 1e-6:.2f} milliseconds)"))
+
+        debug_counter += 1
         return debug_trace

--- a/thunder/dev_utils/debug_transform.py
+++ b/thunder/dev_utils/debug_transform.py
@@ -18,13 +18,11 @@ class DebugTransform(thunder.core.transforms.Transform):
     def __init__(
         self,
         *,
-        pre_callback: Callable[[tuple[BoundSymbol, ...]], str] | None,
-        post_callback: Callable[[tuple[BoundSymbol, ...]], str] | None,
-        guard: Callable[[], bool] | None = None,
+        pre_callback: Callable[[tuple[BoundSymbol, ...]], str] | None = None,
+        post_callback: Callable[[tuple[BoundSymbol, ...]], str] | None = None,
     ):
         self.pre_callback = pre_callback
         self.post_callback = post_callback
-        self.guard = guard if guard is not None else lambda _: True
 
     def transform_trace_post_optimization(self, trace: TraceCtx, **kwargs) -> TraceCtx:
         start_time_ns = time.perf_counter_ns()
@@ -39,8 +37,7 @@ class DebugTransform(thunder.core.transforms.Transform):
                 new_bsyms.append(bsym)
                 continue
 
-            if self.guard(bsym) and self.pre_callback is not None:
-
+            if self.pre_callback is not None:
                 def _pre_call_ctx(bsym, *args, **kwargs):
                     out = self.pre_callback(bsym, *args, **kwargs)
                     thunder.core.utils.check_type(out, str)
@@ -52,8 +49,7 @@ class DebugTransform(thunder.core.transforms.Transform):
 
             new_bsyms.append(bsym)
 
-            if self.guard(bsym) and self.post_callback is not None:
-
+            if self.post_callback is not None:
                 def _post_call_ctx(bsym, *args, **kwargs):
                     out = self.post_callback(bsym, *args, **kwargs)
                     thunder.core.utils.check_type(out, str)

--- a/thunder/examine/__init__.py
+++ b/thunder/examine/__init__.py
@@ -9,7 +9,6 @@ from thunder.core.proxies import TensorProxy
 from thunder.core.symbol import BoundSymbol
 from thunder.torch import _torch_to_thunder_function_map
 from thunder.core.langctxs import resolve_language, LanguageContext, Languages
-from thunder.executors.nvfuserex_impl import FusionDefinitionWrapper
 import torch
 from warnings import warn
 

--- a/thunder/examine/__init__.py
+++ b/thunder/examine/__init__.py
@@ -246,11 +246,14 @@ def get_nvfuser_repro(trace: TraceCtx, fusion_name: str, /) -> str:
         assert False, f"Unable to find fusion '{fusion_name}' in trace."
 
     if fusion.last_used is None:
-        assert False, "Fusion definition needs to be executed to record the inputs. You must execute the fusion first before you can query the repro."
+        assert (
+            False
+        ), "Fusion definition needs to be executed to record the inputs. You must execute the fusion first before you can query the repro."
 
     if fusion.last_inputs is None:
-        assert False, "Fusion definition inputs need to be recorded. Use compile option 'nv_store_fusion_inputs=True' while tracing."
+        assert (
+            False
+        ), "Fusion definition inputs need to be recorded. Use compile option 'nv_store_fusion_inputs=True' while tracing."
 
     fd = fusion.last_used
     return fd.getReproString(fusion.last_inputs)
-

--- a/thunder/examine/__init__.py
+++ b/thunder/examine/__init__.py
@@ -219,7 +219,14 @@ def get_fusion_symbols(trace: TraceCtx, warn_if_fusions_unavailable: bool = True
     return fusions
 
 
-def get_nvFuser_repro(fusion: FusionDefinitionWrapper, /) -> str:
+def get_nvFuser_repro(trace: TraceCtx, fusion_name: str, /) -> str:
+    """
+    Helper function to get the repro of a specific nvFusion segment.
+    """
+    if (fusion := trace.python_ctx().get(fusion_name, None)) is None:
+        available_fusions = [name for name, _ in get_fusions(trace)]
+        assert False, f"Unable to find fusion '{fusion_name}' in trace. Available fusions are: {available_fusions}."
+
     msg = ""
     msg += (
         "import torch\nfrom nvfuser import FusionDefinition, DataType\n"

--- a/thunder/examine/__init__.py
+++ b/thunder/examine/__init__.py
@@ -9,7 +9,6 @@ from thunder.core.proxies import TensorProxy
 from thunder.core.symbol import BoundSymbol
 from thunder.torch import _torch_to_thunder_function_map
 from thunder.core.langctxs import resolve_language, LanguageContext, Languages
-from thunder.executors.nvfuserex_impl import FusionDefinitionWrapper
 import torch
 from warnings import warn
 
@@ -219,9 +218,7 @@ def get_fusion_symbols(trace: TraceCtx, warn_if_fusions_unavailable: bool = True
     return fusions
 
 
-def get_nvfuser_fusion_definition(
-    trace: TraceCtx, name: str, warn_if_fusion_unavailable: bool = True
-) -> FusionDefinitionWrapper | None:
+def get_nvfuser_fusion_definition(trace: TraceCtx, name: str, warn_if_fusion_unavailable: bool = True):
     """
     Return the fusion definition for the symbol with the provided name if found.
     """

--- a/thunder/examine/__init__.py
+++ b/thunder/examine/__init__.py
@@ -227,7 +227,9 @@ def get_nvFuser_repro(trace: TraceCtx, fusion_name: str, /) -> str:
         assert False, f"Unable to find fusion '{fusion_name}' in trace. Available fusions are: {available_fusions}."
 
     if fusion.last_used is None:
-        assert False, "Fusion definition needs to be executed to record the inputs. You must execute the trace first before querying the repro."
+        assert (
+            False
+        ), "Fusion definition needs to be executed to record the inputs. You must execute the trace first before querying the repro."
 
     msg = ""
     msg += (

--- a/thunder/examine/__init__.py
+++ b/thunder/examine/__init__.py
@@ -243,10 +243,14 @@ def get_nvfuser_repro(trace: TraceCtx, fusion_name: str, /) -> str:
         raise RuntimeError(f"Unable to find fusion '{fusion_name}' in trace.")
 
     if fusion.last_used is None:
-        raise RuntimeError("Fusion definition needs to be executed to record the inputs. You must execute the fusion first before you can query the repro.")
+        raise RuntimeError(
+            "Fusion definition needs to be executed to record the inputs. You must execute the fusion first before you can query the repro."
+        )
 
     if fusion.last_inputs is None:
-        raise RuntimeError("Fusion definition inputs need to be recorded. Use compile option 'nv_store_fusion_inputs=True' while tracing.")
+        raise RuntimeError(
+            "Fusion definition inputs need to be recorded. Use compile option 'nv_store_fusion_inputs=True' while tracing."
+        )
 
     fd = fusion.last_used
     return fd.getReproString(fusion.last_inputs)

--- a/thunder/examine/__init__.py
+++ b/thunder/examine/__init__.py
@@ -226,6 +226,9 @@ def get_nvFuser_repro(trace: TraceCtx, fusion_name: str, /) -> str:
         available_fusions = [name for name, _ in get_fusions(trace)]
         assert False, f"Unable to find fusion '{fusion_name}' in trace. Available fusions are: {available_fusions}."
 
+    if fusion.last_used is None:
+        assert False, "Fusion definition needs to be executed to record the inputs. You must execute the trace first before querying the repro."
+
     msg = ""
     msg += (
         "import torch\nfrom nvfuser import FusionDefinition, DataType\n"

--- a/thunder/examine/__init__.py
+++ b/thunder/examine/__init__.py
@@ -218,6 +218,24 @@ def get_fusion_symbols(trace: TraceCtx, warn_if_fusions_unavailable: bool = True
     return fusions
 
 
+def get_nvfuser_fusion_definition(
+    trace: TraceCtx, name: str, warn_if_fusion_unavailable: bool = True
+) -> FusionDefinitionWrapper | None:
+    """
+    Return the fusion definition for the symbol with the provided name if found.
+    """
+    if warn_if_fusion_unavailable and warn_fusions():
+        return None
+
+    for bsym in trace.bound_symbols:
+        if bsym.sym.is_fusion and bsym.sym.name == name:
+            _, fusion_ctx, _ = bsym.gather_ctxs()
+            if (fusion_definition := fusion_ctx.get(name, None)) is not None:
+                return fusion_definition
+
+    return None
+
+
 def get_nvfuser_repro(trace: TraceCtx, fusion_name: str, /) -> str:
     """
     Helper function to get the repro of a specific nvFusion segment.

--- a/thunder/examine/__init__.py
+++ b/thunder/examine/__init__.py
@@ -253,4 +253,8 @@ def get_nvfuser_repro(trace: TraceCtx, fusion_name: str, /) -> str:
         )
 
     fd = fusion.last_used
-    return fd.getReproString(fusion.last_inputs)
+    get_repro = getattr(fd, "getReproString", None)
+    if get_repro is None:
+        raise RuntimeError("The installed version of nvFuser does not support repro generation unless on crash.")
+
+    return get_repro(fusion.last_inputs)

--- a/thunder/examine/__init__.py
+++ b/thunder/examine/__init__.py
@@ -9,6 +9,7 @@ from thunder.core.proxies import TensorProxy
 from thunder.core.symbol import BoundSymbol
 from thunder.torch import _torch_to_thunder_function_map
 from thunder.core.langctxs import resolve_language, LanguageContext, Languages
+from thunder.executors.nvfuserex_impl import FusionDefinitionWrapper
 import torch
 from warnings import warn
 

--- a/thunder/examine/__init__.py
+++ b/thunder/examine/__init__.py
@@ -218,7 +218,7 @@ def get_fusion_symbols(trace: TraceCtx, warn_if_fusions_unavailable: bool = True
     return fusions
 
 
-def get_nvFuser_repro(trace: TraceCtx, fusion_name: str, /) -> str:
+def get_nvfuser_repro(trace: TraceCtx, fusion_name: str, /) -> str:
     """
     Helper function to get the repro of a specific nvFusion segment.
     """

--- a/thunder/examine/__init__.py
+++ b/thunder/examine/__init__.py
@@ -240,17 +240,13 @@ def get_nvfuser_repro(trace: TraceCtx, fusion_name: str, /) -> str:
     """
     fusion = get_nvfuser_fusion_definition(trace, fusion_name)
     if fusion is None:
-        assert False, f"Unable to find fusion '{fusion_name}' in trace."
+        raise RuntimeError(f"Unable to find fusion '{fusion_name}' in trace.")
 
     if fusion.last_used is None:
-        assert (
-            False
-        ), "Fusion definition needs to be executed to record the inputs. You must execute the fusion first before you can query the repro."
+        raise RuntimeError("Fusion definition needs to be executed to record the inputs. You must execute the fusion first before you can query the repro.")
 
     if fusion.last_inputs is None:
-        assert (
-            False
-        ), "Fusion definition inputs need to be recorded. Use compile option 'nv_store_fusion_inputs=True' while tracing."
+        raise RuntimeError("Fusion definition inputs need to be recorded. Use compile option 'nv_store_fusion_inputs=True' while tracing.")
 
     fd = fusion.last_used
     return fd.getReproString(fusion.last_inputs)

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -398,31 +398,6 @@ class FusionDefinitionWrapper:
     def __repr__(self):
         return f"FusionDefinitionWrapper({self.name})"
 
-    def last_inputs(self) -> str:
-        msg = "inputs = [\n"
-        for size, stride, dtype, device in self.last_inputs_meta:
-            # max linear index determines number of elements to generate
-            sz = 1
-            for szi, stri in zip(size, stride):
-                if szi == 0:
-                    sz = 0
-                    break
-                sz += (szi - 1) * stri
-            if dtype.is_floating_point:
-                msg += (
-                    f"    torch.randn(({sz},), dtype={dtype}, device='{device}')"
-                    f".as_strided({tuple(size)}, {tuple(stride)}),\n"
-                )
-            else:
-                upper_bound = 2 if dtype == torch.bool else 10
-                msg += (
-                    f"    torch.randint(0, {upper_bound}, ({sz},), dtype={dtype}, device='{device}')"
-                    f".as_strided({tuple(size())}, {tuple(stride())}),\n"
-                )
-        msg += "]"
-
-        return msg
-
 
 # Group bookend meta operations into separate regions
 # This function returns a List[Region] which changes the executor of meta regions to torchex

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -484,7 +484,9 @@ def create_fusion_definition_wrapper(
     #   objects is captured by names in the trace.
     # These properties are distinct from the inputs and outputs to the trace itself, which
     #   may contain duplicates and whose order must be preserved.
-    store_inputs: None | bool = get_compile_option("nv_store_fusion_inputs", "Enable nvFuser store fusion inputs for repro.")
+    store_inputs: None | bool = get_compile_option(
+        "nv_store_fusion_inputs", "Enable nvFuser store fusion inputs for repro."
+    )
 
     tensor_indices = []
     for idx, x in enumerate(sorted_unique_inputs):

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -485,7 +485,7 @@ def create_fusion_definition_wrapper(
     # These properties are distinct from the inputs and outputs to the trace itself, which
     #   may contain duplicates and whose order must be preserved.
     store_inputs: None | bool = get_compile_option(
-        "nv_store_fusion_inputs", "Enable nvFuser store fusion inputs for repro."
+        "nv_store_fusion_inputs", "Allow nvFuser to store fusion inputs for repro."
     )
 
     tensor_indices = []

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -383,12 +383,15 @@ class FusionDefinitionWrapper:
     cache_info: None | Callable = None
     cache_clear: None | Callable = None
     last_used: None | FusionDefinition = None
-    last_inputs_meta: None | Sequence[tuple] = None
+    last_inputs: None | Sequence[tuple] = None
+    store_inputs: bool = False
 
     def __call__(self, *args):
         fd = self.get_fd(to_descriptors(args))
         self.last_used = fd
-        self.last_inputs_meta = [(i.size(), i.stride(), i.dtype, i.device) for i in args if isinstance(i, torch.Tensor)]
+
+        if self.store_inputs:
+            self.last_inputs = args
 
         # Set device if set in one of the "factory" methods like full, iota, or uniform
         kwargs = {"device": fd._selected_device} if hasattr(fd, "_selected_device") else {}
@@ -481,6 +484,7 @@ def create_fusion_definition_wrapper(
     #   objects is captured by names in the trace.
     # These properties are distinct from the inputs and outputs to the trace itself, which
     #   may contain duplicates and whose order must be preserved.
+    store_inputs: None | bool = get_compile_option("nv_store_fusion_inputs", "Enable nvFuser store fusion inputs for repro.")
 
     tensor_indices = []
     for idx, x in enumerate(sorted_unique_inputs):
@@ -495,7 +499,7 @@ def create_fusion_definition_wrapper(
         # A closure over local trace and region
         return create_fd(bsyms, input_descriptors, sorted_unique_inputs, sorted_unique_outputs)
 
-    fdw = FusionDefinitionWrapper(get_fd, name, get_fd.cache_info, get_fd.cache_clear)
+    fdw = FusionDefinitionWrapper(get_fd, name, get_fd.cache_info, get_fd.cache_clear, store_inputs=store_inputs)
     return fdw
 
 

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -424,7 +424,6 @@ class FusionDefinitionWrapper:
         return msg
 
 
-
 # Group bookend meta operations into separate regions
 # This function returns a List[Region] which changes the executor of meta regions to torchex
 #


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

From discussions in #387 and #783, this PR adds two helper functions:
- One to print a repro script for a specific nvFuser segment; and
- Another to get a fusion definition from the trace(avoids manually querying the context).

I also added a small section in the documentation to explain the usage of the helper function.

Also in this PR an update to the DebugTransform such that it is possible to debug symbols before and after any interesting section of the trace. I don't really like that transform since it's an hack but for now it does the job. I think in the future we should consider adding a debug prim to intercept inputs and add information to a trace.

## Usage:
As described in the documentation to use this feature you need two things:

1. Add the `nv_store_fusion_inputs=True` compile option; and
2. Call `get_nvfuser_repro` with the trace and the name of the fusion you want to see the repro of.

Note: ~This PR depends on nvFuser PR [#2732](https://github.com/NVIDIA/Fuser/pull/2732). Hence I will convert this PR to not a draft when that one passes.~ MERGED!
