### PR TITLE
Trace cleanup, nvfuser version warning

### DIFF
--- a/thunder/core/baseutils.py
+++ b/thunder/core/baseutils.py
@@ -456,7 +456,7 @@ def build_callable(fn_name: str, python_str: str, file_name: str, ctx: dict) -> 
     try:
         code: CodeType = compile(python_str, program_name, mode="exec")
         exec(code, ctx)
-        _callable: Callable = ctx[fn_name] # Grab from globals()
+        _callable: Callable = ctx[fn_name]  # Grab from globals()
         return _callable
     except Exception as e:
         print("Encountered an exception while trying to compile the following program:")

--- a/thunder/core/baseutils.py
+++ b/thunder/core/baseutils.py
@@ -442,10 +442,10 @@ def print_base_printable(x: Any, /) -> str:
 _exec_ctr = 0
 
 
-def compile_and_exec(fn_name: str, python_str: str, program_name: str, ctx: dict) -> Callable:
+def build_callable(fn_name: str, python_str: str, file_name: str, ctx: dict) -> Callable:
     global _exec_ctr
 
-    program_name = f"{program_name}_{_exec_ctr}"
+    program_name = f"{file_name}_{_exec_ctr}"
 
     # simple cache hack
     mtime = None  # this signals that the cache should not be invalidated(!)
@@ -454,9 +454,10 @@ def compile_and_exec(fn_name: str, python_str: str, program_name: str, ctx: dict
     inspect.linecache.cache[program_name] = size, mtime, lines, program_name
 
     try:
-        code = compile(python_str, program_name, mode="exec")
+        code: CodeType = compile(python_str, program_name, mode="exec")
         exec(code, ctx)
-        return ctx[fn_name]
+        _callable: Callable = ctx[fn_name] # Grab from globals()
+        return _callable
     except Exception as e:
         print("Encountered an exception while trying to compile the following program:")
         print(python_str)

--- a/thunder/core/trace.py
+++ b/thunder/core/trace.py
@@ -464,10 +464,9 @@ class TraceCtx:
         ctx["__function_obj"] = self.fn
         ctx["thunder"] = thunder
 
-        callable = baseutils.compile_and_exec(
-            self.siginfo().name, python_str=python_str, program_name=f"thunder.{self.siginfo().name}", ctx=ctx
+        return baseutils.build_callable(
+            self.siginfo().name, python_str=python_str, file_name=f"thunder.{self.siginfo().name}", ctx=ctx
         )
-        return callable
 
     def __repr__(self) -> str:
         return self.python(print_depth=-1)

--- a/thunder/executors/nvfuserex.py
+++ b/thunder/executors/nvfuserex.py
@@ -41,6 +41,7 @@ def nvfuser_available() -> bool:
     required = required_nvfuser_version()
     if v < required:
         import warnings
+
         msg = f"Your nvfuser installation is out of date. Thunder requires version {required}, but found version {v}."
         warnings.warn(msg)
         return False

--- a/thunder/executors/nvfuserex.py
+++ b/thunder/executors/nvfuserex.py
@@ -35,7 +35,16 @@ def required_nvfuser_version() -> LooseVersion:
 
 def nvfuser_available() -> bool:
     v = nvfuser_version()
-    return v is not None and v >= required_nvfuser_version()
+    if v is None:
+        return False
+
+    required = required_nvfuser_version()
+    if v < required:
+        import warnings
+        msg = f"Your nvfuser installation is out of date. Thunder requires version {required}, but found version {v}."
+        warnings.warn(msg)
+        return False
+    return True
 
 
 nvfuserex: None | FusionExecutor = None

--- a/thunder/extend/__init__.py
+++ b/thunder/extend/__init__.py
@@ -458,7 +458,6 @@ def resolve_executors(executors: None | Sequence[Executor | str]) -> tuple[Execu
                 continue
             else:
                 resolved_executors.append(ex)
-        elif e is None:
             raise ValueError(f"The executor list cannot contain None. Executor list: {executors}")
         elif not isinstance(e, Executor):
             raise ValueError(f"An object of type {type(e)} is not a valid Executor. Executor list: {executors}")

--- a/thunder/extend/__init__.py
+++ b/thunder/extend/__init__.py
@@ -460,6 +460,8 @@ def resolve_executors(executors: None | Sequence[Executor | str]) -> tuple[Execu
                 resolved_executors.append(ex)
         elif e is None:
             raise ValueError(f"The executor list cannot contain None. Executor list: {executors}")
+        elif not isinstance(e, Executor):
+            raise ValueError(f"An object of type {type(e)} is not a valid Executor. Executor list: {executors}")
         else:
             resolved_executors.append(e)
 

--- a/thunder/extend/__init__.py
+++ b/thunder/extend/__init__.py
@@ -458,6 +458,8 @@ def resolve_executors(executors: None | Sequence[Executor | str]) -> tuple[Execu
                 continue
             else:
                 resolved_executors.append(ex)
+        elif e is None:
+            raise ValueError(f"The executor list cannot contain None. Executor list: {executors}")
         else:
             resolved_executors.append(e)
 

--- a/thunder/extend/__init__.py
+++ b/thunder/extend/__init__.py
@@ -458,7 +458,6 @@ def resolve_executors(executors: None | Sequence[Executor | str]) -> tuple[Execu
                 continue
             else:
                 resolved_executors.append(ex)
-            raise ValueError(f"The executor list cannot contain None. Executor list: {executors}")
         elif not isinstance(e, Executor):
             raise ValueError(f"An object of type {type(e)} is not a valid Executor. Executor list: {executors}")
         else:


### PR DESCRIPTION
1. Rename `compile_and_exec()` to something more sensible (since it does not in fact execute the trace in the way you would think it does by the name)
2. Rename confusing variable names
3. Add warning for if nvfuser is out of date.
4. Better error message for if a member of the executor list is `None`. It's been debated for a while if None is a valid argument or not, but at the moment if you pass None you get an `AttributeError` on `ex._provenance`.