### PR TITLE
TE - fix propagate metadata for fp8_autocast in `from_trace`

### DIFF
--- a/thunder/core/trace.py
+++ b/thunder/core/trace.py
@@ -482,6 +482,8 @@ def from_trace(trace: TraceCtx) -> TraceCtx:
     t.name_ctr = trace.name_ctr
     t.obj_name_ctr = trace.obj_name_ctr
     t.names = trace.names
+    # This is a detail for enabling transformer_engine's autocast manager.
+    t._include_te_fp8_autocast = trace._include_te_fp8_autocast
 
     t._siginfo = trace._siginfo
     return t

--- a/thunder/tests/test_transformer_engine_executor.py
+++ b/thunder/tests/test_transformer_engine_executor.py
@@ -209,3 +209,35 @@ def test_te_with_retain_graph():
     # https://github.com/NVIDIA/TransformerEngine/issues/990
     out.backward(torch.randn_like(out), retain_graph=True)
     out.backward(torch.randn_like(out))
+
+
+@requiresCUDA
+def test_te_trace_metadata_propagation():
+    # This test is to verify that we correctly propagate metadata `_include_te_fp8_autocast` on
+    # trace using `from_trace`. `_include_te_fp8_autocast` is used to enable wrapping forward trace with `fp8_autocast`.
+    def foo(x, w):
+        return torch.nn.functional.linear(x, w)
+
+    device = "cuda"
+    x = torch.randn(16, 16, device=device, requires_grad=True)
+    w = torch.randn(16, 16, device=device, requires_grad=True)
+
+    class MyNoopTransform(thunder.core.transforms.Transform):
+        def transform_trace_post_optimization(self, computation_trace, **kwargs):
+            new_trace = thunder.core.trace.from_trace(computation_trace)
+            new_trace.bound_symbols = computation_trace.bound_symbols
+            return new_trace
+
+    cfunc = thunder.jit(
+        foo,
+        executors=[transformer_engine_ex],
+        transforms=[
+            MyNoopTransform(),
+        ],
+    )
+    out = cfunc(x, w)
+
+    fwd_traces = thunder.last_traces(cfunc)
+
+    # Verify that we have `te_linear` in the trace.
+    assert any(bsym.sym.name.startswith("te_linear") for bsym in fwd_traces[-1].bound_symbols)


### PR DESCRIPTION
Fixes - https://github.com/Lightning-AI/lightning-thunder/issues/1000
Smaller Repro (without CUDA graph)-

```python
import torch
import thunder
from thunder.core.transform_common import Transform

class Module(torch.nn.Module):
    def __init__(self, in_features, out_features) -> None:
        super().__init__()
        self.linear =  torch.nn.Linear(in_features, out_features)

    def forward(self, x: torch.Tensor):
        return self.linear(x)

class MyNoopTransform(Transform):
    def transform_trace_post_optimization(self, computation_trace, **kwargs):
        new_trace = thunder.core.trace.from_trace(computation_trace)
        new_trace.bound_symbols = computation_trace.bound_symbols
        print(new_trace._include_te_fp8_autocast)  # False (from_trace doesn't propagate this).
        return new_trace

with torch.device('cuda'):
    in_features = 16
    out_features = 16
    model = Module(in_features, out_features)
    for p in model.parameters():
        p.requires_grad = True

    x = torch.randn(16, in_features, requires_grad=True)

    jmodel_def = thunder.jit(model, executors=['transformer_engine',], transforms=[MyNoopTransform(),])

    y = jmodel_def(x)

```

Error 
```
  File "/home/kkalambarkar/git/TransformerEngine/transformer_engine/pytorch/module/base.py", line 964, in get_fp8_workspace
    out.cast_transpose_(
  File "/home/kkalambarkar/git/pytorch/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
  File "/home/kkalambarkar/git/TransformerEngine/transformer_engine/pytorch/float8_tensor.py", line 732, in cast_transpose_
    fp8_meta = self._fp8_meta[fp8_meta_key]
KeyError: 'scaling_fwd'
```

Problem - 

On trace for the forward, we set `_include_te_fp8_autocast` on the trace object which is then used to wrap the python representation of the trace with `fp8_autocast` (this is required for the TELinear to actually do the computation in FP8).

https://github.com/Lightning-AI/lightning-thunder/blob/a59b4efb54ea69980fa7fb63ea78923290e93d5a/thunder/core/trace.py#L380-L390

https://github.com/Lightning-AI/lightning-thunder/blob/a59b4efb54ea69980fa7fb63ea78923290e93d5a/thunder/executors/torch_autograd.py#L303-L306

However, `from_trace` doesn't propagate this metadata. So, if we have an additional transform in post optimisation, which uses `from_trace`, it will not set this. So we will have TELinear without a `fp8_autocast`.

Solution -
Update `from_trace` to propagate this metadata.

Test - 
Tested locally with newly added test. TE tests don't run on CI. However, we do run it on nightlies.

**NOTE** - TE Linear is only enabled for training run (i.e. when inputs have requires_grad=True).

Thanks @mattteochen for pointing that he had seen the same error when `fp8_autocast` was missing.