### PR TITLE
benchmark_litgpt.py: Start building executors list from the default ones

### DIFF
--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -392,7 +392,7 @@ class Benchmark_litGPT:
             dynamo_config.cache_size_limit = 64
             model = torch.compile(model)
         elif "thunder" in self.compile:
-            executors = [thunder.nvfuser_executor, thunder.pytorch_executor]
+            executors = thunder.get_default_executors()
             if "inductor_cat" in self.compile:
                 from thunder.executors.torch_compile import torch_compile_cat_ex as torch_compile_ex
 


### PR DESCRIPTION
`thunder/benchmarks/benchmark_litgpt.py` was ignoring the default executor list in Thunder. With this PR the default list is respected and optional executors are added as first in the priority queue.

Thanks to @mpatel31415 for noticing this (https://github.com/Lightning-AI/lightning-thunder/pull/974#issuecomment-2296468811).

cc @crcrpar