### PR TITLE
improve name assignment

### DIFF
--- a/thunder/tests/test_core.py
+++ b/thunder/tests/test_core.py
@@ -2892,7 +2892,8 @@ def test_proxy_repr():
 
 def test_type_string():
     def fn(x):
-        return 2 * x
+        result = 2 * x
+        return result
 
     jfn = thunder.jit(fn)
 

--- a/thunder/tests/test_jit_general.py
+++ b/thunder/tests/test_jit_general.py
@@ -697,6 +697,9 @@ def test_litgpt_variants(name, device):
     actual_logits = tom(x)
     assert_close(actual_logits, expected_logits)
 
+    # small check that we do not leak internal var names
+    assert "tos" not in str(thunder.last_prologue_traces(tom)[0])
+
     actual_logits.sum().backward()
 
     for param1, param2 in zip(reference.parameters(), model.parameters()):

--- a/thunder/tests/test_nvfuser.py
+++ b/thunder/tests/test_nvfuser.py
@@ -366,23 +366,23 @@ def test_cse_rematerialization(executor, device, _):
     # Nvfuser with recomputation should use precomputed cos and sin values.
     assert len(fusion_bsyms[1].args) == len(fusion_bsyms[6].args)
 
-    # Below, we check that freqs_sin and tos1 (the latter being freqs_cos) are used
+    # Below, we check that freqs_sin and freqs_cos are used
     # in the same operation in both fusions.
     (fusion1_freqs_sin_arg,) = (a for a in fusion_bsyms[1].args if a.name == "freqs_sin")
-    (fusion1_tos1_arg,) = (a for a in fusion_bsyms[1].args if a.name == "tos1")
+    (fusion1_freqs_cos_arg,) = (a for a in fusion_bsyms[1].args if a.name == "freqs_cos")
     (fusion6_freqs_sin_arg,) = (a for a in fusion_bsyms[6].args if a.name == "freqs_sin")
-    (fusion6_tos1_arg,) = (a for a in fusion_bsyms[6].args if a.name == "tos1")
+    (fusion6_freqs_cos_arg,) = (a for a in fusion_bsyms[6].args if a.name == "freqs_cos")
 
     (fusion1_freqs_sin_user,) = (s for s in fusion_bsyms[1].subsymbols if s.args[0] is fusion1_freqs_sin_arg)
     (fusion6_freqs_sin_user,) = (s for s in fusion_bsyms[6].subsymbols if s.args[0] is fusion6_freqs_sin_arg)
 
     assert fusion1_freqs_sin_user.sym is fusion6_freqs_sin_user.sym
     assert fusion1_freqs_sin_user.args[1:] == fusion6_freqs_sin_user.args[1:]
-    (fusion1_tos1_user,) = (s for s in fusion_bsyms[1].subsymbols if s.args[0] is fusion1_tos1_arg)
-    (fusion6_tos1_user,) = (s for s in fusion_bsyms[6].subsymbols if s.args[0] is fusion1_tos1_arg)
+    (fusion1_freqs_cos_user,) = (s for s in fusion_bsyms[1].subsymbols if s.args[0] is fusion1_freqs_cos_arg)
+    (fusion6_freqs_cos_user,) = (s for s in fusion_bsyms[6].subsymbols if s.args[0] is fusion1_freqs_cos_arg)
 
-    assert fusion1_tos1_user.sym is fusion6_tos1_user.sym
-    assert fusion1_tos1_user.args[1:] == fusion6_tos1_user.args[1:]
+    assert fusion1_freqs_cos_user.sym is fusion6_freqs_cos_user.sym
+    assert fusion1_freqs_cos_user.args[1:] == fusion6_freqs_cos_user.args[1:]
 
 
 # Tests that two separated nvFuser regions can be merged when they don't depend


### PR DESCRIPTION
One of the fundamentals of variables is that they are stored before they're loaded.
This can happen implicitly in the setup of frames or explicitly through `STORE_FAST` (for locals).

This PR does two things:
- it looks at assigning names when variables are set. This implicitly prefers outer scopes for variables that are passed to calls, which is good.
- as we also have occasions where the variable is not passed to calls but obtained otherwise, we avoid internal functions (e.g. when a variable is obtained though an attribute or item lookup).

Quite likely, it would be even better to make a stronger preference for outer scopes, maybe by overwriting name assignments if the stack depth of the current assignment is smaller than the previous one. I'll leave that for the next PR though.
