### PR TITLE
[benchmark_litgpt] Add an option to use FSDP2 for when `torch.compile` is used

### DIFF
--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -319,14 +319,17 @@ class Benchmark_litGPT:
                             transformer_block,
                             mesh=mesh,
                             reshard_after_forward=reshard_after_forward,
-                            mp_policy=MixedPrecisionPolicy(),
+                            mp_policy=MixedPrecisionPolicy(
+                                param_dtype=torch.bfloat16,
+                                reduce_dtype=torch.bfloat16,
+                            ),
                         )
 
                 fully_shard(
                     model,
                     mesh=mesh,
                     reshard_after_forward=reshard_after_forward,
-                    mp_policy=MixedPrecisionPolicy(),
+                    mp_policy=MixedPrecisionPolicy(param_dtype=torch.bfloat16, reduce_dtype=torch.bfloat16),
                 )
                 model.to_empty(device=self.device)
                 model.apply(model._init_weights)

--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -301,6 +301,9 @@ class Benchmark_litGPT:
                 # reference: https://github.com/pytorch/torchtitan/blob/6e7a183/docs/fsdp.md
                 from torch.distributed._composable.fsdp import fully_shard, MixedPrecisionPolicy
 
+                if self.bucketing_mode != "none":
+                    warnings.warn(f"fsdp2 ignores {self.bucketing_mode=}")
+
                 torch.cuda.set_device(local_rank)
                 mesh = None
                 if self.sharding_size is not None:

--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -408,6 +408,11 @@ class Benchmark_litGPT:
                 executors.insert(0, transformer_engine_ex)
 
             if "dynamo" in self.compile:
+                if self.distributed_mode == "fsdp2":
+                    print("Resetting cache size for when fsdp2 and using thunder as backend torch.compile")
+                    import torch._dynamo.config as dynamo_config
+
+                    dynamo_config.cache_size_limit = 64
                 if "transformerengine" in self.compile:
                     # [rank0]:   File "/opt/pytorch/lightning-thunder/thunder/executors/transformer_engineex.py", line 410, in _te_functional_linear_backward_impl
                     # [rank0]:     grads = _Linear.backward(ctx, g)

--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -418,19 +418,19 @@ class Benchmark_litGPT:
                     import torch._dynamo.config as dynamo_config
 
                     dynamo_config.cache_size_limit = 64
-                if "transformerengine" in self.compile:
-                    # [rank0]:   File "/opt/pytorch/lightning-thunder/thunder/executors/transformer_engineex.py", line 410, in _te_functional_linear_backward_impl
-                    # [rank0]:     grads = _Linear.backward(ctx, g)
-                    # [rank0]:   File "/usr/local/lib/python3.10/dist-packages/transformer_engine/pytorch/module/linear.py", line 449, in backward
-                    # [rank0]:     weight_fp8.transpose_2d(),
-                    # [rank0]:   File "/usr/local/lib/python3.10/dist-packages/transformer_engine/pytorch/float8_tensor.py", line 625, in transpose_2d
-                    # [rank0]:     if self._transpose is None:
-                    # [rank0]:   File "/usr/local/lib/python3.10/dist-packages/transformer_engine/pytorch/float8_tensor.py", line 39, in get_func
-                    # [rank0]:     return self._fp8_attrs[name]
-                    # [rank0]: AttributeError: 'Float8Tensor' object has no attribute '_fp8_attrs'
-                    raise ValueError(
-                        "TransformerEngine executor cannot be used as an executor of Thunder when Thunder is used as torch.compile backend"
-                    )
+                    if "transformerengine" in self.compile:
+                        # [rank0]:   File "/opt/pytorch/lightning-thunder/thunder/executors/transformer_engineex.py", line 410, in _te_functional_linear_backward_impl
+                        # [rank0]:     grads = _Linear.backward(ctx, g)
+                        # [rank0]:   File "/usr/local/lib/python3.10/dist-packages/transformer_engine/pytorch/module/linear.py", line 449, in backward
+                        # [rank0]:     weight_fp8.transpose_2d(),
+                        # [rank0]:   File "/usr/local/lib/python3.10/dist-packages/transformer_engine/pytorch/float8_tensor.py", line 625, in transpose_2d
+                        # [rank0]:     if self._transpose is None:
+                        # [rank0]:   File "/usr/local/lib/python3.10/dist-packages/transformer_engine/pytorch/float8_tensor.py", line 39, in get_func
+                        # [rank0]:     return self._fp8_attrs[name]
+                        # [rank0]: AttributeError: 'Float8Tensor' object has no attribute '_fp8_attrs'
+                        raise ValueError(
+                            "TransformerEngine executor cannot be used as an executor of Thunder when Thunder is used as torch.compile backend"
+                        )
                 backend = ThunderCompiler(executors=executors)
                 # Because Lightning Fabric is imported in this script it monkey patches the torch.compile function
                 # https://github.com/Lightning-AI/pytorch-lightning/blob/828fd998961f6a60f92c35254bb94d6e049ad069/src/lightning/fabric/wrappers.py#L421

--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -287,7 +287,9 @@ class Benchmark_litGPT:
                 )
             else:
                 if self.distributed_mode == "fsdp2":
-                    raise ValueError(f"`fsdp2` is not available for `thunder.jit`.")
+                    raise ValueError(
+                        f"To use `fsdp2`, use thunder as torch.compile backend by including dynamo in `--compile` option or set `--compile` to either eager or inductor"
+                    )
         else:
             if self.distributed_mode == "ddp":
                 model = torch.nn.parallel.DistributedDataParallel(


### PR DESCRIPTION
## What does this PR do?

This adds an option to use FSDP2 of pytorch.
An example command to use FSDP2 and thunder as torch.compile backend:
```
torchrun --nproc-per-node 8 --local-ranks-filter 0 --role rank --tee 3 thunder/benchmarks/benchmark_litgpt.py --model_name Llama-2-7b-hf --compile dynamo_thunder_inductor_cat_cudnn --distributed_mode fsdp2 --shard_mode zero2
```

## Llama-2-7b-hf on 8 H100, using pjnl-20240814

### batch size 1

| compiler | executors                                 | Tokens/s/GPU | Memory Used |
|----------|-------------------------------------------|--------------|-------------|
| thunder  | inductor_cat_cudnn_transformerengine      | 14264.60     | 52.95       |
| torch    | thunder_inductor_cat_cudnn_dynamo (FSDP2) | 12493.36     | 40.21       |
| torch    | thunder_inductor_cat_dynamo (FSDP2)       | 11946.70     | 39.13       |
| torch    | N/A (FSDP2)                               | 11855.92     | 40.21       |
| torch    | thunder_dynamo                            | 11562.31     | 42.46       |
| thunder  | inductor_cat_cudnn                        | 10611.78     | 42.06       |
| torch    | N/A (FSDP1)                               | 10184.90     | 40.21       |
| eager    | N/A (FSDP2)                               | 9325.13      | 47.45       |
| eager    | N/A (FSDP1)                               | 8520.78      | 47.46       |


### batch size 2

| compiler | executors                                 | Tokens/s/GPU | Memory Used |
|----------|-------------------------------------------|--------------|-------------|
| thunder  | inductor_cat_cudnn_transformerengine      | 16211.24     | 74.04       |
| torch    | thunder_inductor_cat_cudnn_dynamo (FSDP2) | 13861.93     | 61.82       |
| torch    | thunder_inductor_cat_dynamo (FSDP2)       | 13126.78     | 59.67       |
| torch    | N/A (FSDP2)                               | 13527.96     | 61.82       |
| torch    | thunder_dynamo                            | 12634.99     | 65.04       |
| thunder  | inductor_cat_cudnn                        | 11612.35     | 65.79       |
| torch    | N/A (FSDP1)                               | 11512.82     | 61.82       |
| eager    | N/A (FSDP2)                               | 10081.42     | 76.32       |
| eager    | N/A (FSDP1)                               | 9098.47      | 76.32       |

## TODOs
- [ ] investigate the use of TransformerEngine as one executor of thunder.jit as torch.compile backend
- [ ] support gradient accumulation of fsdp2, using `set_requires_gradient_sync` method, ref: https://github.com/pytorch/pytorch/blob/448d54ee929f5dfbe816849e56554d7df439c39f/torch/distributed/_composable/fsdp/fully_shard.py#L220

**note**: thunder with transformer engine as torch.compile backend with fsdp2 does not seem to work:

```
...
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/torch/amp/autocast_mode.py", line 44, in decorate_autocast
[rank0]:     return func(*args, **kwargs)
[rank0]:   File "thunder.backward_fn_359", line 25, in backward_fn
[rank0]:   File "/opt/pytorch/lightning-thunder/thunder/executors/transformer_engineex.py", line 410, in _te_functional_linear_backward_impl
[rank0]:     grads = _Linear.backward(ctx, g)
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/transformer_engine/pytorch/module/linear.py", line 449, in backward
[rank0]:     weight_fp8.transpose_2d(),
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/transformer_engine/pytorch/float8_tensor.py", line 625, in transpose_2d
[rank0]:     if self._transpose is None:
[rank0]:   File "/usr/local/lib/python3.10/dist-packages/transformer_engine/pytorch/float8_tensor.py", line 39, in get_func
[rank0]:     return self._fp8_attrs[name]
[rank0]: AttributeError: 'Float8Tensor' object has no attribute '_fp8_attrs'
```