### PR TITLE
[benchmark] add option to use torchao's float8 of dynamic scaling with fsdp2

### DIFF
--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -358,9 +358,9 @@ class Benchmark_litGPT:
         with init_device:
             model = GPT(self.config)
         if self.distributed_mode == "fsdp2":
-            model.to(dtype=torch.bfloat16)
-        else:
             warnings.warn(f"Parameters are kept in float32 as {self.distributed_mode=}")
+        else:
+            model.to(dtype=torch.bfloat16)
         model = self._torchao_fp8_handler.convert_model_to_fp8(model)
         return model
 

--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -357,8 +357,14 @@ class Benchmark_litGPT:
             init_device = torch.device("meta")
         with init_device:
             model = GPT(self.config)
-        if self.distributed_mode == "fsdp2":
-            warnings.warn(f"Parameters are kept in float32 as {self.distributed_mode=}")
+        if (
+            self.distributed_mode == "fsdp2"
+            and self._torchao_fp8_handler._enabled
+            and self._torchao_fp8_handler.precompute_scale
+        ):
+            warnings.warn(
+                f"Parameters are kept in float32 as {self.distributed_mode=} and fp8 dynamic scaling precompute is enabled"
+            )
         else:
             model.to(dtype=torch.bfloat16)
         model = self._torchao_fp8_handler.convert_model_to_fp8(model)

--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -357,6 +357,7 @@ class Benchmark_litGPT:
             init_device = torch.device("meta")
         with init_device:
             model = GPT(self.config)
+        # TODO(crcrpar): Remove this guard once https://github.com/pytorch/ao/pull/713 is merged
         if (
             self.distributed_mode == "fsdp2"
             and self._torchao_fp8_handler._enabled

--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -768,6 +768,15 @@ def benchmark_main(return_metrics_as_json=False, json_path="", **kwargs) -> None
             print(f"DDP Bucketing Size: {benchmark.ddp_bucket_size} MB")
         print(f"Compiler: {benchmark.compile}")
         print(f"Low Precision Mode: {benchmark.low_precision_mode}")
+        if benchmark._torchao_fp8_handler._enabled:
+            msg = "linear"
+            if benchmark._torchao_fp8_handler.use_fp8_allgather:
+                msg += ", all-gather"
+            if benchmark._torchao_fp8_handler.precompute_scale:
+                msg += ", single all-reduce of AMAX/scales for dynamic scaling"
+            msg += " are enabled"
+            print(f"[torchao float8] {msg}")
+
         print(f"Average iter time: {benchmark.perf_metrics['average_iter_time']:.2f} ms")
         print(f"Memory used: {benchmark.perf_metrics['memory_used_GB']:.02f} GB")
         print(f"Tokens/s: {benchmark.perf_metrics['tokens_per_sec']:.02f}")

--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -357,17 +357,7 @@ class Benchmark_litGPT:
             init_device = torch.device("meta")
         with init_device:
             model = GPT(self.config)
-        # TODO(crcrpar): Remove this guard once https://github.com/pytorch/ao/pull/713 is merged
-        if (
-            self.distributed_mode == "fsdp2"
-            and self._torchao_fp8_handler._enabled
-            and self._torchao_fp8_handler.precompute_scale
-        ):
-            warnings.warn(
-                f"Parameters are kept in float32 as {self.distributed_mode=} and fp8 dynamic scaling precompute is enabled"
-            )
-        else:
-            model.to(dtype=torch.bfloat16)
+        model.to(dtype=torch.bfloat16)
         model = self._torchao_fp8_handler.convert_model_to_fp8(model)
         return model
 

--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -357,10 +357,10 @@ class Benchmark_litGPT:
             init_device = torch.device("meta")
         with init_device:
             model = GPT(self.config)
-        if not getattr(self._torchao_fp8_handler, "_enabled", False):
+        if self.distributed_mode == "fsdp2":
             model.to(dtype=torch.bfloat16)
         else:
-            warnings.warn("Parameters are kept in float32 for torchao precompute fp8 dynamic scaling for fsdp2")
+            warnings.warn(f"Parameters are kept in float32 as {self.distributed_mode=}")
         model = self._torchao_fp8_handler.convert_model_to_fp8(model)
         return model
 

--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -108,8 +108,8 @@ class TorchAOFP8Handler:
         self._enabled = self.use_fp8_linear
         if not self._enabled:
             return
-        if torch.cuda.get_device_capability()[0] < 9:
-            raise ValueError(f"torchao float8 requires Hopper but {torch.cuda.get_device_capability()}")
+        if torch.cuda.get_device_capability() < (8, 9):
+            raise ValueError(f"torchao float8 requires {torch.cuda.get_device_capability()=} >= (8, 9)")
         self.fp8_linear_config = Float8LinearConfig(
             cast_config_input=CastConfig(ScalingType.DYNAMIC),
             cast_config_weight=CastConfig(ScalingType.DYNAMIC),


### PR DESCRIPTION
This adds an option to use float8 of [torchao](https://github.com/pytorch/ao).
An example command to use float8 with FSDP2:
```
torchrun --nproc-per-node 8 --local-ranks-filter 0 --role rank --tee 3 thunder/benchmarks/benchmark_litgpt.py --model_name Llama-2-7b-hf --compile inductor --distributed_mode fsdp2 --shard_mode zero2 --use_torchao_fp8_linear true --use_torchao_fp8_allgather true --use_torchao_fp8_precompute_scale_for_fsdp true
```

note that `--use_torchao_fp8_precompute_scale_for_fsdp true` keeps models in fp32.

## Llama-2-7b-hf on 8 H100, using pjnl-20240821

as of ff66203fdc94f6cb1ed16eacb73a2dc2b05790e2, torchao of https://github.com/pytorch/ao/pull/727/commits/a0376bfabc9a63f898a92349b1fc15e0922ca2a3

if compiler is torch, fsdp2 is used.

| compiler | executors                             | bs | Tokens/s/GPU | Memory Used |
|----------|---------------------------------------|----|--------------|-------------|
| torch    | fp8: linear, all-gather, & precompute | 1  | 14640.35     | 34.26       |
| torch    | fp8: linear, all-gather, & precompute | 2  | 17993.14     | 49.69       |
| torch    | fp8: linear & all-gather              | 1  | 14587.93     | 34.26       |
| torch    | fp8: linear & all-gather              | 2  | 17912.73     | 49.70       |
| torch    | fp8: linear                           | 1  | 13897.13     | 40.64       |
| torch    | fp8: linear                           | 2  | 17219.84     | 56.12       |
| torch    | thunder_inductor_cat_cudnn_dynamo     | 1  | 12506.03     | 40.21       |
| torch    | thunder_inductor_cat_cudnn_dynamo     | 2  | 13890.66     | 61.82       |
| thunder  | inductor_cat_cudnn_transformerengine  | 1  | 14274.20     | 52.88       |
| thunder  | inductor_cat_cudnn_transformerengine  | 2  | 16329.36     | 74.01       |