### PR TITLE
SDPA integration for nvFuser

### DIFF
--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -187,11 +187,11 @@ if nvfuser_executor:
 if torchcompile_cat_executor and pytorch._dynamo.is_inductor_supported():
     add_default_executor(torchcompile_cat_executor)
 
-# if sdpa_executor:
-#     add_default_executor(sdpa_executor)
+if sdpa_executor:
+    add_default_executor(sdpa_executor)
 
-# if cudnn_executor:
-#     add_default_executor(cudnn_executor)
+if cudnn_executor:
+    add_default_executor(cudnn_executor)
 
 #
 # Promoted debugging functions

--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -187,11 +187,11 @@ if nvfuser_executor:
 if torchcompile_cat_executor and pytorch._dynamo.is_inductor_supported():
     add_default_executor(torchcompile_cat_executor)
 
-if sdpa_executor:
-    add_default_executor(sdpa_executor)
+# if sdpa_executor:
+#     add_default_executor(sdpa_executor)
 
-if cudnn_executor:
-    add_default_executor(cudnn_executor)
+# if cudnn_executor:
+#     add_default_executor(cudnn_executor)
 
 #
 # Promoted debugging functions

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -2260,8 +2260,8 @@ def _scaled_dot_product_flash_attention_forward_meta(
         log_sumexp := TensorProxy(
             shape=(batch_size, num_heads, query_seq_len), dtype=dtypes.float32, device=query.device, requires_grad=False
         ),
-        philox_seed := TensorProxy(shape=(), dtype=dtypes.int64, device=query.device, requires_grad=False),
-        philox_offset := TensorProxy(shape=(), dtype=dtypes.int64, device=query.device, requires_grad=False),
+        philox_seed := TensorProxy(shape=(), dtype=dtypes.int64, device=DeviceType.CPU, requires_grad=False),
+        philox_offset := TensorProxy(shape=(), dtype=dtypes.int64, device=DeviceType.CPU, requires_grad=False),
     )
 
 
@@ -2378,6 +2378,10 @@ def _scaled_dot_product_flash_attention_check(
     enable_sdpa: None | bool = get_compile_option("nv_enable_sdpa", "Enable nvFuser flash attention SDPA.")
 
     if not enable_sdpa:
+        return False
+
+    # Flash attn does not support attn_mask currently.
+    if attn_mask is not None:
         return False
 
     if not are_supported_tensors(query, key, value):

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -36,7 +36,7 @@ from thunder.core.rematerialization import rematerialize
 from thunder.core.utils import OrderedSet, check, check_same_dtype
 from thunder.core.trace import TraceCtx, from_trace, TraceProvenance
 from thunder.core.symbol import BoundSymbol, BoundSymbolRHS, Symbol, has_tags
-from thunder.core.devices import Device, DeviceType
+from thunder.core.devices import Device, DeviceType, cpu
 import thunder.core.codeutils as codeutils
 from thunder.core.codeutils import Printable
 from thunder.core.transform_common import dce, cse_single_bsym, replace_redundant_inputs, NON_FUNCTIONAL_OPS
@@ -2260,8 +2260,8 @@ def _scaled_dot_product_flash_attention_forward_meta(
         log_sumexp := TensorProxy(
             shape=(batch_size, num_heads, query_seq_len), dtype=dtypes.float32, device=query.device, requires_grad=False
         ),
-        philox_seed := TensorProxy(shape=(), dtype=dtypes.int64, device=DeviceType.CPU, requires_grad=False),
-        philox_offset := TensorProxy(shape=(), dtype=dtypes.int64, device=DeviceType.CPU, requires_grad=False),
+        philox_seed := TensorProxy(shape=(), dtype=dtypes.int64, device=cpu, requires_grad=False),
+        philox_offset := TensorProxy(shape=(), dtype=dtypes.int64, device=cpu, requires_grad=False),
     )
 
 

--- a/thunder/executors/sdpaex.py
+++ b/thunder/executors/sdpaex.py
@@ -24,7 +24,7 @@ from thunder.executors.utils import (
     _input_dtype_check_fused_scaled_dot_product_attention,
     _input_shape_check_fused_scaled_dot_product_attention,
     _fused_sdp_choice,
-    SpdaBackend
+    SpdaBackend,
 )
 
 sdpa_ex: OperatorExecutor = OperatorExecutor("sdpa", version="0.1")
@@ -105,6 +105,7 @@ def _attention_mask_memory_efficient_helper(attn_mask: None | torch.Tensor, quer
         return padded_attn_mask[:, :, :, 0:key_seq_len]
     else:
         return expanded_attn_mask.contiguous()
+
 
 # This helper function maps to aten::_scaled_dot_product_efficient_attention function.
 def _grad_forward_scaled_dot_product_efficient_attention_meta(
@@ -518,6 +519,7 @@ def _scaled_dot_product_attention_grad(
         if attn_mask is not None:
             put_grad(attn_mask, grad_attn_mask)
     return primal
+
 
 def _scaled_dot_product_attention_checker(
     query: Proxy,

--- a/thunder/executors/sdpaex.py
+++ b/thunder/executors/sdpaex.py
@@ -2,13 +2,11 @@ import math
 from looseversion import LooseVersion
 
 import torch
-from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
 
 import thunder.core.dtypes as dtypes
 from thunder.core.proxies import Proxy, TensorProxy
 import thunder.core.utils as utils
 import thunder.core.devices as devices
-from thunder.core.compile_data import get_compile_option
 
 import thunder.torch as ltorch
 from thunder.torch import TensorLike
@@ -22,15 +20,15 @@ from thunder.extend import OperatorExecutor, register_executor
 
 from enum import Enum
 
+from thunder.executors.utils import (
+    _input_dtype_check_fused_scaled_dot_product_attention,
+    _input_shape_check_fused_scaled_dot_product_attention,
+    _fused_sdp_choice,
+    SpdaBackend
+)
+
 sdpa_ex: OperatorExecutor = OperatorExecutor("sdpa", version="0.1")
 register_executor(sdpa_ex)
-
-
-class SpdaBackend(Enum):
-    ERROR = -1
-    MATH = 0
-    FLASH_ATTENTION = 1
-    MEMORY_EFFICIENT = 2
 
 
 # Both flash attention and memory efficient sdpa require that the last stride be one.
@@ -107,74 +105,6 @@ def _attention_mask_memory_efficient_helper(attn_mask: None | torch.Tensor, quer
         return padded_attn_mask[:, :, :, 0:key_seq_len]
     else:
         return expanded_attn_mask.contiguous()
-
-
-# TODO These checks should be converted to compile-time checks using a checker function
-# This helper function checks that the shape of input tensors are supported by fused sdpa implementation.
-def _input_shape_check_fused_scaled_dot_product_attention(
-    query: TensorLike, key: TensorLike, value: TensorLike, attn_mask: None | TensorLike
-):
-    # Restrict input tensors to 4 dimension
-    utils.check(
-        query.ndim == 4,
-        lambda: f"grad_forward_sdpa: Expected query tensor to have 4 dimension, but it has {query.ndim}.",
-    )
-    utils.check(
-        key.ndim == 4,
-        lambda: f"grad_forward_sdpa: Expected key tensor to have 4 dimension, but it has {key.ndim}.",
-    )
-    utils.check(
-        value.ndim == 4,
-        lambda: f"grad_forward_sdpa: Expected value tensor to have 4 dimension, but it has {value.ndim}.",
-    )
-    utils.check(
-        attn_mask is None or attn_mask.ndim == 4,
-        lambda: f"grad_forward_sdpa: Expected attn_mask tensor to have 4 dimension, but it has {attn_mask.ndim}.",
-    )
-
-    # query (batch_size, num_heads, query_seq_len, E)
-    # key (batch_size, num_heads, key_seq_len, E)
-    # value (batch_size, num_heads, key_seq_len, Ev)
-    # attn_mask (batch_size, num_heads, query_seq_len, key_seq_len)
-    inputs = [query, key, value]
-    if attn_mask is not None:
-        inputs.append(attn_mask)
-
-    # NOTE aten::scaled_dot_product_efficient_attention does not support broadcastable batch size.
-    utils.check(
-        all(a.shape[0] == inputs[0].shape[0] for a in inputs),
-        lambda: "grad_forward_sdpa: Expected all inputs to have same batch_size.",
-    )
-
-    # Check for the same number of heads
-    utils.check(
-        all(a.shape[1] == 1 or a.shape[1] == inputs[0].shape[1] for a in inputs),
-        lambda: "grad_forward_sdpa: Expected all inputs to have same number of attention heads or a broadcastable dimension.",
-    )
-
-
-# TODO These checks should be converted to compile-time checks using a checker function
-# This helper function checks that the dtypes of input tensors are supported by fused sdpa implementation.
-def _input_dtype_check_fused_scaled_dot_product_attention(
-    query: TensorLike,
-    key: TensorLike,
-    value: TensorLike,
-    attn_mask: None | TensorLike,
-    supported_dtypes: tuple[dtypes.dtype, ...],
-):
-    utils.check(
-        query.dtype in supported_dtypes,
-        lambda: f"grad_forward_sdpa: Only {supported_dtypes} dtypes are supported, but query has {query.dtype}.",
-    )
-    utils.check(
-        key.dtype in supported_dtypes,
-        lambda: f"grad_forward_sdpa: Only {supported_dtypes} dtypes are supported, but key has {key.dtype}.",
-    )
-    utils.check(
-        value.dtype in supported_dtypes,
-        lambda: f"grad_forward_sdpa: Only {supported_dtypes} dtypes are supported, but value has {value.dtype}.",
-    )
-
 
 # This helper function maps to aten::_scaled_dot_product_efficient_attention function.
 def _grad_forward_scaled_dot_product_efficient_attention_meta(
@@ -588,100 +518,6 @@ def _scaled_dot_product_attention_grad(
         if attn_mask is not None:
             put_grad(attn_mask, grad_attn_mask)
     return primal
-
-
-# This helper function converts Thunder Proxy to PyTorch Meta Tensor
-def _convert_to_meta_tensor(a: None | TensorProxy) -> None | torch.Tensor:
-    from thunder.torch import _thunder_to_torch_dtype_map
-
-    if a is None:
-        return None
-    return torch.empty(
-        a.shape,
-        dtype=_thunder_to_torch_dtype_map[a.dtype],
-        requires_grad=a.requires_grad,
-        device="meta",
-    )
-
-
-# This helper function converts PyTorch meta tensor to FakeTensor, which
-# models stride order for contiguity checks.
-def _convert_to_fake_tensor(mode: FakeTensorMode, a: None | torch.Tensor) -> None | FakeTensor:
-    if a is None:
-        return None
-    return FakeTensor(mode, a, device="cuda")
-
-
-# Convert input tensors represented as Thunder Proxy to PyTorch FakeTensor.
-# Determine which fused sdpa kernel.
-def _fused_sdp_choice(
-    query: Proxy,
-    key: Proxy,
-    value: Proxy,
-    attn_mask: None | Proxy,
-    dropout_p: float = 0.0,
-    is_causal: bool = False,
-    scale: None | float = None,
-) -> int:
-    input_tensors = (query, key, value, attn_mask)
-    meta_input_tensors = list(map(_convert_to_meta_tensor, input_tensors))
-    with FakeTensorMode() as mode:
-        fake_query, fake_key, fake_value, fake_attn_mask = list(
-            map(lambda a: _convert_to_fake_tensor(mode, a), meta_input_tensors)
-        )
-
-    import thunder
-
-    if isinstance(is_causal, thunder.core.proxies.IntegerProxy):
-        is_causal = is_causal.value
-
-    if LooseVersion(torch.__version__) < LooseVersion("2.2.0"):
-        # Figure out which SDPA to use. There are performance cliffs to the
-        # various implementations, and this makes the decision cognizant of
-        # those cliffs.
-        backend = torch._fused_sdp_choice(
-            fake_query,
-            fake_key,
-            fake_value,
-            fake_attn_mask,
-            dropout_p,
-            is_causal,
-            scale=scale,
-        )
-        return SpdaBackend(backend)
-    else:
-        from torch.backends.cuda import (
-            SDPAParams,
-            can_use_efficient_attention,
-            can_use_flash_attention,
-            flash_sdp_enabled,
-            math_sdp_enabled,
-            mem_efficient_sdp_enabled,
-        )
-
-        args = []
-        if hasattr(SDPAParams, "enable_gqa"):
-            args.append(False)
-
-        sdp_params = SDPAParams(fake_query, fake_key, fake_value, fake_attn_mask, dropout_p, is_causal, *args)
-
-        enable_debug: None | bool = get_compile_option(
-            "sdpa_debug", "Enables sdpa backend warning messages when a specific kernel is unavailable."
-        )
-        # Set default value.
-        if enable_debug is None:
-            enable_debug = False
-        assert isinstance(enable_debug, bool)
-
-        if flash_sdp_enabled() and can_use_flash_attention(sdp_params, enable_debug):
-            return SpdaBackend.FLASH_ATTENTION
-        elif mem_efficient_sdp_enabled() and can_use_efficient_attention(sdp_params, enable_debug):
-            return SpdaBackend.MEMORY_EFFICIENT
-        elif math_sdp_enabled():
-            return SpdaBackend.MATH
-        else:
-            return SpdaBackend.ERROR
-
 
 def _scaled_dot_product_attention_checker(
     query: Proxy,

--- a/thunder/executors/utils.py
+++ b/thunder/executors/utils.py
@@ -158,6 +158,7 @@ def _input_shape_check_fused_scaled_dot_product_attention(
         lambda: "grad_forward_sdpa: Expected all inputs to have same number of attention heads or a broadcastable dimension.",
     )
 
+
 # TODO These checks should be converted to compile-time checks using a checker function
 # This helper function checks that the dtypes of input tensors are supported by fused sdpa implementation.
 def _input_dtype_check_fused_scaled_dot_product_attention(
@@ -180,6 +181,7 @@ def _input_dtype_check_fused_scaled_dot_product_attention(
         lambda: f"grad_forward_sdpa: Only {supported_dtypes} dtypes are supported, but value has {value.dtype}.",
     )
 
+
 # This helper function converts Thunder Proxy to PyTorch Meta Tensor
 def _convert_to_meta_tensor(a: None | TensorProxy) -> None | torch.Tensor:
     from thunder.torch import _thunder_to_torch_dtype_map
@@ -201,11 +203,13 @@ def _convert_to_fake_tensor(mode: FakeTensorMode, a: None | torch.Tensor) -> Non
         return None
     return FakeTensor(mode, a, device="cuda")
 
+
 class SpdaBackend(Enum):
     ERROR = -1
     MATH = 0
     FLASH_ATTENTION = 1
     MEMORY_EFFICIENT = 2
+
 
 # Convert input tensors represented as Thunder Proxy to PyTorch FakeTensor.
 # Determine which fused sdpa kernel.

--- a/thunder/executors/utils.py
+++ b/thunder/executors/utils.py
@@ -17,6 +17,9 @@ from thunder.core.pytree import tree_flatten, tree_map, tree_unflatten
 from thunder.core.proxies import Variable, variableify, Proxy, unvariableify
 from thunder.core.prims import PrimIDs
 from thunder.core.transform_common import order_proxies
+from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
+from thunder.core.compile_data import get_compile_option
+
 
 # TODO Make these tags
 comment_symbols = {
@@ -110,3 +113,166 @@ def set_saved_tensors(ctx, saved_tensors):
         yield
     finally:
         del ctx.saved_tensors
+
+
+# TODO These checks should be converted to compile-time checks using a checker function
+# This helper function checks that the shape of input tensors are supported by fused sdpa implementation.
+def _input_shape_check_fused_scaled_dot_product_attention(
+    query: TensorLike, key: TensorLike, value: TensorLike, attn_mask: None | TensorLike
+):
+    # Restrict input tensors to 4 dimension
+    utils.check(
+        query.ndim == 4,
+        lambda: f"grad_forward_sdpa: Expected query tensor to have 4 dimension, but it has {query.ndim}.",
+    )
+    utils.check(
+        key.ndim == 4,
+        lambda: f"grad_forward_sdpa: Expected key tensor to have 4 dimension, but it has {key.ndim}.",
+    )
+    utils.check(
+        value.ndim == 4,
+        lambda: f"grad_forward_sdpa: Expected value tensor to have 4 dimension, but it has {value.ndim}.",
+    )
+    utils.check(
+        attn_mask is None or attn_mask.ndim == 4,
+        lambda: f"grad_forward_sdpa: Expected attn_mask tensor to have 4 dimension, but it has {attn_mask.ndim}.",
+    )
+
+    # query (batch_size, num_heads, query_seq_len, E)
+    # key (batch_size, num_heads, key_seq_len, E)
+    # value (batch_size, num_heads, key_seq_len, Ev)
+    # attn_mask (batch_size, num_heads, query_seq_len, key_seq_len)
+    inputs = [query, key, value]
+    if attn_mask is not None:
+        inputs.append(attn_mask)
+
+    # NOTE aten::scaled_dot_product_efficient_attention does not support broadcastable batch size.
+    utils.check(
+        all(a.shape[0] == inputs[0].shape[0] for a in inputs),
+        lambda: "grad_forward_sdpa: Expected all inputs to have same batch_size.",
+    )
+
+    # Check for the same number of heads
+    utils.check(
+        all(a.shape[1] == 1 or a.shape[1] == inputs[0].shape[1] for a in inputs),
+        lambda: "grad_forward_sdpa: Expected all inputs to have same number of attention heads or a broadcastable dimension.",
+    )
+
+# TODO These checks should be converted to compile-time checks using a checker function
+# This helper function checks that the dtypes of input tensors are supported by fused sdpa implementation.
+def _input_dtype_check_fused_scaled_dot_product_attention(
+    query: TensorLike,
+    key: TensorLike,
+    value: TensorLike,
+    attn_mask: None | TensorLike,
+    supported_dtypes: tuple[dtypes.dtype, ...],
+):
+    utils.check(
+        query.dtype in supported_dtypes,
+        lambda: f"grad_forward_sdpa: Only {supported_dtypes} dtypes are supported, but query has {query.dtype}.",
+    )
+    utils.check(
+        key.dtype in supported_dtypes,
+        lambda: f"grad_forward_sdpa: Only {supported_dtypes} dtypes are supported, but key has {key.dtype}.",
+    )
+    utils.check(
+        value.dtype in supported_dtypes,
+        lambda: f"grad_forward_sdpa: Only {supported_dtypes} dtypes are supported, but value has {value.dtype}.",
+    )
+
+# This helper function converts Thunder Proxy to PyTorch Meta Tensor
+def _convert_to_meta_tensor(a: None | TensorProxy) -> None | torch.Tensor:
+    from thunder.torch import _thunder_to_torch_dtype_map
+
+    if a is None:
+        return None
+    return torch.empty(
+        a.shape,
+        dtype=_thunder_to_torch_dtype_map[a.dtype],
+        requires_grad=a.requires_grad,
+        device="meta",
+    )
+
+
+# This helper function converts PyTorch meta tensor to FakeTensor, which
+# models stride order for contiguity checks.
+def _convert_to_fake_tensor(mode: FakeTensorMode, a: None | torch.Tensor) -> None | FakeTensor:
+    if a is None:
+        return None
+    return FakeTensor(mode, a, device="cuda")
+
+class SpdaBackend(Enum):
+    ERROR = -1
+    MATH = 0
+    FLASH_ATTENTION = 1
+    MEMORY_EFFICIENT = 2
+
+# Convert input tensors represented as Thunder Proxy to PyTorch FakeTensor.
+# Determine which fused sdpa kernel.
+def _fused_sdp_choice(
+    query: Proxy,
+    key: Proxy,
+    value: Proxy,
+    attn_mask: None | Proxy,
+    dropout_p: float = 0.0,
+    is_causal: bool = False,
+    scale: None | float = None,
+) -> int:
+    input_tensors = (query, key, value, attn_mask)
+    meta_input_tensors = list(map(_convert_to_meta_tensor, input_tensors))
+    with FakeTensorMode() as mode:
+        fake_query, fake_key, fake_value, fake_attn_mask = list(
+            map(lambda a: _convert_to_fake_tensor(mode, a), meta_input_tensors)
+        )
+
+    import thunder
+
+    if isinstance(is_causal, thunder.core.proxies.IntegerProxy):
+        is_causal = is_causal.value
+
+    if LooseVersion(torch.__version__) < LooseVersion("2.2.0"):
+        # Figure out which SDPA to use. There are performance cliffs to the
+        # various implementations, and this makes the decision cognizant of
+        # those cliffs.
+        backend = torch._fused_sdp_choice(
+            fake_query,
+            fake_key,
+            fake_value,
+            fake_attn_mask,
+            dropout_p,
+            is_causal,
+            scale=scale,
+        )
+        return SpdaBackend(backend)
+    else:
+        from torch.backends.cuda import (
+            SDPAParams,
+            can_use_efficient_attention,
+            can_use_flash_attention,
+            flash_sdp_enabled,
+            math_sdp_enabled,
+            mem_efficient_sdp_enabled,
+        )
+
+        args = []
+        if hasattr(SDPAParams, "enable_gqa"):
+            args.append(False)
+
+        sdp_params = SDPAParams(fake_query, fake_key, fake_value, fake_attn_mask, dropout_p, is_causal, *args)
+
+        enable_debug: None | bool = get_compile_option(
+            "sdpa_debug", "Enables sdpa backend warning messages when a specific kernel is unavailable."
+        )
+        # Set default value.
+        if enable_debug is None:
+            enable_debug = False
+        assert isinstance(enable_debug, bool)
+
+        if flash_sdp_enabled() and can_use_flash_attention(sdp_params, enable_debug):
+            return SpdaBackend.FLASH_ATTENTION
+        elif mem_efficient_sdp_enabled() and can_use_efficient_attention(sdp_params, enable_debug):
+            return SpdaBackend.MEMORY_EFFICIENT
+        elif math_sdp_enabled():
+            return SpdaBackend.MATH
+        else:
+            return SpdaBackend.ERROR

--- a/thunder/extend/__init__.py
+++ b/thunder/extend/__init__.py
@@ -73,7 +73,7 @@ class Executor:
     @property
     def implmap(self) -> dict[Hashable, ImplInfo]:
         return self._implmap
-    
+
     @property
     def opmap(self) -> dict[str, Symbol]:
         return self._opmap

--- a/thunder/tests/test_nvfuser.py
+++ b/thunder/tests/test_nvfuser.py
@@ -1012,4 +1012,5 @@ def test_sdpa(executor, device, _):
     fwd_traces = thunder.last_traces(compiled_func)
     bwd_traces = thunder.last_backward_traces(compiled_func)
     fusions = examine.get_fusions(fwd_traces[-1])
-    breakpoint()
+    print (fwd_traces[-1])
+    print (bwd_traces[-1])

--- a/thunder/tests/test_nvfuser.py
+++ b/thunder/tests/test_nvfuser.py
@@ -1033,7 +1033,7 @@ def test_sdpa(
     tensor_inputs = [q, k, v]
     scalar_inputs = [dropout_p, is_causal, scale]
 
-    compiled_func = thunder.jit(sdpa_fn, executor=executor.executors_list(), nv_enable_sdpa=True)
+    compiled_func = thunder.jit(sdpa_fn, executors_list=executor.executors_list(), nv_enable_sdpa=True)
     with torch.random.fork_rng(devices=[torch.cuda.current_device()]):
         attn_out = compiled_func(*tensor_inputs, *scalar_inputs)
     attn_out.backward(grad_out)

--- a/thunder/tests/test_nvfuser.py
+++ b/thunder/tests/test_nvfuser.py
@@ -1013,4 +1013,3 @@ def test_sdpa(executor, device, _):
     bwd_traces = thunder.last_backward_traces(compiled_func)
     fusions = examine.get_fusions(fwd_traces[-1])
     breakpoint()
-

--- a/thunder/tests/test_nvfuser.py
+++ b/thunder/tests/test_nvfuser.py
@@ -992,6 +992,7 @@ def test_div_truediv_integer_tensors_consistency_nvfuser(executor, device, thund
         jout = f(x, y)
         assert rout.equal(jout)
 
+
 @instantiate(
     dtypes=(thunder.float16, thunder.bfloat16),
     devicetypes=(devices.DeviceType.CUDA,),
@@ -1001,19 +1002,28 @@ def test_div_truediv_integer_tensors_consistency_nvfuser(executor, device, thund
             nvfuser_version() is None or nvfuser_version() < LooseVersion("0.2.10"),
             reason="Requires nvFuser version 0.2.10 or later",
         ),
-        pytest.mark.parametrize('dropout_p', [0.0, 0.2]),
-        pytest.mark.parametrize('is_causal', [False, True]),
-        pytest.mark.parametrize('scale', [None, 1e-3]),
+        pytest.mark.parametrize("dropout_p", [0.0, 0.2]),
+        pytest.mark.parametrize("is_causal", [False, True]),
+        pytest.mark.parametrize("scale", [None, 1e-3]),
     ),
 )
-def test_sdpa(executor, device: str, thunder_dtype: dtypes.dtype, dropout_p: None | float, is_causal: None | bool, scale: None | float):
-    
+def test_sdpa(
+    executor,
+    device: str,
+    thunder_dtype: dtypes.dtype,
+    dropout_p: None | float,
+    is_causal: None | bool,
+    scale: None | float,
+):
+
     def sdpa_fn(q, k, v, dropout_p, is_causal, scale):
-        return torch.nn.functional.scaled_dot_product_attention(q, k, v, dropout_p=dropout_p, is_causal=is_causal, scale=scale)
+        return torch.nn.functional.scaled_dot_product_attention(
+            q, k, v, dropout_p=dropout_p, is_causal=is_causal, scale=scale
+        )
 
     torch.manual_seed(0)
     dtype = ltorch.to_torch_dtype(thunder_dtype)
-    
+
     N, H, L, S, E = 4, 8, 16, 16, 8
     q = make_tensor((N, H, L, E), device=device, dtype=dtype, requires_grad=True)
     k = make_tensor((N, H, S, E), device=device, dtype=dtype, requires_grad=True)
@@ -1034,10 +1044,10 @@ def test_sdpa(executor, device: str, thunder_dtype: dtypes.dtype, dropout_p: Non
 
     assert len(fwd_fusion) == 1
     assert len(bwd_fusion) == 1
-    assert 'nv_sdpfa_fwd' in fwd_fusion[-1][-1].name
+    assert "nv_sdpfa_fwd" in fwd_fusion[-1][-1].name
 
     # Check nv_sdpfa_fwd is not in bwd_fusion -> that would indicate rematerialization
-    assert ('nv_sdpfa_bwd' in bwd_fusion[-1][-1].name and 'nv_sdpfa_fwd' not in bwd_fusion[-1][-1].name)
+    assert "nv_sdpfa_bwd" in bwd_fusion[-1][-1].name and "nv_sdpfa_fwd" not in bwd_fusion[-1][-1].name
 
     # Torch reference computation
     # Clone the inputs to verify gradients with torch reference
@@ -1050,13 +1060,9 @@ def test_sdpa(executor, device: str, thunder_dtype: dtypes.dtype, dropout_p: Non
     with torch.random.fork_rng(devices=[torch.cuda.current_device()]):
         ref_attn_out = sdpa_fn(*ref_tensor_inputs, *scalar_inputs)
     ref_attn_out.backward(grad_out)
-    
-    nv_outputs = (attn_out, q.grad, k.grad, v.grad)
-    ref_outputs =  (ref_attn_out, *(inp.grad for inp in ref_tensor_inputs))
-    
-    for (nv_out, ref_out) in zip(nv_outputs, ref_outputs):
-        torch.testing.assert_close(nv_out, ref_out)
-    
-            
-        
 
+    nv_outputs = (attn_out, q.grad, k.grad, v.grad)
+    ref_outputs = (ref_attn_out, *(inp.grad for inp in ref_tensor_inputs))
+
+    for nv_out, ref_out in zip(nv_outputs, ref_outputs):
+        torch.testing.assert_close(nv_out, ref_out)

--- a/thunder/tests/test_nvfuser.py
+++ b/thunder/tests/test_nvfuser.py
@@ -993,24 +993,70 @@ def test_div_truediv_integer_tensors_consistency_nvfuser(executor, device, thund
         assert rout.equal(jout)
 
 @instantiate(
-    dtypes=NOTHING,
+    dtypes=(thunder.float16, thunder.bfloat16),
+    devicetypes=(devices.DeviceType.CUDA,),
     executors=(nvFuserExecutor,),
+    decorators=(
+        pytest.mark.skipif(
+            nvfuser_version() is None or nvfuser_version() < LooseVersion("0.2.10"),
+            reason="Requires nvFuser version 0.2.10 or later",
+        ),
+        pytest.mark.parametrize('dropout_p', [0.0, 0.2]),
+        pytest.mark.parametrize('is_causal', [False, True]),
+        pytest.mark.parametrize('scale', [None, 1e-3]),
+    ),
 )
-def test_sdpa(executor, device, _):
-    def fn(q, k, v, grad_out):
-        return torch.nn.functional.scaled_dot_product_attention(q, k, v)
+def test_sdpa(executor, device: str, thunder_dtype: dtypes.dtype, dropout_p: None | float, is_causal: None | bool, scale: None | float):
+    
+    def sdpa_fn(q, k, v, dropout_p, is_causal, scale):
+        return torch.nn.functional.scaled_dot_product_attention(q, k, v, dropout_p=dropout_p, is_causal=is_causal, scale=scale)
 
-    compiled_func = thunder.jit(fn, executor=executor.executors_list(), nv_enable_sdpa=True)
+    torch.manual_seed(0)
+    dtype = ltorch.to_torch_dtype(thunder_dtype)
+    
     N, H, L, S, E = 4, 8, 16, 16, 8
-    q = torch.randn((N, H, L, E), device='cuda', dtype=torch.bfloat16, requires_grad=True)
-    k = torch.randn((N, H, S, E), device='cuda', dtype=torch.bfloat16, requires_grad=True)
-    v = torch.randn((N, H, S, E), device='cuda', dtype=torch.bfloat16, requires_grad=True)
-    grad_out = torch.randn((N, H, L, E), device='cuda', dtype=torch.bfloat16)
+    q = make_tensor((N, H, L, E), device=device, dtype=dtype, requires_grad=True)
+    k = make_tensor((N, H, S, E), device=device, dtype=dtype, requires_grad=True)
+    v = make_tensor((N, H, S, E), device=device, dtype=dtype, requires_grad=True)
+    grad_out = make_tensor((N, H, L, E), device=device, dtype=dtype)
 
-    out = compiled_func(q, k, v, grad_out)
-    out.backward(grad_out)
-    fwd_traces = thunder.last_traces(compiled_func)
-    bwd_traces = thunder.last_backward_traces(compiled_func)
-    fusions = examine.get_fusions(fwd_traces[-1])
-    print (fwd_traces[-1])
-    print (bwd_traces[-1])
+    tensor_inputs = [q, k, v]
+    scalar_inputs = [dropout_p, is_causal, scale]
+
+    compiled_func = thunder.jit(sdpa_fn, executor=executor.executors_list(), nv_enable_sdpa=True)
+    with torch.random.fork_rng(devices=[torch.cuda.current_device()]):
+        attn_out = compiled_func(*tensor_inputs, *scalar_inputs)
+    attn_out.backward(grad_out)
+    fwd_trace = thunder.last_traces(compiled_func)[-1]
+    bwd_trace = thunder.last_backward_traces(compiled_func)[-1]
+    fwd_fusion = examine.get_fusions(fwd_trace)
+    bwd_fusion = examine.get_fusions(bwd_trace)
+
+    assert len(fwd_fusion) == 1
+    assert len(bwd_fusion) == 1
+    assert 'nv_sdpfa_fwd' in fwd_fusion[-1][-1].name
+
+    # Check nv_sdpfa_fwd is not in bwd_fusion -> that would indicate rematerialization
+    assert ('nv_sdpfa_bwd' in bwd_fusion[-1][-1].name and 'nv_sdpfa_fwd' not in bwd_fusion[-1][-1].name)
+
+    # Torch reference computation
+    # Clone the inputs to verify gradients with torch reference
+    ref_tensor_inputs = []
+    for inp in tensor_inputs:
+        ref_inp = inp.clone().detach()
+        ref_inp.requires_grad = True
+        ref_tensor_inputs.append(ref_inp)
+
+    with torch.random.fork_rng(devices=[torch.cuda.current_device()]):
+        ref_attn_out = sdpa_fn(*ref_tensor_inputs, *scalar_inputs)
+    ref_attn_out.backward(grad_out)
+    
+    nv_outputs = (attn_out, q.grad, k.grad, v.grad)
+    ref_outputs =  (ref_attn_out, *(inp.grad for inp in ref_tensor_inputs))
+    
+    for (nv_out, ref_out) in zip(nv_outputs, ref_outputs):
+        torch.testing.assert_close(nv_out, ref_out)
+    
+            
+        
+


### PR DESCRIPTION
This PR:
1. Adds SDPA operator for nvFuser -- currently it is behind the `nv_enable_sdpa=True` compile flag, and only supports flash attention.
2. Moves `register_operator` to `Executor` class to allow use for `nvFuserExecutor`.
3. Moves some common utility functions from `sdpaex.py` to `utils.py`

The motivation behind this operator is to support multi-GPU development in nvFuser. At present, we do not have plans to generate code for this operator. It will be executed through ATen fallback path in nvFuser.

See https://github.com/NVIDIA/Fuser/issues/2278 for discussions.

CC: @jjsjann123 @wujingyue 
