### PR TITLE
Do not reorder between copy_ and return statement

### DIFF
--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -818,19 +818,6 @@ instantiated) this heuristic actually leads to worse code.
                     fused_bsyms.extend(fusion.bound_symbols)
             fused_bsyms.extend(epilogue)
 
-        # Force return operator to be the last one in the fused_bsyms
-        if fused_bsyms[-1].sym.id != PrimIDs.RETURN:
-            return_idx: int = -1
-            for i, fused_bsym in enumerate(fused_bsyms):
-                if fused_bsym.sym.id == PrimIDs.RETURN:
-                    return_idx = i
-                    break
-            utils.check(
-                return_idx != -1,
-                lambda: f"Return operator does not exist in bound symbols",
-            )
-            fused_bsyms.append(fused_bsyms.pop(return_idx))
-
         fusedtrace.bound_symbols = fused_bsyms
 
         # Some of the operations might be better placed with its consumers (for

--- a/thunder/tests/framework.py
+++ b/thunder/tests/framework.py
@@ -135,6 +135,9 @@ def available_devicetypes():
 
 
 class TestExecutor:
+    def is_available(self) -> bool:
+        return True
+
     def supports_dtype(self, dtype: datatypes.dtype) -> bool:
         return dtype in datatypes.resolve_dtypes(self.supported_dtypes)
 
@@ -209,6 +212,9 @@ class TorchCompileCatTestExecutor(TestExecutor):
     supported_devicetypes = (devices.DeviceType.CPU, devices.DeviceType.CUDA)
     supported_dtypes = (datatypes.dtype,)
 
+    def is_available(self) -> bool:
+        return not IS_WINDOWS
+
     def executors_list(self) -> list[extend.Executor]:
         from thunder.executors.torch_compile import torch_compile_cat_ex
 
@@ -222,6 +228,9 @@ class TorchCompileTestExecutor(TestExecutor):
     name = "torchcompile"
     supported_devicetypes = (devices.DeviceType.CPU, devices.DeviceType.CUDA)
     supported_dtypes = (datatypes.dtype,)
+
+    def is_available(self) -> bool:
+        return not IS_WINDOWS
 
     def executors_list(self) -> list[extend.Executor]:
         from thunder.executors.torch_compile import torch_compile_ex
@@ -465,7 +474,7 @@ class instantiate:
         for executor, devicetype in product(
             sorted(self.executors, key=lambda x: repr(x)), sorted(self.devicetypes, key=lambda x: repr(x))
         ):
-            if executor is None:
+            if executor is None or not executor.is_available():
                 continue
 
             if not executor.supports_devicetype(devicetype):

--- a/thunder/tests/test_inplace_functionalization.py
+++ b/thunder/tests/test_inplace_functionalization.py
@@ -11,7 +11,15 @@ import thunder
 import thunder.core.devices as devices
 from thunder.core import dtypes
 from thunder.core.prims import PrimIDs
-from thunder.tests.framework import instantiate, ops, requiresCUDA, NOTHING, TorchExecutor, nvFuserExecutor
+from thunder.tests.framework import (
+    instantiate,
+    ops,
+    requiresCUDA,
+    NOTHING,
+    TorchExecutor,
+    TorchCompileExecutor,
+    nvFuserExecutor,
+)
 from thunder.tests.opinfos import opinfos, OpInfo, make_number, SampleInput
 from thunder.tests.make_tensor import make_tensor
 from thunder.torch import _torch_to_thunder_function_map, _inplace_to_out_of_place
@@ -451,6 +459,7 @@ def test_multiple_inplace_to_multiple_args(executor, device, _):
 
 @instantiate(
     dtypes=NOTHING,
+    executors=(TorchExecutor, TorchCompileExecutor, nvFuserExecutor),
 )
 def test_single_tensor_adam_like(executor, device, _):
 


### PR DESCRIPTION
## What does this PR do?

Fixes #912. Registers `COPY_` symbols before the return statement as its dependencies.