### PR TITLE
fix - prims.reshape implementation with torchex

### DIFF
--- a/thunder/examine/memory_caculation.py
+++ b/thunder/examine/memory_caculation.py
@@ -17,6 +17,7 @@ thunder_alias_operator_list = (
     "transpose",
     "expand",
     "reshape",
+    "torch_prims_reshape_impl",  # torchex implementation of prims.reshape.
     "permute",
     "contiguous",
     "torch_wait_prim_impl",

--- a/thunder/executors/passes.py
+++ b/thunder/executors/passes.py
@@ -26,6 +26,11 @@ comment_symbols = {prims.PrimIDs.COMMENT, prims.PrimIDs.UNPACK_TRIVIAL}
 
 
 # Transforms a trace by determining which execution transforms to call given the list of executors in priority order
+# This pass tries to preserve the original trace and proxies.
+# Implementation Steps -
+# 1. The trace is updated with `visitor_transform` with `visit_helper_` (where executors try to claim the symbols). Note that this replaces the output proxies in the trace.
+# 2. `visit_helper_` also creates a swapmap from the new symbols back to old one.
+# 3. After the `visitor_transform`, it iterates over the updated trace and puts back the old proxies.
 def _transform_for_operator_executor_execution(trace: TraceCtx, executors_list: Sequence[Executor]) -> TraceCtx:
     start_time_ns = time.perf_counter_ns()
 

--- a/thunder/executors/torchex.py
+++ b/thunder/executors/torchex.py
@@ -577,7 +577,11 @@ _register_implementation(
 )
 _register_implementation(prims.cat, cat, checker=_always_executable)
 _register_implementation(prims.flip, flip, checker=_always_executable)
-_register_implementation(prims.reshape, reshape, checker=_always_executable)
+# NOTE - `ltorch.reshape` short circuits when new shape is same as original shape and returns the input proxy as output.
+#        `prims.reshape` doesn't do that and returns a new proxy. So we add `torch_prims_reshape_impl` which is consistent
+#        with `prims.reshape` semantics otherwise this can lead incorrectness.
+torch_prims_reshape_impl = ex.register_operator("torch_prims_reshape_impl", meta=prims.reshape.meta, fn=torch.reshape)
+_register_implementation(prims.reshape, torch_prims_reshape_impl, checker=_always_executable)
 slice_prim_impl = ex.register_operator("torch_slice_prim_impl", meta=prims.slice_prim.meta, fn=_slice_prim_impl)
 _register_implementation(prims.slice_prim, slice_prim_impl, checker=_always_executable)
 _register_implementation(prims.squeeze, checker=_always_executable, execution_transform=_squeeze_transform)

--- a/thunder/tests/test_core.py
+++ b/thunder/tests/test_core.py
@@ -3062,14 +3062,17 @@ def test_cat_mixed_dtypes():
     torch.testing.assert_close(tuple(t.grad for t in tensors), tuple(t.grad for t in tensors_jit))
 
 
-def test_reshape_noop_prims():
-
+@pytest.mark.parametrize("requires_grad", [True, False])
+def test_reshape_noop_prims(requires_grad):
+    # NOTE - We test for requires_grad with True and False,
+    #        as the trace before execution may have `ltorch.reshape` (for requires_grad=False) or
+    #        `prims.reshape` (for requires_grad=True) as the `grad` rule is only defined for `prims.reshape`.
     def fn(x: torch.Tensor, y: torch.Tensor):
-        x_view = x.view(-1, 5)
-        y_view = y.view(-1)
+        x_view = x.reshape(-1, 5)
+        y_view = y.reshape(-1)
         return x_view + 3, y_view + 2
 
-    t = torch.randn(8, 5, requires_grad=True)
+    t = torch.randn(8, 5, requires_grad=requires_grad)
     labels = torch.tensor([2, 4, 2, 3, 1, 0, 4, 4])
 
     jfn = thunder.jit(fn)

--- a/thunder/tests/test_core.py
+++ b/thunder/tests/test_core.py
@@ -3060,3 +3060,20 @@ def test_cat_mixed_dtypes():
     actual.backward(cotangent)
 
     torch.testing.assert_close(tuple(t.grad for t in tensors), tuple(t.grad for t in tensors_jit))
+
+
+def test_reshape_noop_prims():
+
+    def fn(x: torch.Tensor, y: torch.Tensor):
+        x_view = x.view(-1, 5)
+        y_view = y.view(-1)
+        return x_view + 3, y_view + 2
+
+    t = torch.randn(8, 5, requires_grad=True)
+    labels = torch.tensor([2, 4, 2, 3, 1, 0, 4, 4])
+
+    jfn = thunder.jit(fn)
+    actual = jfn(t, labels)
+    expected = fn(t, labels)
+
+    torch.testing.assert_close(actual, expected)


### PR DESCRIPTION
Fixes https://github.com/Lightning-AI/lightning-thunder/issues/864

The issue here was that there was a discrepancy between the `torch.reshape` (which uses `ltorch.reshape` for meta) implementation and the semantics of `prims.reshape`.

`ltorch.reshape` short-circuits if the `reshape` is a no-op when same shape as input is provided. (`ltorch.reshape` is implemented with `clang.reshape`)
https://github.com/Lightning-AI/lightning-thunder/blob/67ec2c6f4e72f6215f12941bf161915f8f458181/thunder/clang/__init__.py#L1043-L1051

However, `prims.reshape` always returns a new TensorProxy

https://github.com/Lightning-AI/lightning-thunder/blob/67ec2c6f4e72f6215f12941bf161915f8f458181/thunder/core/prims.py#L3098-L3112

This difference in behaviour leads to incorrect values being swapped as output in `transform_for_execution` leading to failures.

------
**NOTE** - I was planning to add a check to `__transform_for_operator_executor_execution` to verify that all inputs proxies to the trace have a consumer but I found that this is not necessarily true (we have a test case for a function where nothing is returned)

https://github.com/Lightning-AI/lightning-thunder/blob/fa307a5656d2b7000a07a489f3d434aa7ba8cfd6/thunder/tests/test_core.py#L303-L306