### PR TITLE
replace `fabric` `TransformerEnginePrecision` with custom swapping function

### DIFF
--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -79,7 +79,7 @@ def is_transformer_engine(low_precision_mode: str) -> bool:
 
 
 def swap_linear_layers_for_te(model: nn.Module, device: Any, swap_layernorm: bool = True) -> None:
-    
+
     def parameters_cnt(model: nn.Module) -> int:
         return sum(p.numel() for p in model.parameters())
 
@@ -90,18 +90,14 @@ def swap_linear_layers_for_te(model: nn.Module, device: Any, swap_layernorm: boo
 
             if isinstance(m, nn.Linear):
                 has_bias = m.bias is not None
-                new_linear = te.Linear(
-                    m.in_features, m.out_features, bias=bias_flag, device=device
-                )
+                new_linear = te.Linear(m.in_features, m.out_features, bias=bias_flag, device=device)
                 new_linear.weight.data = child.weight.data.clone()
                 if has_bias:
                     new_linear.bias.data = child.bias.data.clone()
                 setattr(module, n, new_linear)
-            
+
             if swap_layernorm and isinstance(m, nn.LayerNorm):
-                new_layernorm = te.LayerNorm(
-                    m.normalized_shape[0], eps=m.eps, device=device
-                )
+                new_layernorm = te.LayerNorm(m.normalized_shape[0], eps=m.eps, device=device)
                 new_layernorm.weight.data = child.weight.data.clone()
                 new_layernorm.bias.data = child.bias.data.clone()
                 setattr(module, n, new_layernorm)


### PR DESCRIPTION
## What does this PR do?

Fixes (well, not really as of now) [#887](https://github.com/Lightning-AI/lightning-thunder/issues/887):
- since `meta` is no longer used as default, the following issue does not persist
- still, decoupling from `fabric` is appreciated (see [#1](https://github.com/Lightning-AI/lightning-thunder/blob/bdc1e8ae1d2a0a8dbd5d22928ab0fc3cd7dfe40b/thunder/benchmarks/benchmark_litgpt.py#L539), [#2](https://github.com/Lightning-AI/lightning-thunder/issues/809))
- additionally, this makes it possible to benchmark w/ and w/o LayerNorm swapping, not possible in `TransformerEnginePrecision`, for `eager` and `inductor`

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
