### PR TITLE
skip DDPTest unless >=2 GPUs

### DIFF
--- a/thunder/tests/distributed/test_ddp.py
+++ b/thunder/tests/distributed/test_ddp.py
@@ -51,8 +51,9 @@ from torch.testing._internal import common_utils
 
 
 @unittest.skipUnless(
-    torch.cuda.is_available() and torch.distributed.is_available() and torch.distributed.is_nccl_available(),
-    "DDP test requires CUDA and NCCL `torch.distributed` backend",
+    torch.cuda.is_available() and torch.distributed.is_available() and torch.distributed.is_nccl_available()
+    and torch.cuda.device_count() >= 2,
+    "DDP test requires CUDA and NCCL `torch.distributed` backend, and at least 2 GPUs",
 )
 class DDPTest(DistributedParallelTestCase):
     # Reference issue "Add an example of DDP(compile(model)) to tests"

--- a/thunder/tests/distributed/test_ddp.py
+++ b/thunder/tests/distributed/test_ddp.py
@@ -51,7 +51,9 @@ from torch.testing._internal import common_utils
 
 
 @unittest.skipUnless(
-    torch.cuda.is_available() and torch.distributed.is_available() and torch.distributed.is_nccl_available()
+    torch.cuda.is_available()
+    and torch.distributed.is_available()
+    and torch.distributed.is_nccl_available()
     and torch.cuda.device_count() >= 2,
     "DDP test requires CUDA and NCCL `torch.distributed` backend, and at least 2 GPUs",
 )


### PR DESCRIPTION
There are some "distributed" test failures, e.g. `thunder.tests.distributed.test_ddp.DDPTest.test_ddp_compile_module` detected in our CI on **single** GPU machines. That test passes correctly on multi-GPU nodes. Since it says it's DDP test, it should be skipped on nodes without enough GPUs.

This PR skips DDPTest unless `torch.cuda.device_count() >= 2`

