### PR TITLE
[benchmark] Init model on cuda device instead of meta for fsdp and thunder.jit

### DIFF
--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -253,7 +253,9 @@ class Benchmark_litGPT:
             }
 
     def init_model(self):
-        init_device = torch.device("meta") if self.distributed_mode in FSDP_MODES else self.device
+        init_device = self.device
+        if self.distributed_mode in FSDP_MODES and (self.compile in ("eager", "inductor") or "dynamo" in self.compile):
+            init_device = torch.device("meta")
         with init_device:
             model = GPT(self.config)
         model.to(dtype=torch.bfloat16)


### PR DESCRIPTION
Initialize model on cuda device, not meta, as per the following error

```
[rank7]:[rank7]: Traceback (most recent call last):
[rank7]:[rank7]:   File "/opt/pytorch/lightning-thunder/thunder/benchmarks/benchmark_litgpt.py", line 705, in <module>
[rank7]:[rank7]:     CLI(benchmark_main)
[rank7]:[rank7]:   File "/usr/local/lib/python3.10/dist-packages/jsonargparse/_cli.py", line 96, in CLI
[rank7]:[rank7]:     return _run_component(components, init)
[rank7]:[rank7]:   File "/usr/local/lib/python3.10/dist-packages/jsonargparse/_cli.py", line 204, in _run_component
[rank7]:[rank7]:     return component(**cfg)
[rank7]:[rank7]:   File "/opt/pytorch/lightning-thunder/thunder/benchmarks/benchmark_litgpt.py", line 629, in benchmark_main
[rank7]:[rank7]:     benchmark.train()
[rank7]:[rank7]:   File "/opt/pytorch/lightning-thunder/thunder/benchmarks/benchmark_litgpt.py", line 535, in train
[rank7]:[rank7]:     logits = self.model(input_ids)
[rank7]:[rank7]:   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1736, in _wrapped_call_impl
[rank7]:[rank7]:     return self._call_impl(*args, **kwargs)
[rank7]:[rank7]:   File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1747, in _call_impl
[rank7]:[rank7]:     return forward_call(*args, **kwargs)
[rank7]:[rank7]:   File "/opt/pytorch/lightning-thunder/thunder/core/module.py", line 80, in forward
[rank7]:[rank7]:     res = self._forward_fn(*args, **kwargs)
[rank7]:[rank7]:   File "/opt/pytorch/lightning-thunder/thunder/__init__.py", line 744, in fn_
[rank7]:[rank7]:     cache_entry, inps, pro_to_epi = get_computation_and_inputs(*args, **kwargs)
[rank7]:[rank7]:   File "/opt/pytorch/lightning-thunder/thunder/core/langctxs.py", line 136, in _fn
[rank7]:[rank7]:     result = fn(*args, **kwargs)
[rank7]:[rank7]:   File "/opt/pytorch/lightning-thunder/thunder/__init__.py", line 229, in cache_info_wrapper
[rank7]:[rank7]:     res = fn(*args, **kwargs)
[rank7]:[rank7]:   File "/opt/pytorch/lightning-thunder/thunder/__init__.py", line 641, in get_computation_and_inputs
[rank7]:[rank7]:     inps, pro_to_epi = pro(*args, **kwargs)
[rank7]:[rank7]:   File "/usr/local/lib/python3.10/dist-packages/torch/utils/_contextlib.py", line 116, in decorate_context
[rank7]:[rank7]:     return func(*args, **kwargs)
[rank7]:[rank7]:   File "/usr/local/lib/python3.10/dist-packages/torch/amp/autocast_mode.py", line 44, in decorate_autocast
[rank7]:[rank7]:     return func(*args, **kwargs)
[rank7]:[rank7]:   File "/usr/local/lib/python3.10/dist-packages/torch/amp/autocast_mode.py", line 44, in decorate_autocast
[rank7]:[rank7]:     return func(*args, **kwargs)
[rank7]:[rank7]:   File "thunder.prologue_0", line 255, in prologue
[rank7]:[rank7]:   File "/opt/pytorch/lightning-thunder/thunder/executors/pythonex.py", line 53, in _check_tensor_shape_and_metadata_impl
[rank7]:[rank7]:     tuple(t.shape) == shape and str(t.device) == device and t.dtype == dtype and t.requires_grad == requires_grad
[rank7]:[rank7]: AssertionError: expected tensor with (4096, 128), cuda:7, torch.bfloat16, requires_grad=False, got (4096, 128), meta, torch.bfloat16, False
```