### PR TITLE
Fix `test_find_cut_dropout_nvfuser_cuda_None failure` when the tensorproxy name is not in fixed order

### DIFF
--- a/thunder/tests/test_nvfuser_remat.py
+++ b/thunder/tests/test_nvfuser_remat.py
@@ -333,8 +333,9 @@ def test_find_cut_dropout(executor, device, _):
     # Note cut[1]/producer.output[0] is the boolean mask for dropout. It should
     # be chosen over the float32 mask. See this issue: "The Recomputation
     # Algorithm on Dropout choses a float32 mask to save"
-    assert cut[1] == producer.output[0].name
-    assert cut[2] == producer.output[1].name
+    producer_output_names = tuple(o.name for o in producer.output)
+    assert cut[1] in producer_output_names
+    assert cut[2] in producer_output_names
 
 
 @instantiate(


### PR DESCRIPTION
When running ` thunder/tests/test_inplace_functionalization.py  thunder/tests/test_nvfuser_remat.py::test_find_cut_dropout_nvfuser_cuda_None` or `pytest thunder/tests/test_randomness.py  thunder/tests/test_nvfuser_remat.py::test_find_cut_dropout_nvfuser_cuda_None`, you will get an error message:
```
FAILED thunder/tests/test_nvfuser_remat.py::test_find_cut_dropout_nvfuser_cuda_None - AssertionError: assert 't11' == 't7'
  
  - t7
  + t11
``` 
However, each test can be successful when run alone.
when running `pytest thunder/tests/test_nvfuser_remat.py::test_find_cut_dropout_nvfuser_cuda_None` the trace and cut are:
```
@torch.no_grad()
@no_autocast
def _value_and_grad(*args):
  # args: "Collection"
  [t1] = nvFusion0()
    # t1 = prims.full((2, 2), 1, device=devices.Device("cuda:0"), dtype=dtypes.float32)  # t1: "cuda:0 f32[2, 2]"
  t0, = args
  del args
  [t5, t9] = nvFusion1(t0)
    # t2 = prims.exp(t0)  # t2: "cuda:0 f32[2, 2]"
    # t3 = prims.exp(t2)  # t3: "cuda:0 f32[2, 2]"
    # t4 = prims.uniform((2, 2), 0.0, 1.0, device=devices.Device("cuda:0"), dtype=dtypes.float32)  # t4: "cuda:0 f32[2, 2]"
    # t5 = prims.lt(t4, 0.9)  # t5: "cuda:0 b8[2, 2]"
    # t6 = prims.convert_element_type(t5, dtypes.float32)  # t6: "cuda:0 f32[2, 2]"
    # t7 = prims.mul(t3, t6)  # t7: "cuda:0 f32[2, 2]"
    # t8 = prims.mul(t7, 1.1111111111111112)  # t8: "cuda:0 f32[2, 2]"
    # t9 = prims.exp(t8)  # t9: "cuda:0 f32[2, 2]"
  t11 = torch.permute(t9, (1, 0))  # t11: "cuda:0 f32[2, 2]"
    # t11 = ltorch.permute(t9, (1, 0))  # t11: "cuda:0 f32[2, 2]"
      # t11 = prims.transpose(t9, (1, 0))  # t11: "cuda:0 f32[2, 2]"
  t10 = torch.matmul(t9, t9)  # t10: "cuda:0 f32[2, 2]"
    # t10 = ltorch.matmul(t9, t9)  # t10: "cuda:0 f32[2, 2]"
      # t10 = prims.matmul(t9, t9)  # t10: "cuda:0 f32[2, 2]"
  t12 = torch.matmul(t1, t11)  # t12: "cuda:0 f32[2, 2]"
    # t12 = ltorch.matmul(t1, t11)  # t12: "cuda:0 f32[2, 2]"
      # t12 = prims.matmul(t1, t11)  # t12: "cuda:0 f32[2, 2]"
  t14 = torch.matmul(t11, t1)  # t14: "cuda:0 f32[2, 2]"
    # t14 = ltorch.matmul(t11, t1)  # t14: "cuda:0 f32[2, 2]"
      # t14 = prims.matmul(t11, t1)  # t14: "cuda:0 f32[2, 2]"
  del t11, t1
  [t23] = nvFusion2(t0, t5, t12, t14, t9)
    # t2 = prims.exp(t0)  # t2: "cuda:0 f32[2, 2]"
    # t3 = prims.exp(t2)  # t3: "cuda:0 f32[2, 2]"
    # t6 = prims.convert_element_type(t5, dtypes.float32)  # t6: "cuda:0 f32[2, 2]"
    # t15 = prims.add(t12, t14)  # t15: "cuda:0 f32[2, 2]"
    # t16 = prims.mul(t15, t9)  # t16: "cuda:0 f32[2, 2]"
    # t18 = prims.mul(1.1111111111111112, t16)  # t18: "cuda:0 f32[2, 2]"
    # t19 = prims.mul(t6, t18)  # t19: "cuda:0 f32[2, 2]"
    # t22 = prims.mul(t19, t3)  # t22: "cuda:0 f32[2, 2]"
    # t23 = prims.mul(t22, t2)  # t23: "cuda:0 f32[2, 2]"
  del t0, t5, t12, t14, t9
  return (t10, (t23,))
(Pdb) p cut
('t0', 't5', 't9')
(Pdb) p producer.output
[<TensorProxy(name="t5", dtype=thunder.dtypes.bool8, shape=(2, 2))>, <TensorProxy(name="t9", dtype=thunder.dtypes.float32, shape=(2, 2))>]
```
when running 2 tests together the trace and cut are:
```
@torch.no_grad()
@no_autocast
def _value_and_grad(*args):
  # args: "Collection"
  [t1] = nvFusion0()
    # t1 = prims.full((2, 2), 1, device=devices.Device("cuda:0"), dtype=dtypes.float32)  # t1: "cuda:0 f32[2, 2]"
  t0, = args
  del args
  [t7, t11] = nvFusion1(t0)
    # t2 = prims.exp(t0)  # t2: "cuda:0 f32[2, 2]"
    # t3 = prims.exp(t2)  # t3: "cuda:0 f32[2, 2]"
    # t6 = prims.uniform((2, 2), 0.0, 1.0, device=devices.Device("cuda:0"), dtype=dtypes.float32)  # t6: "cuda:0 f32[2, 2]"
    # t7 = prims.lt(t6, 0.9)  # t7: "cuda:0 b8[2, 2]"
    # t8 = prims.convert_element_type(t7, dtypes.float32)  # t8: "cuda:0 f32[2, 2]"
    # t9 = prims.mul(t3, t8)  # t9: "cuda:0 f32[2, 2]"
    # t10 = prims.mul(t9, 1.1111111111111112)  # t10: "cuda:0 f32[2, 2]"
    # t11 = prims.exp(t10)  # t11: "cuda:0 f32[2, 2]"
  t13 = torch.permute(t11, (1, 0))  # t13: "cuda:0 f32[2, 2]"
    # t13 = ltorch.permute(t11, (1, 0))  # t13: "cuda:0 f32[2, 2]"
      # t13 = prims.transpose(t11, (1, 0))  # t13: "cuda:0 f32[2, 2]"
  t12 = torch.matmul(t11, t11)  # t12: "cuda:0 f32[2, 2]"
    # t12 = ltorch.matmul(t11, t11)  # t12: "cuda:0 f32[2, 2]"
      # t12 = prims.matmul(t11, t11)  # t12: "cuda:0 f32[2, 2]"
  t14 = torch.matmul(t1, t13)  # t14: "cuda:0 f32[2, 2]"
    # t14 = ltorch.matmul(t1, t13)  # t14: "cuda:0 f32[2, 2]"
      # t14 = prims.matmul(t1, t13)  # t14: "cuda:0 f32[2, 2]"
  t16 = torch.matmul(t13, t1)  # t16: "cuda:0 f32[2, 2]"
    # t16 = ltorch.matmul(t13, t1)  # t16: "cuda:0 f32[2, 2]"
      # t16 = prims.matmul(t13, t1)  # t16: "cuda:0 f32[2, 2]"
  del t13, t1
  [t25] = nvFusion2(t0, t7, t14, t16, t11)
    # t2 = prims.exp(t0)  # t2: "cuda:0 f32[2, 2]"
    # t3 = prims.exp(t2)  # t3: "cuda:0 f32[2, 2]"
    # t8 = prims.convert_element_type(t7, dtypes.float32)  # t8: "cuda:0 f32[2, 2]"
    # t17 = prims.add(t14, t16)  # t17: "cuda:0 f32[2, 2]"
    # t18 = prims.mul(t17, t11)  # t18: "cuda:0 f32[2, 2]"
    # t20 = prims.mul(1.1111111111111112, t18)  # t20: "cuda:0 f32[2, 2]"
    # t21 = prims.mul(t8, t20)  # t21: "cuda:0 f32[2, 2]"
    # t24 = prims.mul(t21, t3)  # t24: "cuda:0 f32[2, 2]"
    # t25 = prims.mul(t24, t2)  # t25: "cuda:0 f32[2, 2]"
  del t0, t7, t14, t16, t11
  return (t12, (t25,))
(Pdb) p producer.output
[<TensorProxy(name="t7", dtype=thunder.dtypes.bool8, shape=(2, 2))>, <TensorProxy(name="t11", dtype=thunder.dtypes.float32, shape=(2, 2))>]
(Pdb) p cut
('t0', 't11', 't7')
```
So I think we can relax the conditions of the assertion.