### PR TITLE
improve fusion stability

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,6 +3,6 @@ looseversion ==1.3.0
 lightning-utilities >=0.7.0
 numpy >=1.23.0,<2  # not yet ready for numpy 2
 igraph >=0.10.4
-optree >=0.9.2
+optree >=0.11.0
 opt_einsum >= 3.3.0
 mpmath <1.4.0  # todo: teporarl pin for `NameError: name '_C' is not defined`

--- a/thunder/core/pytree.py
+++ b/thunder/core/pytree.py
@@ -57,6 +57,8 @@ def tree_flatten(args, namespace=""):
 # while generating the split functions.
 tree_map = partial(optree.tree_map, none_is_leaf=True, namespace=OPTREE_NAMESPACE)
 
+tree_iter = partial(optree.tree_iter, none_is_leaf=True, namespace=OPTREE_NAMESPACE)
+
 
 def tree_unflatten(values, spec):
     return optree.tree_unflatten(spec, values)

--- a/thunder/core/utils.py
+++ b/thunder/core/utils.py
@@ -733,6 +733,9 @@ class _OrderedSet(Generic[T, T1], Iterable[T]):
         if c in self.d:
             del self.d[c]
 
+    def issubset(self, other):
+        return all((e in other) for e in self)
+
     def union(self, *others: "Sequence[_OrderedSet]") -> Self:
         return self.__class__(itertools.chain(self, *others))
 

--- a/thunder/core/utils.py
+++ b/thunder/core/utils.py
@@ -728,6 +728,14 @@ class _OrderedSet(Generic[T, T1], Iterable[T]):
     def add(self, x: T | T1):
         self.d[self.canonicalize(x)] = None
 
+    def discard(self, x: T | T1):
+        c = self.canonicalize(x)
+        if c in self.d:
+            del self.d[c]
+
+    def union(self, *others: "Sequence[_OrderedSet]") -> Self:
+        return self.__class__(itertools.chain(self, *others))
+
     def update(self, x: Iterable[T | T1]) -> None:
         for i in x:
             self.d.setdefault(self.canonicalize(i), None)

--- a/thunder/executors/cudagraphex.py
+++ b/thunder/executors/cudagraphex.py
@@ -135,8 +135,8 @@ class CUDAGraphExecutor(FusionExecutor):
         super().__init__(name, version=torch.version.cuda)
 
     def fuse(self, region: Region, fusion_counter: int, num_static_inputs: None | int = None) -> BoundSymbol:
-        inputs = [unvariableify(inp) for inp in sorted(region.inputs, key=lambda var: var.proxy.name)]
-        outputs = [unvariableify(out) for out in sorted(region.outputs, key=lambda var: var.proxy.name)]
+        inputs = [unvariableify(inp) for inp in region.inputs]
+        outputs = [unvariableify(out) for out in region.outputs]
 
         fusion_name = f"CUDAGraph{fusion_counter}"
         fusion_callable: Callable = make_callable(f"{fusion_name}_fn", region.bound_symbols, inputs, outputs)

--- a/thunder/executors/data_dependent_partition.py
+++ b/thunder/executors/data_dependent_partition.py
@@ -24,8 +24,8 @@ class Node:
         self.stop = stop
         self.group_bsyms = group_bsyms
         self.group_indices = group_indices
-        self.parents: set[Node] = set()
-        self.children: set[Node] = set()
+        self.parents: utils.OrderedSet[Node] = utils.OrderedSet()
+        self.children: utils.OrderedSet[Node] = utils.OrderedSet()
 
     def __repr__(self) -> str:
         s = f"node ID {self.ID} : "

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -611,11 +611,8 @@ class nvFuserExecutor(FusionExecutor):
         return list(filter(lambda x: x.sym != prims.python_return, trace.bound_symbols))
 
     def fuse(self, region: Region, fusion_counter: int) -> BoundSymbol:
-        def keyfn(x: Variable) -> str:
-            return x.proxy.name
-
-        sorted_unique_inputs: list[Proxy] = list(unvariableify(x) for x in sorted(region.inputs, key=keyfn))
-        sorted_unique_outputs: list[Proxy] = list(unvariableify(x) for x in sorted(region.outputs, key=keyfn))
+        sorted_unique_inputs: list[Proxy] = [unvariableify(x) for x in region.inputs]
+        sorted_unique_outputs: list[Proxy] = [unvariableify(x) for x in region.outputs]
 
         flattened_bsyms: list[BoundSymbol] = []
         for bsym in region.bound_symbols:

--- a/thunder/executors/torch_compile.py
+++ b/thunder/executors/torch_compile.py
@@ -119,8 +119,8 @@ class TorchCompileExecutor(FusionExecutor):
         def keyfn(x: Variable) -> str:
             return x.proxy.name
 
-        sorted_unique_inputs: list[Proxy] = list(unvariableify(x) for x in sorted(region.inputs, key=keyfn))
-        sorted_unique_outputs: list[Proxy] = list(unvariableify(x) for x in sorted(region.outputs, key=keyfn))
+        sorted_unique_inputs: list[Proxy] = [unvariableify(x) for x in region.inputs]
+        sorted_unique_outputs: list[Proxy] = [unvariableify(x) for x in region.outputs]
 
         compiled: Callable = make_compiled(region.bound_symbols, sorted_unique_inputs, sorted_unique_outputs)
 

--- a/thunder/tests/test_core.py
+++ b/thunder/tests/test_core.py
@@ -3096,7 +3096,7 @@ def test_bound_symbol_sort_stability():
 
     fusions = examine.get_fusion_symbols(lt)
 
-    no_number = partial(re.sub, "nvFusion\d+", "nvFusion")
+    no_number = partial(re.sub, r"nvFusion\d+", "nvFusion")
     fusions = [no_number(str(thunder.core.transform_common.canonicalize_proxies([f])[0])) for f in fusions]
 
     f0 = fusions[0]

--- a/thunder/tests/test_core.py
+++ b/thunder/tests/test_core.py
@@ -3,6 +3,7 @@ import traceback
 from functools import partial, reduce
 from itertools import product
 import dataclasses
+import re
 
 import pytest
 import torch
@@ -3092,3 +3093,12 @@ def test_bound_symbol_sort_stability():
             ]
         )
     )
+
+    fusions = examine.get_fusion_symbols(lt)
+
+    no_number = partial(re.sub, "nvFusion\d+", "nvFusion")
+    fusions = [no_number(str(thunder.core.transform_common.canonicalize_proxies([f])[0])) for f in fusions]
+
+    f0 = fusions[0]
+    for f in fusions[1:]:
+        assert f0 == f

--- a/thunder/tests/test_nvfuser.py
+++ b/thunder/tests/test_nvfuser.py
@@ -200,9 +200,9 @@ def test_redundant_cast_nvfusion(executor, device: str, dtype: dtypes.dtype):
     assert len(fusions) == 2
 
     # Verifies that the nvFusion inputs and outputs are updated properly
-    t0 = fusions[0].output
-    assert fusions[1].args[0].name == "t0"
-    assert t0[0].name == "t0"
+    t0 = fusions[0].output[0]
+    assert fusions[1].args[2].name == "t0"
+    assert t0.name == "t0"
     assert extrace.output[0].name == "t0"
     assert len(fusions[0].subsymbols) == 3
 
@@ -316,7 +316,7 @@ def test_cse_subsymbol_redundant_args(executor, device, _):
     assert len(fusion_bsyms) == 1
     nvf_0 = fusion_bsyms[0]
 
-    assert [t.name for t in tree_flatten(nvf_0.args)[0]] == ["t0", "w", "z"]
+    assert [t.name for t in tree_flatten(nvf_0.args)[0]] == ["t0", "z", "w"]
     assert len(nvf_0.subsymbols) == 7
     assert [t.name for t in tree_flatten(nvf_0.output)[0]] == ["t13"]
 


### PR DESCRIPTION
This stabilizes fusion things orderings (bsyms and args), which is useful for having similar blocks produce similar graph sections even after transform for execution.
Closes #898  
