### PR TITLE
Improve memory usage for stablecode-completion-alpha-3b

### DIFF
--- a/thunder/executors/torch_compile.py
+++ b/thunder/executors/torch_compile.py
@@ -229,6 +229,10 @@ supported_ops = {
     prims.reshape.id,
     prims.slice_prim.id,
     prims.transpose.id,
+    # div and erf are used in GELU and are fused horizontally with RoPE when
+    # parallel residual paths are used in the transformer block
+    prims.div.id,
+    prims.erf.id,
 }
 torch_compile_cat_ex._implmap = {
     op: ImplInfo(checker=cuda_device_checker) for op in pytorch_ex.implmap if op in supported_ops


### PR DESCRIPTION
Running this model on DGX-H100 with FSDP was giving an OOM error. With the proposed change peak memory usage is now 67.79GB.

This works by fusing RoPE and GELU into one fusion region and allowing the rematerialization pass to recompute GELU in the backward fusion region.

More details in https://github.com/Lightning-AI/lightning-thunder/issues/246#issuecomment-2302121789.

The following command was used to check the OOM error.
```
torchrun --nproc_per_node=8 thunder/benchmarks/benchmark_litgpt.py --model_name stablecode-completion-alpha-3b --compile=thunder --distributed_mode=fsdp
```

cc @apaz-cli