### PR TITLE
Set SDPBackend explicitly for validation

### DIFF
--- a/thunder/tests/test_nvfuser.py
+++ b/thunder/tests/test_nvfuser.py
@@ -1056,10 +1056,11 @@ def test_sdpa(
         ref_inp = inp.clone().detach()
         ref_inp.requires_grad = True
         ref_tensor_inputs.append(ref_inp)
-    
+
     from torch.nn.attention import SDPBackend, sdpa_kernel
+
     with torch.random.fork_rng(devices=[torch.cuda.current_device()]) and sdpa_kernel(SDPBackend.FLASH_ATTENTION):
-            ref_attn_out = sdpa_fn(*ref_tensor_inputs, *scalar_inputs)
+        ref_attn_out = sdpa_fn(*ref_tensor_inputs, *scalar_inputs)
     ref_attn_out.backward(grad_out)
 
     nv_outputs = (attn_out, q.grad, k.grad, v.grad)

--- a/thunder/tests/test_nvfuser.py
+++ b/thunder/tests/test_nvfuser.py
@@ -1056,13 +1056,13 @@ def test_sdpa(
         ref_inp = inp.clone().detach()
         ref_inp.requires_grad = True
         ref_tensor_inputs.append(ref_inp)
-
-    with torch.random.fork_rng(devices=[torch.cuda.current_device()]):
-        ref_attn_out = sdpa_fn(*ref_tensor_inputs, *scalar_inputs)
+    
+    from torch.nn.attention import SDPBackend, sdpa_kernel
+    with torch.random.fork_rng(devices=[torch.cuda.current_device()]) and sdpa_kernel(SDPBackend.FLASH_ATTENTION):
+            ref_attn_out = sdpa_fn(*ref_tensor_inputs, *scalar_inputs)
     ref_attn_out.backward(grad_out)
 
     nv_outputs = (attn_out, q.grad, k.grad, v.grad)
     ref_outputs = (ref_attn_out, *(inp.grad for inp in ref_tensor_inputs))
-
     for nv_out, ref_out in zip(nv_outputs, ref_outputs):
         torch.testing.assert_close(nv_out, ref_out)


### PR DESCRIPTION
NVFuser CI has failed `thunder/tests/test_sdpa.py` tests for H100.
This is because the backend picked for `torch.nn.scaled_dot_product_attention` in these cases is `cudnn_attention` whereas nvfuser is using flash attention. Explicitly setting the SDPBackend will allow validation against torch reference.

When checking if `sdpa` operator can be accepted by nvfuser, we use `utils.py/_fused_sdp_choice` (same as `sdpaex.py`). This function returns `FlashAttention` as the backend whenever flash attention is enabled and can be used for the given set of inputs (for `torch.__version__ > 2.2.0`). Hence, it is possible that for the reference computation,  `torch.nn.attention.scaled_dot_product_attention` actually uses a different backend.


