### PR TITLE
fix memory leak from ThunderModule

### DIFF
--- a/thunder/common.py
+++ b/thunder/common.py
@@ -5,6 +5,7 @@ from collections import deque, defaultdict
 import time
 from functools import wraps
 from io import StringIO
+from weakref import WeakValueDictionary
 
 from thunder.core.options import (
     CACHE_OPTIONS,
@@ -253,7 +254,7 @@ class CompileData:
 
         # to not introduce (more) ref cycles, make this int->ThunderModule with
         # but the accessor has to check if tmm[id(module)]._module is module
-        self._thunder_module_map = {}
+        self._thunder_module_map = WeakValueDictionary()
 
         # We set the process_group_for_ddp attribute on the module when
         # thunder.distributed.ddp(module) is called.

--- a/thunder/common.py
+++ b/thunder/common.py
@@ -252,7 +252,7 @@ class CompileData:
 
         self.is_module = isinstance(self.fn, torch.nn.Module)
 
-        # to not introduce (more) ref cycles, make this int->ThunderModule with
+        # to not introduce (more) ref cycles, use WeakValueDictionary and map from int->ThunderModule
         # but the accessor has to check if tmm[id(module)]._module is module
         self._thunder_module_map = WeakValueDictionary()
 

--- a/thunder/tests/test_core.py
+++ b/thunder/tests/test_core.py
@@ -3171,3 +3171,21 @@ def test_state_dict():
     jm2.load_state_dict(jm1.state_dict())
 
     torch.testing.assert_close(jm1(inp), jm2(inp))
+
+
+def test_opt_module_is_freed():
+    import torch
+    import thunder
+    import weakref
+    import gc
+
+    mod = torch.nn.ReLU()
+    opt_mod = thunder.jit(mod)
+    ref_opt_mod = weakref.ref(opt_mod)
+    x = torch.randn(10, 10)
+    opt_mod(x)
+    del x
+    del mod
+    del opt_mod
+    pass
+    assert ref_opt_mod() is None


### PR DESCRIPTION
Partly fixes - https://github.com/Lightning-AI/lightning-thunder/issues/1034

Thank you @kiya00 for finding this leak and with small repro.

**NOTE** - `opt_mod` and `mod` both are held longer than intended due to cycle. This PR only fixes for `opt_mod`. We add a test for `mod` marked with `xfail`.

Repro - 
```python
import torch
import thunder
import weakref
import gc

mod = torch.nn.ReLU()
ref_mod = weakref.ref(mod, lambda _: print("mod deleted!"))
opt_mod = thunder.jit(mod)
ref_opt_mod = weakref.ref(opt_mod, lambda _: print("opt_mod deleted!"))
x = torch.randn(10, 10)
refx = weakref.ref(x, lambda _: print("x deleted!"))
opt_mod(x)
del x
del mod
del opt_mod
# gc.collect()
print("done!")  # done!

if ref_mod() is not None:
    import refcycle
    graph = refcycle.snapshot()

    try:
        cycle = graph.shortest_cycle(ref_mod())
        print("CYCLE FOUND FROM MOD")
    except ValueError:
        print("NO CYCLE FROM MOD")
        pass

    # More cycles are found here
    for anc in graph.ancestors(ref_mod()):
        try:
            cycle = graph.shortest_cycle(anc)
            print("CYCLE FOUND FROM ANCESTOR")
            break
        except ValueError:
            pass

    # for obj in cycle:
    #     print(obj)

    # Save the latest cycle.
    cycle.export_json("cycle.json")
    cycle.export_image("cycle.png")

```

Ref Cycle - `list(ref_opt_mod()._lc_cd._thunder_module_map.values())[0] is ref_opt_mod()` this is `True`

![image](https://github.com/user-attachments/assets/d2f02720-653d-45cc-92e9-16f04fa99607)

Solution -

Use `WeakValueDictionary` to store the modules as values in `_thunder_module_map`.