### PR TITLE
Set the default language context to be the torch language context

### DIFF
--- a/thunder/core/langctxs.py
+++ b/thunder/core/langctxs.py
@@ -52,9 +52,13 @@ def set_langctx(ctx: LanguageContext, /) -> Any:
 
 
 def get_langctx() -> LanguageContext:
-    """Gets the current language context"""
-    t = _langctx.get()
-    return t
+    """Gets the current language context (defaulting to the torch language)"""
+    # The default value is set here and not in the ContextVar constructor
+    # because the torch language context is not available at the time the
+    # ContextVar is created
+    # If get_langctx is called before the torch language context is registered,
+    # it will raise a LookupError
+    return _langctx.get(resolve_language(Languages.TORCH))
 
 
 def reset_langctx(token: Any, /) -> None:
@@ -94,7 +98,7 @@ def resolve_language(id: Any, /) -> LanguageContext:
     lang: None | LanguageContext = _langctx_registry.get(id, None)
 
     if lang is None:
-        raise ValueError(f"Unknown language context {id}")
+        raise LookupError(f"Unknown language context {id}")
 
     return lang
 

--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -586,16 +586,6 @@ def clear_grads(module: torch.nn.Module) -> None:
         b.grad = None
 
 
-from thunder.core.interpreter import make_opaque
-from thunder.core.langctxs import langctx, Languages
-
-
-# TODO RC1 Replace with langctx
-def torchctx(fn):
-    _fn = langctx(Languages.TORCH)(fn)
-    return make_opaque(_fn)
-
-
 _grad_fn_map: dict[Any, Callable] = {}
 
 
@@ -639,7 +629,6 @@ register_grad(pids.UNPACK_SEQUENCE, prims.unpack_sequence)
 #
 # Data movement and transformation operator grads
 #
-@torchctx
 def _convert_element_type_prim_grad(a: Number | TensorProxy, dtype: type | dtypes.dtype) -> Number | TensorProxy:
     fwd = prims.convert_element_type(a, dtype)
 
@@ -678,7 +667,6 @@ register_grad(pids.UNIFORM, _uniform_grad)
 #
 
 
-@torchctx
 def _broadcast_in_dim_prim_grad(
     a: TensorProxy, shape: Sequence[int], broadcast_dimensions: Sequence[int]
 ) -> TensorProxy:
@@ -707,7 +695,6 @@ def _broadcast_in_dim_prim_grad(
 register_grad(pids.BROADCAST_IN_DIM, _broadcast_in_dim_prim_grad)
 
 
-@torchctx
 def _cat_prim_grad(tensors: list[TensorProxy], /, dim: int) -> TensorProxy:
     fwd = prims.cat(tensors, dim)
 
@@ -742,7 +729,6 @@ def _reshape_prim_grad(a: TensorProxy, shape: tuple[int, ...]) -> TensorProxy:
 register_grad(pids.RESHAPE, _reshape_prim_grad)
 
 
-@torchctx
 def _slice_prim_grad(
     a: TensorProxy, start_indices: Sequence[int], end_indices: Sequence[int], strides: None | Sequence[int] = None
 ) -> TensorProxy:
@@ -772,7 +758,6 @@ def _slice_prim_grad(
 register_grad(pids.SLICE, _slice_prim_grad)
 
 
-@torchctx
 def _squeeze_prim_grad(a: TensorProxy, /, dims: tuple[int, ...]) -> TensorProxy:
     fwd = prims.squeeze(a, tuple(dims))
 
@@ -788,7 +773,6 @@ def _squeeze_prim_grad(a: TensorProxy, /, dims: tuple[int, ...]) -> TensorProxy:
 register_grad(pids.SQUEEZE, _squeeze_prim_grad)
 
 
-@torchctx
 def _take_prim_grad(a: TensorProxy, index: TensorProxy, dim: int) -> TensorProxy:
     fwd = prims.take(a, index, dim)
 
@@ -807,7 +791,6 @@ def _take_prim_grad(a: TensorProxy, index: TensorProxy, dim: int) -> TensorProxy
 register_grad(pids.TAKE, _take_prim_grad)
 
 
-@torchctx
 def _gather_prim_grad(a: TensorProxy, index: TensorProxy, dim: int) -> TensorProxy:
     fwd = prims.gather(a, index, dim)
 
@@ -824,7 +807,6 @@ def _gather_prim_grad(a: TensorProxy, index: TensorProxy, dim: int) -> TensorPro
 register_grad(pids.GATHER, _gather_prim_grad)
 
 
-@torchctx
 def _scatter_prim_grad(a: TensorProxy, /, index: TensorProxy, src: TensorProxy | Number, dim: int) -> TensorProxy:
     fwd = prims.scatter(a, index, src, dim)
 
@@ -846,7 +828,6 @@ def _scatter_prim_grad(a: TensorProxy, /, index: TensorProxy, src: TensorProxy |
 register_grad(pids.SCATTER, _scatter_prim_grad)
 
 
-@torchctx
 def _index_copy_grad(a: TensorProxy, /, index: TensorProxy, src: TensorProxy, dim: int) -> TensorProxy:
     fwd = prims.index_copy(a, index, src, dim)
 
@@ -876,7 +857,6 @@ def _index_copy_grad(a: TensorProxy, /, index: TensorProxy, src: TensorProxy, di
 register_grad(pids.INDEX_COPY, _index_copy_grad)
 
 
-@torchctx
 def _scatter_add_prim_grad(a: TensorProxy, /, index: TensorProxy, value: TensorProxy, dim: int) -> TensorProxy:
     utils.check(
         not value._requires_grad or value.shape == index.shape,
@@ -898,7 +878,6 @@ def _scatter_add_prim_grad(a: TensorProxy, /, index: TensorProxy, value: TensorP
 register_grad(pids.SCATTER_ADD, _scatter_add_prim_grad)
 
 
-@torchctx
 def _take_along_axis_prim_grad(a: TensorProxy, index: TensorProxy, dim: int) -> TensorProxy:
     fwd = prims.take_along_axis(a, index, dim)
 
@@ -915,7 +894,6 @@ def _take_along_axis_prim_grad(a: TensorProxy, index: TensorProxy, dim: int) -> 
 register_grad(pids.TAKE_ALONG_AXIS, _take_along_axis_prim_grad)
 
 
-@torchctx
 def _transpose_prim_grad(a: TensorProxy, permutation: tuple[int, ...]) -> TensorProxy:
     fwd = prims.transpose(a, tuple(permutation))
 
@@ -934,7 +912,6 @@ register_grad(pids.TRANSPOSE, _transpose_prim_grad)
 #
 
 
-@torchctx
 def _stride_order_prim_grad(a: TensorProxy, /, order: Sequence[int]) -> TensorProxy:
     fwd = prims.stride_order(a, order)
 
@@ -950,7 +927,6 @@ register_grad(pids.STRIDE_ORDER, _stride_order_prim_grad)
 #
 # Elementwise unary operator grads
 #
-@torchctx
 def _abs_prim_grad(a: Number | TensorProxy) -> Number | TensorProxy:
     fwd = prims.abs(a)
 
@@ -975,7 +951,6 @@ def _cos_prim_grad(a: Number | TensorProxy) -> Number | TensorProxy:
 register_grad(pids.COS, _cos_prim_grad)
 
 
-@torchctx
 def _erf_prim_grad(a: Number | TensorProxy) -> Number | TensorProxy:
     fwd = prims.erf(a)
 
@@ -989,7 +964,6 @@ def _erf_prim_grad(a: Number | TensorProxy) -> Number | TensorProxy:
 register_grad(pids.ERF, _erf_prim_grad)
 
 
-@torchctx
 def _exp_prim_grad(a: Number | TensorProxy) -> Number | TensorProxy:
     fwd = prims.exp(a)
 
@@ -1003,7 +977,6 @@ def _exp_prim_grad(a: Number | TensorProxy) -> Number | TensorProxy:
 register_grad(pids.EXP, _exp_prim_grad)
 
 
-@torchctx
 def _log_prim_grad(a: Number | TensorProxy) -> Number | TensorProxy:
     fwd = prims.log(a)
 
@@ -1017,7 +990,6 @@ def _log_prim_grad(a: Number | TensorProxy) -> Number | TensorProxy:
 register_grad(pids.LOG, _log_prim_grad)
 
 
-@torchctx
 def _neg_prim_grad(a: Number | TensorProxy) -> Number | TensorProxy:
     fwd = prims.neg(a)
 
@@ -1030,7 +1002,6 @@ def _neg_prim_grad(a: Number | TensorProxy) -> Number | TensorProxy:
 register_grad(pids.NEG, _neg_prim_grad)
 
 
-@torchctx
 def _rsqrt_prim_grad(a: Number | TensorProxy, /) -> Number | TensorProxy:
     fwd = prims.rsqrt(a)
 
@@ -1059,7 +1030,6 @@ def _sin_prim_grad(a: Number | TensorProxy) -> Number | TensorProxy:
 register_grad(pids.SIN, _sin_prim_grad)
 
 
-@torchctx
 def _tanh_prim_grad(a: Number | TensorProxy, /) -> Number | TensorProxy:
     fwd = prims.tanh(a)
 
@@ -1077,7 +1047,6 @@ register_grad(pids.TANH, _tanh_prim_grad)
 #
 
 
-@torchctx
 def _add_prim_grad(a: Number | TensorProxy, b: Number | TensorProxy, /) -> Number | TensorProxy:
     fwd = a + b
 
@@ -1094,7 +1063,6 @@ register_grad(pids.ADD, _add_prim_grad)
 
 # NOTE The following grad definition relies on the fact that only inexact dtypes are differentiable,
 #   and torch's true division operator and the division primitive agree on those types
-@torchctx
 def _div_prim_grad(a: Number | TensorProxy, b: Number | TensorProxy, /) -> Number | TensorProxy:
     fwd = a / b
 
@@ -1117,7 +1085,6 @@ register_grad(pids.LE, prims.le)
 register_grad(pids.LT, prims.lt)
 
 
-@torchctx
 def _mul_prim_grad(a: Number | TensorProxy, b: Number | TensorProxy, /) -> Number | TensorProxy:
     fwd = a * b
 
@@ -1132,7 +1099,6 @@ def _mul_prim_grad(a: Number | TensorProxy, b: Number | TensorProxy, /) -> Numbe
 register_grad(pids.MUL, _mul_prim_grad)
 
 
-@torchctx
 def _sub_prim_grad(a: Number | TensorProxy, b: Number | TensorProxy) -> Number | TensorProxy:
     fwd = a - b
 
@@ -1197,7 +1163,6 @@ def _sum_prim_grad(a: TensorProxy, /, dims: Sequence[int]) -> TensorProxy:
 register_grad(pids.SUM, _sum_prim_grad)
 
 
-@torchctx
 def _topk_prim_grad(
     a: TensorProxy, /, k: int, dim: None | int = None, largest: bool = True, sorted: bool = True, *, out=None
 ):
@@ -1218,7 +1183,6 @@ def _topk_prim_grad(
 register_grad(pids.TOPK, _topk_prim_grad)
 
 
-@torchctx
 def _sort_prim_grad(
     a: TensorProxy, /, dim: None | int = None, descending: bool = False, stable: bool = False, *, out=None
 ) -> (TensorProxy, TensorProxy):
@@ -1245,7 +1209,6 @@ register_grad(pids.SORT, _sort_prim_grad)
 # TODO Fix division by zero when n_elem_reduced == 0 or when mean.numel == 0
 #   by returning zeros_like(a) or similar.
 # TODO Fix grad when correction > n_elem_reduced.
-@torchctx
 def _var_mean_prim_grad(a: TensorProxy, /, dims: Sequence[int], *, correction: Number) -> TensorProxy:
     v, m = prims.var_mean(a, dims, correction=correction)
 
@@ -1279,7 +1242,6 @@ register_grad(pids.VAR_MEAN, _var_mean_prim_grad)
 #
 # Linear algebra operator grads
 #
-@torchctx
 def _linear_prim_grad(a: TensorProxy, w: TensorProxy, bias: None | TensorProxy) -> TensorProxy:
     fwd = prims.linear(a, w, bias)
 
@@ -1311,7 +1273,6 @@ register_grad(pids.LINEAR, _linear_prim_grad)
 
 # TODO Add explicit ltorch vs clang module to the tensor operations below
 # TODO could we get rid of the final squeezes in the b.ndim == 1 case and the a.ndim == 1 case?
-@torchctx
 def _matmul_prim_grad(a: TensorProxy, b: TensorProxy, /) -> TensorProxy:
     fwd = prims.matmul(a, b)
     g = get_grad(fwd)
@@ -1346,7 +1307,6 @@ register_grad(pids.MATMUL, _matmul_prim_grad)
 #
 
 
-@torchctx
 def _embedding_prim_grad(
     a: TensorProxy, /, weight, *, padding_idx=-1, max_norm=None, norm_type=2.0, scale_grad_by_freq=False, sparse=False
 ) -> TensorProxy:

--- a/thunder/executors/cudnnex.py
+++ b/thunder/executors/cudnnex.py
@@ -75,7 +75,6 @@ from dataclasses import dataclass
 from functools import lru_cache
 from typing import Union, Dict
 
-from thunder.core.langctxs import langctx
 import thunder.core.dtypes as dtypes
 from thunder.torch import TensorLike
 from thunder.core.compile_data import get_compile_option
@@ -725,7 +724,6 @@ cudnn_sdpa_bwd = cudnn_ex.register_operator(
 )
 
 
-@langctx("torch")
 def _cudnn_sdpa_fwd_wrapper(
     query: TensorProxy,
     key: TensorProxy,
@@ -741,7 +739,6 @@ def _cudnn_sdpa_fwd_wrapper(
     return output
 
 
-@langctx("torch")
 def _cudnn_sdpa_bwd_wrapper(
     query: TensorProxy,
     key: TensorProxy,

--- a/thunder/executors/torchex.py
+++ b/thunder/executors/torchex.py
@@ -18,7 +18,6 @@ import torch
 import math
 from looseversion import LooseVersion
 
-from thunder.core.langctxs import langctx, Languages
 import thunder.core.dtypes as dtypes
 from thunder.core.dtypes import to_torch_dtype, to_dtype
 import thunder.core.devices as devices
@@ -1234,12 +1233,10 @@ def _index_put_prim_transform(
     return index_put(a, indices, values, accumulate)
 
 
-@langctx(Languages.TORCH)
 def _gather_prim_transform(a: TensorProxy, /, index: TensorProxy, dim: int) -> TensorProxy:
     return gather(a, dim, index)
 
 
-@langctx(Languages.TORCH)
 def _gather_transform(a: TensorLike, /, dim: int, index: TensorLike) -> TensorLike:
     return gather(a, dim, index)
 
@@ -1275,9 +1272,6 @@ def _scatter_transform(
 
 # NOTE torch.compile has a compilation issue with scatter add in bfloat16,
 #      hence the special case here.
-# NOTE The scatter add transforms must set the torch language context explicitly so the .to() method
-#   on tensors is resolved (alternatively they could explicitly call thunder.torch.to)
-@langctx(Languages.TORCH)
 def _scatter_add_prim_transform(a: TensorProxy, /, index: TensorProxy, value: TensorProxy, dim: int) -> TensorProxy:
     if a.dtype == dtypes.bfloat16:
         a = a.to(torch.float32)
@@ -1289,7 +1283,6 @@ def _scatter_add_prim_transform(a: TensorProxy, /, index: TensorProxy, value: Te
 
 # NOTE torch.compile has a compilation issue with scatter add in bfloat16,
 #      hence the special case here.
-@langctx(Languages.TORCH)
 def _scatter_add_transform(a: TensorLike, /, dim: int, index: TensorLike, src: TensorLike) -> TensorLike:
     # NOTE scatter_add does not participate in type promotion, so if a has the bfloat16 dtype, then so does src
     if a.dtype == dtypes.bfloat16:

--- a/thunder/executors/transformer_engineex.py
+++ b/thunder/executors/transformer_engineex.py
@@ -23,7 +23,6 @@ from thunder.core.symbol import Symbol
 from thunder.core.vjp_utils import disable_caching_split_forward_and_backward
 from thunder.extend import OperatorExecutor, register_executor
 from thunder.core.compile_data import get_compile_option, get_compile_data
-from thunder.core.langctxs import langctx, Languages
 from thunder.distributed import FSDPType
 
 
@@ -492,8 +491,6 @@ def _create_fp8_linear_bound_symbol(
 #
 
 
-# NOTE: We need langctx so that we can resolve `view` on TensorProxy.
-@langctx(Languages.TORCH)
 def _linear_checker(
     a: TensorProxy,
     w: TensorProxy,

--- a/thunder/tests/test_extend.py
+++ b/thunder/tests/test_extend.py
@@ -8,7 +8,6 @@ from torch.testing import assert_close
 
 import thunder
 import thunder.core.devices as devices
-from thunder.core.langctxs import langctx
 from thunder.core.proxies import TensorProxy
 from thunder.core.transforms import grad, get_grad, put_grads
 from thunder.extend import (
@@ -33,7 +32,6 @@ def test_extend_core():
     ) -> tuple[torch.Tensor, torch.Tensor]:
         return np.multiply(a, b), np.multiply(c, d)
 
-    @langctx("torch")
     def multimul_like(
         a: Number | TensorProxy,
         b: Number | TensorProxy,
@@ -71,7 +69,6 @@ def test_extend_core():
 
         return all(is_cpu(x) for x in (a, b))
 
-    @langctx("torch")
     def mymul_grad(a: TensorProxy, b: TensorProxy) -> TensorProxy:
         fwd = a * b
 


### PR DESCRIPTION
We already document the torch language context as the default one:
https://github.com/Lightning-AI/lightning-thunder/blob/e05785ed35633b61a8dbb276a4f78a8b514d8e5c/thunder/__init__.py#L289
https://github.com/Lightning-AI/lightning-thunder/blob/e05785ed35633b61a8dbb276a4f78a8b514d8e5c/thunder/common.py#L242-L243

but the language context is not set in all cases where method resolution is needed and that led to developers to add the `langctx("torch")` decorators/context managers in places where it's not needed but where it's needed it was confusing why do we require setting a PyTorch language when we're using and accelerating PyTorch. This PR modifies the main function developers are expected to use to get a current language context and when nothing is explicitly set the default option now is a PyTorch language context.
When people want to use another context they can still do that, but now the default mode eases the cognitive load of using and extending Thunder for PyTorch use cases.

Thanks to @ptrblck and the team for the feedback!