### PR TITLE
benchmark_litgpt.py: fix executors to be a list; fix the order of executors for sdpa

### DIFF
--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -401,14 +401,6 @@ class Benchmark_litGPT:
                 from thunder.executors.torch_compile import torch_compile_ex
 
                 executors.insert(0, torch_compile_ex)
-            if "cudnn" in self.compile:
-                from thunder.executors.cudnnex import cudnn_ex
-
-                executors.insert(0, cudnn_ex)
-            else:
-                from thunder.executors.sdpaex import sdpa_ex
-
-                executors.insert(0, sdpa_ex)
 
             if "transformerengine" in self.compile:
                 from thunder.executors.transformer_engineex import transformer_engine_ex

--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -392,7 +392,7 @@ class Benchmark_litGPT:
             dynamo_config.cache_size_limit = 64
             model = torch.compile(model)
         elif "thunder" in self.compile:
-            executors = thunder.get_default_executors()
+            executors = list(thunder.get_default_executors())
             if "inductor_cat" in self.compile:
                 from thunder.executors.torch_compile import torch_compile_cat_ex as torch_compile_ex
 

--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -392,7 +392,7 @@ class Benchmark_litGPT:
             dynamo_config.cache_size_limit = 64
             model = torch.compile(model)
         elif "thunder" in self.compile:
-            executors = [thunder.nvfuser_executor, thunder.pytorch_executor]
+            executors = thunder.get_default_executors()
             if "inductor_cat" in self.compile:
                 from thunder.executors.torch_compile import torch_compile_cat_ex as torch_compile_ex
 


### PR DESCRIPTION
A follow-up fix for https://github.com/Lightning-AI/lightning-thunder/pull/1002. `default_executors` returns a tuple that can't be modified. I'm sorry I haven't tested the code properly.

In addition, this PR removes "cudnn" reading from the compile option because it's part of the default executors.

cc @crcrpar