### PR TITLE
Register `copy_`s as return's `BoundSymbol._additional_dependencies`

### DIFF
--- a/thunder/core/functionalization.py
+++ b/thunder/core/functionalization.py
@@ -572,7 +572,7 @@ def apply_functionalization_to_canonicalized_trace(
                 copy_outputs.append(copy_bsym.flat_proxy_outs[0])
 
     return_bsym = new_bsyms[-1].from_bsym_swap_proxies(swap_map_for_return)
-    return_bsym._hidden_dependencies += tuple(copy_outputs)
+    return_bsym._additional_dependencies += tuple(copy_outputs)
     functionalized_bsyms.append(return_bsym)
 
     functionalized_computation_trace.bound_symbols = functionalized_bsyms

--- a/thunder/core/functionalization.py
+++ b/thunder/core/functionalization.py
@@ -537,7 +537,7 @@ def apply_functionalization_to_canonicalized_trace(
     # obviated by the functionalization above.
     consumer_map_of_functionalized_bsyms = consumers(new_bsyms)
     producer_map_of_functionalized_bsyms = producers(new_bsyms)
-    bsym_to_copy_bsyms: dict[BoundSymbol, list[BoundSymbol]] = defaultdict(list)
+    bsym_to_copy_bsyms: dict[BoundSymbol, list[list[BoundSymbol]]] = defaultdict(list)
     for var_copy_from, copy_bsyms in copy_from_to_copy_bsyms.items():
         copy_from = unvariableify(var_copy_from)
         key_bsym: BoundSymbol = producer_map_of_functionalized_bsyms[copy_from]
@@ -554,20 +554,26 @@ def apply_functionalization_to_canonicalized_trace(
                     lambda: f"Unexpected `prims.copy_` found in {[bsym.sym for bsym in consumer_bsyms]} for {var_copy_from}",
                 )
                 key_bsym = consumer_bsyms[-1]
-        bsym_to_copy_bsyms[key_bsym].extend(copy_bsyms)
+        bsym_to_copy_bsyms[key_bsym].append(copy_bsyms)
 
     functionalized_computation_trace = from_trace(canonicalized_trace)
     functionalized_computation_trace.set_provenance(TraceProvenance("Functionalize in-place ops"))
 
     swap_map_for_return: dict[VariableInterface, TensorProxy] = {}
     functionalized_bsyms: list[BoundSymbol] = []
+    copy_outputs: list[TensorProxy] = []
     for bsym in new_bsyms[:-1]:
         functionalized_bsyms.append(bsym)
         if bsym in bsym_to_copy_bsyms:
-            functionalized_bsyms.extend(bsym_to_copy_bsyms[bsym])
-            copy_bsym = functionalized_bsyms[-1]
-            swap_map_for_return[variableify(copy_bsym.flat_proxy_args[0])] = copy_bsym.flat_proxy_args[1]
-    functionalized_bsyms.append(new_bsyms[-1].from_bsym_swap_proxies(swap_map_for_return))
+            for copy_bsyms in bsym_to_copy_bsyms[bsym]:
+                functionalized_bsyms.extend(copy_bsyms)
+                copy_bsym = functionalized_bsyms[-1]
+                swap_map_for_return[variableify(copy_bsym.flat_proxy_args[0])] = copy_bsym.flat_proxy_args[1]
+                copy_outputs.append(copy_bsym.flat_proxy_outs[0])
+
+    return_bsym = new_bsyms[-1].from_bsym_swap_proxies(swap_map_for_return)
+    return_bsym._hidden_dependencies += tuple(copy_outputs)
+    functionalized_bsyms.append(return_bsym)
 
     functionalized_computation_trace.bound_symbols = functionalized_bsyms
     return functionalized_computation_trace

--- a/thunder/core/functionalization.py
+++ b/thunder/core/functionalization.py
@@ -298,6 +298,7 @@ def create_functional_bsym_from(inplace_bsym: BoundSymbol) -> BoundSymbol:
         output=inplace_bsym.output,
         subsymbols=inplace_bsym.subsymbols,
         _call_ctx=inplace_bsym._call_ctx,
+        _additional_dependencies=inplace_bsym._additional_dependencies,
     )
     if functional_bsym.subsymbols[-1].sym.id == prims.PrimIDs.COPY_:
         functional_bsym.subsymbols = functional_bsym.subsymbols[:-1]

--- a/thunder/core/symbol.py
+++ b/thunder/core/symbol.py
@@ -366,9 +366,12 @@ class BoundSymbol(BoundSymbolInterface):
     _object_ctx: dict = field(default_factory=dict)
     _executor: None | Any = None
 
-    # Only used by prims.python_return
-    # prims.copy_'s must be placed before the return statement
-    _copy_outputs_before_return: Sequence[BoundSymbol] = ()
+    # BoundSymbols may later be reordered and grouped into regions for fusion.
+    # This reordering consideres bsym.flat_proxy_args as bsym's dependencies and place them before bsym itself.
+    # This includes bsym._additional_dependencies in addition to bsym.args and kwargs.
+    # e.g. functionalization registeres prims.copy_'s output as prims.python_return's additional dependency
+    # so that the copy happens before returning.
+    _additional_dependencies: Sequence[BoundSymbol] = ()
 
     # The line number of the bound symbol
     # NOTE This is only intended for internal use, and should be set explicitly on all BoundSymbols
@@ -399,7 +402,7 @@ class BoundSymbol(BoundSymbolInterface):
             "_import_ctx": self._import_ctx,
             "_object_ctx": self._object_ctx,
             "_executor": self._executor,
-            "_copy_outputs_before_return": self._copy_outputs_before_return,
+            "_additional_dependencies": self._additional_dependencies,
         }
 
         self_kwargs.update(kwargs)

--- a/thunder/core/symbol.py
+++ b/thunder/core/symbol.py
@@ -477,6 +477,7 @@ class BoundSymbol(BoundSymbolInterface):
 
         nargs = swap(self.args) if not skip_inputs else self.args
         nkwargs = swap(self.kwargs) if not skip_inputs else self.kwargs
+        new_additional_deps = swap(self._additional_dependencies) if not skip_inputs else self._additional_dependencies
 
         new_output = swap(self.output) if not skip_output else self.output
 
@@ -488,14 +489,20 @@ class BoundSymbol(BoundSymbolInterface):
         else:
             subsymbols = list(self.subsymbols)
 
-        return self.from_bsym(args=nargs, kwargs=nkwargs, output=new_output, subsymbols=subsymbols)
+        return self.from_bsym(
+            args=nargs,
+            kwargs=nkwargs,
+            _additional_dependencies=new_additional_deps,
+            output=new_output,
+            subsymbols=subsymbols,
+        )
 
     # Only used by prims.python_return
     # NOTE Making these cached properties relies on the assumption that the inputs to come before the return statement
 
     @functools.cached_property
     def flat_args_and_spec(self):
-        return tree_flatten_with_dataclass((self.args, self.kwargs, self._copy_outputs_before_return))
+        return tree_flatten_with_dataclass((self.args, self.kwargs, self._additional_dependencies))
 
     @functools.cached_property
     def flat_args(self):

--- a/thunder/core/symbol.py
+++ b/thunder/core/symbol.py
@@ -366,6 +366,10 @@ class BoundSymbol(BoundSymbolInterface):
     _object_ctx: dict = field(default_factory=dict)
     _executor: None | Any = None
 
+    # e.g. prims.copy_'s must happen before prims.python_return,
+    # not just the value it returns
+    _hidden_dependencies: Sequence[BoundSymbol] = ()
+
     # The line number of the bound symbol
     # NOTE This is only intended for internal use, and should be set explicitly on all BoundSymbols
     #   being analyzed before use, since it may have been set by previous passes, too
@@ -395,6 +399,7 @@ class BoundSymbol(BoundSymbolInterface):
             "_import_ctx": self._import_ctx,
             "_object_ctx": self._object_ctx,
             "_executor": self._executor,
+            "_hidden_dependencies": self._hidden_dependencies,
         }
 
         self_kwargs.update(kwargs)
@@ -487,7 +492,7 @@ class BoundSymbol(BoundSymbolInterface):
 
     @functools.cached_property
     def flat_args_and_spec(self):
-        return tree_flatten_with_dataclass((self.args, self.kwargs))
+        return tree_flatten_with_dataclass((self.args, self.kwargs, self._hidden_dependencies))
 
     @functools.cached_property
     def flat_args(self):

--- a/thunder/core/symbol.py
+++ b/thunder/core/symbol.py
@@ -497,8 +497,8 @@ class BoundSymbol(BoundSymbolInterface):
             subsymbols=subsymbols,
         )
 
-    # Only used by prims.python_return
-    # NOTE Making these cached properties relies on the assumption that the inputs to come before the return statement
+    # NOTE Making these cached properties relies on the assumption that the inputs to and output of a BoundSymbol
+    #   are immutable
 
     @functools.cached_property
     def flat_args_and_spec(self):

--- a/thunder/core/symbol.py
+++ b/thunder/core/symbol.py
@@ -254,7 +254,9 @@ class Symbol:
         return ba.args, ba.kwargs
 
     # TODO Remove _call_ctx
-    def bind(self, *args, output, subsymbols=(), _call_ctx: None | dict = None, **kwargs) -> BoundSymbol:
+    def bind(
+        self, *args, output, subsymbols=(), _call_ctx: None | dict = None, _additional_dependencies=(), **kwargs
+    ) -> BoundSymbol:
         if self.meta is not None:
             args, kwargs = self.normalize(*args, **kwargs)
 
@@ -276,6 +278,7 @@ class Symbol:
             source_filename=source_filename,
             source_positions=source_positions,
             _call_ctx=_call_ctx,
+            _additional_dependencies=_additional_dependencies,
         )
         if self._bind_postprocess:
             self._bind_postprocess(b)

--- a/thunder/core/transform_common.py
+++ b/thunder/core/transform_common.py
@@ -393,8 +393,8 @@ def order_proxies(bsyms: Sequence[BoundSymbol]) -> dict[str, int]:
             if len(bsym.subsymbols) > 0:
                 process_bound_symbols(bsym.subsymbols)
             # should kwargs be sorted by name?
-            for p in tree_iter((bsym.args, bsym.kwargs, bsym._hidden_dependencies, bsym.output)):
-                if isinstance(p, thunder.Proxy) and p.name not in proxy_order:
+            for p in tree_iter((bsym.flat_proxy_args, bsym.flat_proxy_outs)):
+                if p.name not in proxy_order:
                     counter += 1
                     proxy_order[p.name] = counter
 

--- a/thunder/core/transform_common.py
+++ b/thunder/core/transform_common.py
@@ -392,7 +392,8 @@ def order_proxies(bsyms: Sequence[BoundSymbol]) -> dict[str, int]:
         for bsym in bound_symbols:
             if len(bsym.subsymbols) > 0:
                 process_bound_symbols(bsym.subsymbols)
-            for p in tree_iter((bsym.args, bsym.kwargs, bsym.output)):  # should kwargs be sorted by name?
+            # should kwargs be sorted by name?
+            for p in tree_iter((bsym.args, bsym.kwargs, bsym._hidden_dependencies, bsym.output)):
                 if isinstance(p, thunder.Proxy) and p.name not in proxy_order:
                     counter += 1
                     proxy_order[p.name] = counter

--- a/thunder/dev_utils/debug_transform.py
+++ b/thunder/dev_utils/debug_transform.py
@@ -13,7 +13,12 @@ def create_debug_boundsymbol(name: str, bsym: BoundSymbol, call_ctx: Callable):
         debug_bsym._call_ctx = {name: partial(call_ctx, debug_bsym, bsym)}
 
     debug_sym = Symbol(name, lambda *_: None, is_prim=True, _bind_postprocess=bind_postprocess)
-    debug_bsym = debug_sym.bind(*bsym.args, output=None, **bsym.kwargs)
+    debug_bsym = debug_sym.bind(
+        *bsym.args,
+        **bsym.kwargs,
+        output=None,
+        _additional_dependencies=bsym._additional_dependencies,
+    )
     return debug_bsym
 
 

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -723,7 +723,9 @@ class nvFuserExecutor(FusionExecutor):
         return_bsym = cse_trace.bound_symbols[-1]
         assert return_bsym.sym.id == prims.PrimIDs.RETURN
         trace_output = tree_map(map_redundant, return_bsym.args)
-        cse_trace.bound_symbols[-1] = prims.python_return.bind(*trace_output, output=())
+        cse_trace.bound_symbols[-1] = prims.python_return.bind(
+            *trace_output, output=(), _additional_dependencies=return_bsym._additional_dependencies
+        )
 
         end_time_ns = time.perf_counter_ns()
         elapsed_time_ns = end_time_ns - start_time_ns


### PR DESCRIPTION
Rewrites #936. Fixes #912. Fixes #930.

Based on a message from @IvanYashchuk 