### PR TITLE
Fix type_as

### DIFF
--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -2959,12 +2959,11 @@ def type_as_sample_generator(op, device, dtype, requires_grad, **kwargs):
         (1, 2, 3),
     )
 
-    other_dev = "cpu" if device == "cuda" else "cuda"
     for a_shape, b_shape in itertools.product(shapes, shapes):
         yield SampleInput(make(a_shape), make(b_shape))
         yield SampleInput(make(a_shape), make(b_shape, dtype=torch.float32))
         # Tests when inputs from different devices
-        yield SampleInput(make(a_shape), make(b_shape, device=other_dev))
+        yield SampleInput(make(a_shape), make(b_shape, device="cpu"))
 
 
 type_as_sample = OpInfo(

--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -2959,9 +2959,12 @@ def type_as_sample_generator(op, device, dtype, requires_grad, **kwargs):
         (1, 2, 3),
     )
 
+    other_dev = "cpu" if device == "cuda" else "cuda"
     for a_shape, b_shape in itertools.product(shapes, shapes):
         yield SampleInput(make(a_shape), make(b_shape))
         yield SampleInput(make(a_shape), make(b_shape, dtype=torch.float32))
+        # Tests when inputs from different devices
+        yield SampleInput(make(a_shape), make(b_shape, device=other_dev))
 
 
 type_as_sample = OpInfo(

--- a/thunder/tests/test_grad.py
+++ b/thunder/tests/test_grad.py
@@ -487,7 +487,9 @@ def test_vjp_correctness_type_as_manual(op, device, dtype, executor, comp):
         # Compute vjp result using Thunder
         flat_op, flat_args, spec = flatten_func(op.op, sample.args, sample.kwargs)
         filtered_op, filtered_args = _make_differentiable_wrapper(flat_op, flat_args)
-        actual_out = executor.make_callable_legacy(vjp(filtered_op), disable_torch_autograd=True)(filtered_args, (v,))
+        actual_out = executor.make_callable_legacy(vjp(filtered_op), disable_torch_autograd_support=True)(
+            filtered_args, (v,)
+        )
         comp(actual_out[1][0], expected[0])
         comp(actual_out[0], out)
 

--- a/thunder/tests/test_grad.py
+++ b/thunder/tests/test_grad.py
@@ -487,9 +487,7 @@ def test_vjp_correctness_type_as_manual(op, device, dtype, executor, comp):
         # Compute vjp result using Thunder
         flat_op, flat_args, spec = flatten_func(op.op, sample.args, sample.kwargs)
         filtered_op, filtered_args = _make_differentiable_wrapper(flat_op, flat_args)
-        actual_out = executor.make_callable_legacy(
-            vjp(filtered_op), disable_torch_autograd=True
-        )(filtered_args, (v,))
+        actual_out = executor.make_callable_legacy(vjp(filtered_op), disable_torch_autograd=True)(filtered_args, (v,))
         comp(actual_out[1][0], expected[0])
         comp(actual_out[0], out)
 

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -520,7 +520,7 @@ def type_as(a: TensorProxy, b: TensorProxy, /) -> TensorProxy:
     #   tensors and TensorProxies being passed to this operation
     utils.check_type(b, TensorProxy)
 
-    return to(a, b.true_dtype)
+    return to(a, b.true_dtype, device=b.device)
 
 
 @torchsymbol(torch.Tensor.long, is_method=True)


### PR DESCRIPTION
## What does this PR do?

Fixes #962.

Thunder behaves differently in torch.Tensor.type_as when inputting a cpu and a cuda tensor
