### PR TITLE
Add Inductor (torch.compile) concatenation executor to the default list of executors

### DIFF
--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -175,13 +175,17 @@ get_always_executors = extend.get_always_executors
 
 cudnn_executor: None | extend.Executor = extend.get_executor("cudnn")
 sdpa_executor: None | extend.Executor = extend.get_executor("sdpa")
+torchcompile_cat_executor: None | extend.Executor = extend.get_executor("torchcompile_cat")
 nvfuser_executor: None | extend.Executor = extend.get_executor("nvfuser")
 pytorch_executor: None | extend.Executor = extend.get_executor("torch")
 
-# Default executor list is [cudnn -> sdpa -> nvfuser -> torch -> python]
+# Default executor list is [cudnn -> sdpa -> torchcompile_cat -> nvfuser -> torch -> python]
 # Note that add_default_executor inserts executor at start of list, hence the reverse order below.
 if nvfuser_executor:
     add_default_executor(nvfuser_executor)
+
+if torchcompile_cat_executor:
+    add_default_executor(torchcompile_cat_executor)
 
 if sdpa_executor:
     add_default_executor(sdpa_executor)

--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -184,7 +184,7 @@ pytorch_executor: None | extend.Executor = extend.get_executor("torch")
 if nvfuser_executor:
     add_default_executor(nvfuser_executor)
 
-if torchcompile_cat_executor:
+if torchcompile_cat_executor and pytorch._dynamo.is_inductor_supported():
     add_default_executor(torchcompile_cat_executor)
 
 if sdpa_executor:

--- a/thunder/executors/torch_compile.py
+++ b/thunder/executors/torch_compile.py
@@ -200,8 +200,6 @@ from thunder.executors.torchex import ex as pytorch_ex
 required_ops = {
     "torch.cat",
     prims.cat.id,
-    prims.pad.id,
-    prims.slice_prim.id,
 }
 torch_compile_cat_ex = TorchCompileExecutor(name="torchcompile_cat", required_ops=required_ops)
 register_executor(torch_compile_cat_ex)

--- a/thunder/executors/torch_compile.py
+++ b/thunder/executors/torch_compile.py
@@ -203,7 +203,22 @@ required_ops = {
 }
 torch_compile_cat_ex = TorchCompileExecutor(name="torchcompile_cat", required_ops=required_ops)
 register_executor(torch_compile_cat_ex)
-torch_compile_cat_ex._implmap = {op: ImplInfo() for op in pytorch_ex.implmap}
+# TODO: Carefully enable more ops checking that they do improve performance
+supported_ops = {
+    "torch.split",
+    prims.add.id,
+    prims.broadcast_in_dim.id,
+    prims.cat.id,
+    prims.convert_element_type.id,
+    prims.full.id,
+    prims.mul.id,
+    prims.neg.id,
+    prims.pad.id,
+    prims.reshape.id,
+    prims.slice_prim.id,
+    prims.transpose.id,
+}
+torch_compile_cat_ex._implmap = {op: ImplInfo() for op in pytorch_ex.implmap if op in supported_ops}
 
 
 torch_compile_ex = TorchCompileExecutor(name="torchcompile")

--- a/thunder/executors/torch_compile.py
+++ b/thunder/executors/torch_compile.py
@@ -230,7 +230,9 @@ supported_ops = {
     prims.slice_prim.id,
     prims.transpose.id,
 }
-torch_compile_cat_ex._implmap = {op: ImplInfo(checker=cuda_device_checker) for op in pytorch_ex.implmap if op in supported_ops}
+torch_compile_cat_ex._implmap = {
+    op: ImplInfo(checker=cuda_device_checker) for op in pytorch_ex.implmap if op in supported_ops
+}
 
 
 torch_compile_ex = TorchCompileExecutor(name="torchcompile")

--- a/thunder/executors/torch_compile.py
+++ b/thunder/executors/torch_compile.py
@@ -203,22 +203,7 @@ required_ops = {
 }
 torch_compile_cat_ex = TorchCompileExecutor(name="torchcompile_cat", required_ops=required_ops)
 register_executor(torch_compile_cat_ex)
-# TODO: Carefully enable more ops checking that they do improve performance
-supported_ops = {
-    "torch.split",
-    prims.add.id,
-    prims.broadcast_in_dim.id,
-    prims.cat.id,
-    prims.convert_element_type.id,
-    prims.full.id,
-    prims.mul.id,
-    prims.neg.id,
-    prims.pad.id,
-    prims.reshape.id,
-    prims.slice_prim.id,
-    prims.transpose.id,
-}
-torch_compile_cat_ex._implmap = {op: ImplInfo() for op in pytorch_ex.implmap if op in supported_ops}
+torch_compile_cat_ex._implmap = {op: ImplInfo() for op in pytorch_ex.implmap}
 
 
 torch_compile_ex = TorchCompileExecutor(name="torchcompile")

--- a/thunder/executors/torch_compile.py
+++ b/thunder/executors/torch_compile.py
@@ -206,6 +206,7 @@ register_executor(torch_compile_cat_ex)
 # TODO: Carefully enable more ops checking that they do improve performance
 supported_ops = {
     "torch.split",
+    "torch.sum",
     prims.add.id,
     prims.broadcast_in_dim.id,
     prims.cat.id,

--- a/thunder/executors/torch_compile.py
+++ b/thunder/executors/torch_compile.py
@@ -7,11 +7,12 @@ import torch
 from lightning_utilities import compare_version
 
 from thunder.core import prims, utils
-from thunder.core.proxies import Proxy, unvariableify, Variable
+from thunder.core.proxies import Proxy, TensorProxy, unvariableify, Variable
 from thunder.core.rematerialization import rematerialize
 from thunder.core.symbol import BoundSymbol, Symbol
 from thunder.core.trace import from_trace, TraceCtx, TraceProvenance
 from thunder.core.transform_common import dce
+from thunder.core.pytree import tree_flatten
 from thunder.executors.passes import update_fusion_call_ctx
 from thunder.executors.utils import Region
 from thunder.extend import FusionExecutor, register_executor, ImplInfo
@@ -190,6 +191,16 @@ class TorchCompileExecutor(FusionExecutor):
 from thunder.executors.torchex import ex as pytorch_ex
 
 
+def cuda_device_checker(*args, **kwargs):
+    # We only want to compile if all the TensorProxy arguments are on the GPU
+    flat_args, _ = tree_flatten((args, kwargs))
+    flat_tensorproxy_args = [x for x in flat_args if isinstance(x, TensorProxy)]
+    for arg in flat_tensorproxy_args:
+        if arg.device.type != "cuda":
+            return False
+    return True
+
+
 # NOTE: [torch_compile_cat_ex vs torch_compile_ex]
 # The former only relies on `torch.compile` for the operators where it shines the most and is meant to be used
 # together with the nvfuser executor. Its current goal is only to fuse RoPE but the set of ops fused will change as each
@@ -219,7 +230,7 @@ supported_ops = {
     prims.slice_prim.id,
     prims.transpose.id,
 }
-torch_compile_cat_ex._implmap = {op: ImplInfo() for op in pytorch_ex.implmap if op in supported_ops}
+torch_compile_cat_ex._implmap = {op: ImplInfo(checker=cuda_device_checker) for op in pytorch_ex.implmap if op in supported_ops}
 
 
 torch_compile_ex = TorchCompileExecutor(name="torchcompile")

--- a/thunder/tests/test_torch_compile_executor.py
+++ b/thunder/tests/test_torch_compile_executor.py
@@ -3,7 +3,7 @@ import torch
 from torch._dynamo import is_inductor_supported
 
 import thunder
-from thunder.executors.torch_compile import torch_compile_ex, torch_compile_cat_ex
+from thunder.executors.torch_compile import supported_ops, torch_compile_ex, torch_compile_cat_ex
 from thunder.executors.torchex import ex as pytorch_ex
 from thunder.executors.nvfuserex import nvfuserex
 from thunder.tests.bf16 import device_supports_bf16

--- a/thunder/tests/test_torch_compile_executor.py
+++ b/thunder/tests/test_torch_compile_executor.py
@@ -58,7 +58,7 @@ def test_torch_compile_cat_rope_single_fusion():
         requires_grad=True,
     )
 
-    jfn = thunder.jit(bench.fn(), executors=[torch_compile_cat_ex])
+    jfn = thunder.jit(bench.fn(), executors=[torch_compile_cat_ex, nvfuserex])
     args, kwargs = bench.make_batch()
     jfn(*args, **kwargs)
     forward_execution_trace = thunder.last_traces(jfn)[-1]

--- a/thunder/tests/test_torch_compile_executor.py
+++ b/thunder/tests/test_torch_compile_executor.py
@@ -46,7 +46,9 @@ def test_torch_compile_cat_nvfuser_phi2_tanh():
     logits.sum().backward()
 
 
+@pytest.mark.skipif(not is_inductor_supported(), reason="inductor unsupported")
 @requiresCUDA
+@pytest.mark.skipif(not device_supports_bf16(torch.device("cuda")), reason="bf16 is not supported")
 def test_torch_compile_cat_rope_single_fusion():
     from thunder.benchmarks import LlamaQKVSplitRopeBenchmark
     from thunder.examine import get_fusions

--- a/thunder/tests/test_torch_compile_executor.py
+++ b/thunder/tests/test_torch_compile_executor.py
@@ -63,6 +63,8 @@ def test_torch_compile_cat_rope_single_fusion():
     jfn(*args, **kwargs)
     forward_execution_trace = thunder.last_traces(jfn)[-1]
     assert len(get_fusions(forward_execution_trace)) == 1
+    assert len(forward_execution_trace.bound_symbols) == 5
 
     backward_execution_trace = thunder.last_backward_traces(jfn)[-1]
     assert len(get_fusions(backward_execution_trace)) == 1
+    assert len(backward_execution_trace.bound_symbols) == 14

--- a/thunder/tests/test_torch_compile_executor.py
+++ b/thunder/tests/test_torch_compile_executor.py
@@ -46,6 +46,7 @@ def test_torch_compile_cat_nvfuser_phi2_tanh():
     logits.sum().backward()
 
 
+@requiresCUDA
 def test_torch_compile_cat_rope_single_fusion():
     from thunder.benchmarks import LlamaQKVSplitRopeBenchmark
     from thunder.examine import get_fusions


### PR DESCRIPTION
We should use an Inductor-based concatenation executor (through torch.compile) by default since it gives us a perf improvement for sections of the network that include the `torch.cat` operation (mainly RoPE). Previously we didn't enable it by default because there were memory leaks that were fixed (see https://github.com/Lightning-AI/lit-thunder-LEGACY/issues/2194 if you have access).

In addition, this PR also avoids hitting a problem with nvFuser (https://github.com/NVIDIA/Fuser/issues/2792). The backward of RoPE was generating a nvFuser fusion in between TorchCompile region because the torchcompile_cat executor wasn't marked to be able to execute `torch.sum`. I also added a test that verifies that only one fusion region is created.
In the (NVIDIA-internal) Mixology dashboard Llama-3-8B, Mistral-7B-v0.1, and stablecode-completion-alpha-3b models do not work with Thunder + Inductor concatenation executor and this problem should be fixed in this PR (cc @apaz-cli @mpatel31415).