### PR TITLE
Replace `TransformerEnginePrecision` with a custom function

### DIFF
--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -79,7 +79,7 @@ def is_transformer_engine(low_precision_mode: str) -> bool:
 
 
 def swap_linear_layers_for_te(model: nn.Module, device: Any, swap_layernorm: bool = True) -> None:
-    
+
     def parameters_cnt(model: nn.Module) -> int:
         return sum(p.numel() for p in model.parameters())
 
@@ -90,18 +90,14 @@ def swap_linear_layers_for_te(model: nn.Module, device: Any, swap_layernorm: boo
 
             if isinstance(m, nn.Linear):
                 has_bias = m.bias is not None
-                new_linear = te.Linear(
-                    m.in_features, m.out_features, bias=bias_flag, device=device
-                )
+                new_linear = te.Linear(m.in_features, m.out_features, bias=bias_flag, device=device)
                 new_linear.weight.data = child.weight.data.clone()
                 if has_bias:
                     new_linear.bias.data = child.bias.data.clone()
                 setattr(module, n, new_linear)
-            
+
             if swap_layernorm and isinstance(m, nn.LayerNorm):
-                new_layernorm = te.LayerNorm(
-                    m.normalized_shape[0], eps=m.eps, device=device
-                )
+                new_layernorm = te.LayerNorm(m.normalized_shape[0], eps=m.eps, device=device)
                 new_layernorm.weight.data = child.weight.data.clone()
                 new_layernorm.bias.data = child.bias.data.clone()
                 setattr(module, n, new_layernorm)

--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -102,9 +102,8 @@ def check_and_update_config_for_te_if_needed(config: Config) -> None:
         print("No updates were necessary.")
 
 
-
 def swap_linear_layers_for_te(model: torch.nn.Module, device: Any, swap_layernorm: bool = True) -> None:
-    
+
     def parameters_cnt(model: torch.nn.Module) -> int:
         return sum(p.numel() for p in model.parameters())
 
@@ -115,15 +114,11 @@ def swap_linear_layers_for_te(model: torch.nn.Module, device: Any, swap_layernor
 
             if isinstance(m, torch.nn.Linear):
                 has_bias = m.bias is not None
-                new_linear = te.Linear(
-                    m.in_features, m.out_features, bias=has_bias, device=device
-                )
+                new_linear = te.Linear(m.in_features, m.out_features, bias=has_bias, device=device)
                 setattr(module, n, new_linear)
-            
+
             if swap_layernorm and isinstance(m, torch.nn.LayerNorm):
-                new_layernorm = te.LayerNorm(
-                    m.normalized_shape[0], eps=m.eps, device=device
-                )
+                new_layernorm = te.LayerNorm(m.normalized_shape[0], eps=m.eps, device=device)
                 setattr(module, n, new_layernorm)
 
     initial_params_cnt = parameters_cnt(model)


### PR DESCRIPTION
## What does this PR do?

Fixes [#887](https://github.com/Lightning-AI/lightning-thunder/issues/887):
* since `meta` is a default device for eager & inductor fsdp, we are not copying weights
* decoupling from fabric is appreciated (see [#1](https://github.com/Lightning-AI/lightning-thunder/blob/bdc1e8ae1d2a0a8dbd5d22928ab0fc3cd7dfe40b/thunder/benchmarks/benchmark_litgpt.py#L539), [#2](https://github.com/Lightning-AI/lightning-thunder/issues/809))
* additionally, this makes it possible to benchmark w/ and w/o LayerNorm swapping, not possible in TransformerEnginePrecision, for eager and inductor
* What is more, there are quite a few cases (i.e. `Nous-Hermes-13b`), where the default litgpt configuration is not suitable for running in TransformerEngine and it throws an error - added `check_and_update_config_for_te_if_needed` function to adjust the config to run for TE. Let me know if you would see it in a separate PR.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
