### PR TITLE
Add function to query the set of auto-registered torch operators on jitted function

### DIFF
--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -1019,7 +1019,7 @@ def print_auto_registered_torch_ops(fn: Callable, /) -> set[str] | None:
     op_names = set()
     trc = last_traces(fn)[0]
     for bsym in trc.bound_symbols:
-        if (meta_func_name := getattr(bsym.sym.meta, "__name__", None)) and meta_func_name == "meta_func":
+        if getattr(bsym.sym.meta, "__name__", None) == "meta_func":
             op_names.add(bsym.sym.id)
     return op_names if op_names else None
 

--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -1014,6 +1014,16 @@ def last_compile_options(fn: Callable, /) -> None:
         print(f"\t{option}")
 
 
+def print_auto_registered_torch_ops(fn: Callable, /) -> set[str] | None:
+    """Returns a set of auto-registered Torch operator names present in the given JIT-compiled function."""
+    op_names = set()
+    trc = last_traces(fn)[0]
+    for bsym in trc.bound_symbols:
+        if (meta_func_name := getattr(bsym.sym.meta, "__name__", None)) and meta_func_name == "meta_func":
+            op_names.add(bsym.sym.id)
+    return op_names if op_names else None
+
+
 # TODO (mruberry) Update this
 def _grad_transform(trace):
     grad_fwd_trace = from_trace(trace)

--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -1015,7 +1015,7 @@ def last_compile_options(fn: Callable, /) -> None:
         print(f"\t{option}")
 
 
-def get_auto_registered_torch_ops(fn: Callable, /) -> set[str] | None:
+def get_auto_registered_torch_op_names(fn: Callable, /) -> set[str] | None:
     """Returns a set of auto-registered Torch operator names present in the given JIT-compiled function."""
     op_names = set()
     trc = last_traces(fn)[0]

--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -1017,10 +1017,8 @@ def last_compile_options(fn: Callable, /) -> None:
 
 def get_auto_registered_torch_op_names(fn: Callable, /) -> set[str] | None:
     """Returns a set of auto-registered Torch operator names present in the given JIT-compiled function."""
-    op_names = set()
     trc = last_traces(fn)[0]
-    tuple(op_names.add(bsym.sym.id) for bsym in trc.bound_symbols if has_tags(bsym, {prims.OpTags.AUTO_REGISTERED}))
-    return op_names if op_names else None
+    return {bsym.sym.id for bsym in trc.bound_symbols if has_tags(bsym, {prims.OpTags.AUTO_REGISTERED})}
 
 
 # TODO (mruberry) Update this

--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -54,6 +54,7 @@ from thunder.extend import Executor, add_default_executor
 from thunder.core.compile_data import compile_data_and_stats, get_compile_data
 from thunder.core.langctxs import LanguageContext
 import thunder.core.langctxs as langctxs
+from thunder.core.symbol import has_tags
 from thunder.core.baseutils import run_once, check
 from thunder.core.codeutils import Positions
 from thunder.core.proxies import (
@@ -1014,13 +1015,11 @@ def last_compile_options(fn: Callable, /) -> None:
         print(f"\t{option}")
 
 
-def print_auto_registered_torch_ops(fn: Callable, /) -> set[str] | None:
+def get_auto_registered_torch_ops(fn: Callable, /) -> set[str] | None:
     """Returns a set of auto-registered Torch operator names present in the given JIT-compiled function."""
     op_names = set()
     trc = last_traces(fn)[0]
-    for bsym in trc.bound_symbols:
-        if getattr(bsym.sym.meta, "__name__", None) == "meta_func":
-            op_names.add(bsym.sym.id)
+    tuple(op_names.add(bsym.sym.id) for bsym in trc.bound_symbols if has_tags(bsym, {prims.OpTags.AUTO_REGISTERED}))
     return op_names if op_names else None
 
 

--- a/thunder/common.py
+++ b/thunder/common.py
@@ -86,7 +86,7 @@ class CompileStats:
         last_computation_execution_start (int):
         last_computation_execution_stop (int):
         cache (dict):
-        interpreter_cashe (list):
+        interpreter_cache (list):
         calls (int):
         cache_hits (int):
         cache_misses (int):

--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -282,6 +282,7 @@ class OpTags(Enum):
     # Labels operations that should not be removed by the dead code elimination (DCE) pass
     DONT_DCE = auto()
     IN_PLACE = auto()
+    AUTO_REGISTERED = auto()
 
 
 # TODO RC1 Document this function and describe the parts of a primitive

--- a/thunder/tests/test_auto_register_torchops.py
+++ b/thunder/tests/test_auto_register_torchops.py
@@ -8,7 +8,7 @@ import thunder.torch.default_torch_ops as ops
 from thunder.torch import _get_torch_function_name
 import torch
 
-from thunder.tests.framework import requiresCUDA, TorchExecutor
+from thunder.tests.framework import requiresCUDA, TorchExecutor, instantiate, NOTHING
 from thunder.tests.make_tensor import make_tensor
 from thunder.tests.opinfos import get_opinfo, OpInfo
 from thunder.tests.test_einops import skipIfNoCUDA
@@ -206,3 +206,22 @@ class TestFallbackToTorch:
         for op in _skip_ops_alexnet:
             vjp_op_name = f"{op.name}_vjp"
             assert any(bsym.sym.name == vjp_op_name for bsym in bwd_trcs[-1].bound_symbols)
+
+
+@instantiate(dtypes=NOTHING)
+def test_query_autoreg_ops(executor, device: str, _):
+    def fn(a):
+        x = torch.special.gammaln(torch.special.zeta(torch.special.gammaln(a), a))
+        return torch.special.erf(x)
+
+    def fn_none(a):
+        return torch.nn.functional.relu(a)
+
+    expected = ({"torch.special.erf", "torch.special.gammaln"}, None)
+    for fn, expect in zip((fn, fn_none), expected):
+        cfn = executor.make_callable(fn)
+
+        a = make_tensor((2, 2), device=device, dtype=torch.float32)
+        cfn(a)
+        ops = thunder.print_auto_registered_torch_ops(cfn)
+        assert expect == ops

--- a/thunder/tests/test_auto_register_torchops.py
+++ b/thunder/tests/test_auto_register_torchops.py
@@ -223,5 +223,5 @@ def test_query_autoreg_ops(executor, device: str, _):
 
         a = make_tensor((2, 2), device=device, dtype=torch.float32)
         cfn(a)
-        ops = thunder.get_auto_registered_torch_ops(cfn)
+        ops = thunder.get_auto_registered_torch_op_names(cfn)
         assert expect == ops

--- a/thunder/tests/test_auto_register_torchops.py
+++ b/thunder/tests/test_auto_register_torchops.py
@@ -223,5 +223,5 @@ def test_query_autoreg_ops(executor, device: str, _):
 
         a = make_tensor((2, 2), device=device, dtype=torch.float32)
         cfn(a)
-        ops = thunder.print_auto_registered_torch_ops(cfn)
+        ops = thunder.get_auto_registered_torch_ops(cfn)
         assert expect == ops

--- a/thunder/tests/test_auto_register_torchops.py
+++ b/thunder/tests/test_auto_register_torchops.py
@@ -217,7 +217,7 @@ def test_query_autoreg_ops(executor, device: str, _):
     def fn_none(a):
         return torch.nn.functional.relu(a)
 
-    expected = ({"torch.special.erf", "torch.special.gammaln"}, None)
+    expected = ({"torch.special.erf", "torch.special.gammaln"}, set())
     for fn, expect in zip((fn, fn_none), expected):
         cfn = executor.make_callable(fn)
 

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -5453,6 +5453,7 @@ def register_default_torch_op(torchfn: Callable, torch_module):
         name=torchfn_name,
         meta=_fn,
         id=f"{torch_module.__name__}.{torchfn_name}",
+        tags=(prims.OpTags.AUTO_REGISTERED,),
     )
     _torch_to_thunder_function_map[torchfn] = sym
     from thunder.executors.torchex import _always_executable, ex


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

As a follow up to #811, this PR added a query function `print_auto_registered_torch_ops(fn) -> set[str] | None` to retrieve the set of auto-registered torch ops based on the symbols in the trace

Requirement: Fix the bug about `torch.special` operators found along the way (https://github.com/Lightning-AI/lightning-thunder/pull/979)
