### PR TITLE
Added `LangctxImplWrapper` in place of `@wraps`.

### DIFF
--- a/thunder/core/langctxs.py
+++ b/thunder/core/langctxs.py
@@ -1,7 +1,7 @@
 from contextvars import ContextVar
 from typing import Optional, Any
 from collections.abc import Callable
-from functools import wraps, update_wrapper
+from functools import update_wrapper
 from contextlib import contextmanager
 from enum import Enum, auto
 


### PR DESCRIPTION
Moving towards a pickle-able `TraceCtx` object. They contain bound symbols, which contain symbols, which contain meta functions, which are wrapped in a language context with a function decorated with `@wraps`. But those wrappers are functions with nonlocal variables, so they keep a frame object alive, and that frame object contains a reference to `globals()`, which contains modules, which cannot be pickled. A problem.

So, to resolve this problem, I've created an object to hold the necessary information for the wrapper, without it keeping a frame object alive.

Next on the list is to tackle `sym.module`/`sym._module`. After that, `TraceCtx` objects should be pickleable.

