### PR TITLE
add ProxyTag and static memory location tagging for cudagraphs

### DIFF
--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -57,6 +57,7 @@ from thunder.core.proxies import (
     DistParallelType,
     proxy,
     Proxy,
+    ProxyTag,
     AnyProxy,
     NumberProxy,
     StringProxy,
@@ -114,6 +115,7 @@ from thunder.core.compile_data import compile_data_and_stats
 #
 # jit_ext.py implements extensions of thunder's interpreter
 #
+ProxyTag.register_tag("STATIC_MEMORY_LOCATION")
 
 
 EXT_FLAG_IS_PROXY_DERIVED = 1
@@ -1503,8 +1505,10 @@ def unpack_inputs(ctx, prologue_trace, pro_to_comp_inps, pro_to_epi_inps, args, 
             name = ".".join(name)
             if typ == "_parameters":
                 bsym = prims.unpack_parameter.bind(root_module, name, output=output)
+                output.tags.add(ProxyTag.STATIC_MEMORY_LOCATION)
             elif typ == "_buffers":
                 bsym = prims.unpack_buffer.bind(root_module, name, output=output)
+                output.tags.add(ProxyTag.STATIC_MEMORY_LOCATION)
             elif typ == "_modules":
                 bsym = prims.unpack_submodule.bind(root_module, name, output=output)
             else:

--- a/thunder/core/proxies.py
+++ b/thunder/core/proxies.py
@@ -87,10 +87,35 @@ def make_proxy_name(*, name: None | str = None, prefix: None | str = None) -> st
     return trc.make_name(prefix=prefix)
 
 
+class ProxyTag:
+    def __new__(cls, name, _register=False):
+        if _register:
+            res = super().__new__(cls)
+            res._value = name
+            setattr(cls, name, res)
+            return res
+
+        return getattr(cls, name)
+
+    @classmethod
+    def register_tag(cls, name):
+        ProxyTag(name, _register=True)
+
+    def __repr__(self):
+        return f"ProxyTag.{self._value}"
+
+
 # TODO Document this class
 # TODO Support multiple histories
 class Proxy(VariableInterface, ProxyInterface):
-    def __init__(self, name: str | None = None, *, prefix: None | str = None, history: None | tuple = None):
+    def __init__(
+        self,
+        name: str | None = None,
+        *,
+        prefix: None | str = None,
+        history: None | tuple = None,
+        tags: set | None = None,
+    ):
         # Determines the prefix
         if prefix is None:
             if isinstance(self, FloatProxy):
@@ -124,6 +149,11 @@ class Proxy(VariableInterface, ProxyInterface):
         self._name = make_proxy_name(name=name, prefix=prefix)
         self._has_weak_name: bool = name is None
         self.history = history
+        self._tags = tags if tags is not None else set()
+
+    @property
+    def tags(self) -> set:
+        return self._tags
 
     @property
     def name(self) -> str:
@@ -138,6 +168,7 @@ class Proxy(VariableInterface, ProxyInterface):
         kwargs = dict(
             name=self.name,
             history=self.history,
+            tags=self.tags,
         )
         kwargs.update(changes)
         return Proxy(**kwargs)
@@ -376,8 +407,8 @@ class Proxy(VariableInterface, ProxyInterface):
 # Unlike many other proxies, this does not mimic the type of the object it wraps
 # TODO RC1 Rename ._o to ._value for consistency
 class AnyProxy(Proxy):
-    def __init__(self, o: Any, /, *, name: str | None = None, history: None | tuple = None):
-        super().__init__(name=name, history=history)
+    def __init__(self, o: Any, /, *, name: str | None = None, history: None | tuple = None, tags: set | None = None):
+        super().__init__(name=name, history=history, tags=tags)
         self._o = o
 
     def __repr__(self) -> str:
@@ -391,17 +422,18 @@ class AnyProxy(Proxy):
         kwargs = dict(
             name=self.name,
             history=self.history,
+            tags=self.tags,
         )
         kwargs.update(changes)
         return AnyProxy(self._o, **kwargs)
 
 
 class StringProxy(Proxy, str):
-    def __new__(cls, s: str, /, *, name: str | None = None, history: None | tuple = None):
+    def __new__(cls, s: str, /, *, name: str | None = None, history: None | tuple = None, tags: set | None = None):
         return str.__new__(cls, s)
 
-    def __init__(self, s: str, /, *, name: str | None = None, history: None | tuple = None):
-        Proxy.__init__(self, name=name, history=history)
+    def __init__(self, s: str, /, *, name: str | None = None, history: None | tuple = None, tags: set | None = None):
+        Proxy.__init__(self, name=name, history=history, tags=tags)
         self.value: str = s
 
     def __str__(self) -> str:
@@ -417,6 +449,7 @@ class StringProxy(Proxy, str):
         kwargs = dict(
             name=self.name,
             history=self.history,
+            tags=self.tags,
         )
         kwargs.update(changes)
         return StringProxy(self.value, **kwargs)
@@ -442,8 +475,8 @@ class StringProxy(Proxy, str):
 # The following class is DEPRECATED, and is only preserved her for experimental feature development
 #   that relies upon it.
 class CollectionProxy(Proxy):
-    def __init__(self, coll: Any, *, name: str | None = None):
-        Proxy.__init__(self, name=name)
+    def __init__(self, coll: Any, *, name: str | None = None, tags: set | None = None):
+        Proxy.__init__(self, name=name, tags=tags)
         self.coll = coll
 
     def collection(self) -> Any:
@@ -454,11 +487,11 @@ class CollectionProxy(Proxy):
 
 
 class TupleProxy(Proxy, tuple):
-    def __new__(cls, tup: tuple, *, name: None | str = None, history: None | tuple = None):
+    def __new__(cls, tup: tuple, *, name: None | str = None, history: None | tuple = None, tags: set | None = None):
         return tuple.__new__(cls, tup)
 
-    def __init__(self, tup: tuple, *, name: None | str = None, history: None | tuple = None):
-        Proxy.__init__(self, name=name, history=history)
+    def __init__(self, tup: tuple, *, name: None | str = None, history: None | tuple = None, tags: set | None = None):
+        Proxy.__init__(self, name=name, history=history, tags=tags)
         self._value = tup
 
     def type_string(self) -> str:
@@ -471,6 +504,7 @@ class TupleProxy(Proxy, tuple):
         kwargs = dict(
             name=self.name,
             history=self.history,
+            tags=self.tags,
         )
         kwargs.update(changes)
         return TupleProxy(self._value, **kwargs)
@@ -492,15 +526,15 @@ class TupleProxy(Proxy, tuple):
 
 
 class ListProxy(Proxy, list):
-    def __new__(cls, lst: list, *, name: None | str = None, history: None | tuple = None):
+    def __new__(cls, lst: list, *, name: None | str = None, history: None | tuple = None, tags: set | None = None):
         l = list.__new__(cls, lst)
 
         # NOTE This intentionally does not call the ListProxy.extend() method
         list.extend(l, lst)
         return l
 
-    def __init__(self, lst: list, *, name: None | str = None, history: None | tuple = None):
-        Proxy.__init__(self, name=name, history=history)
+    def __init__(self, lst: list, *, name: None | str = None, history: None | tuple = None, tags: set | None = None):
+        Proxy.__init__(self, name=name, history=history, tags=tags)
         self._value = lst
 
     def type_string(self, /) -> str:
@@ -513,6 +547,7 @@ class ListProxy(Proxy, list):
         kwargs = dict(
             name=self.name,
             history=self.history,
+            tags=self.tags,
         )
         kwargs.update(changes)
         return ListProxy(self._value, **kwargs)
@@ -552,13 +587,13 @@ class ListProxy(Proxy, list):
 
 
 class DictProxy(Proxy, dict):
-    def __new__(cls, d: dict, *, name: None | str = None, history: None | tuple = None):
+    def __new__(cls, d: dict, *, name: None | str = None, history: None | tuple = None, tags: set | None = None):
         nd = dict.__new__(cls, d)
         dict.update(nd, d)
         return nd
 
-    def __init__(self, d: dict, *, name: None | str = None, history: None | tuple = None):
-        Proxy.__init__(self, name=name, history=history)
+    def __init__(self, d: dict, *, name: None | str = None, history: None | tuple = None, tags: set | None = None):
+        Proxy.__init__(self, name=name, history=history, tags=tags)
         self._value = d
 
     def type_string(self, /) -> str:
@@ -571,6 +606,7 @@ class DictProxy(Proxy, dict):
         kwargs = dict(
             name=self.name,
             history=self.history,
+            tags=self.tags,
         )
         kwargs.update(changes)
         return DictProxy(self._value, **kwargs)
@@ -638,6 +674,7 @@ class NumberProxy(Proxy, NumberProxyInterface):
         python_type: type,
         history: None | tuple = None,
         constraint: None | CONSTRAINT = None,
+        tags: set | None = None,
     ):
         self.value = value
         self.python_type = python_type
@@ -645,7 +682,7 @@ class NumberProxy(Proxy, NumberProxyInterface):
             constraint = CONSTRAINT.DYNAMIC
         self.constraint = constraint
 
-        Proxy.__init__(self, name, history=history)
+        Proxy.__init__(self, name, history=history, tags=tags)
 
     # NOTE: Python numbers hash to themselves, and this mimics that behavior
     def __hash__(self) -> int:
@@ -658,6 +695,7 @@ class NumberProxy(Proxy, NumberProxyInterface):
         kwargs = dict(
             name=self.name,
             history=self.history,
+            tags=self.tags,
             value=self.value,
             python_type=self.python_type,
             constraint=self.constraint,
@@ -1039,8 +1077,17 @@ def pytype(x: Proxy) -> type | None:
 
 # TODO RC1 Update Proxy number inits to be value, /, *, name, history
 class ComplexProxy(NumberProxy):
-    def __init__(self, name=None, value=None, history: None | tuple = None, constraint: None | CONSTRAINT = None):
-        NumberProxy.__init__(self, name=name, value=value, python_type=complex, history=history, constraint=constraint)
+    def __init__(
+        self,
+        name=None,
+        value=None,
+        history: None | tuple = None,
+        constraint: None | CONSTRAINT = None,
+        tags: set | None = None,
+    ):
+        NumberProxy.__init__(
+            self, name=name, value=value, python_type=complex, history=history, constraint=constraint, tags=tags
+        )
 
     def replace(self, **changes):
         r"""Return a copy of the ComplexProxy object with new values for the specified fields as given to the constructor as arguments.
@@ -1049,6 +1096,7 @@ class ComplexProxy(NumberProxy):
         kwargs = dict(
             name=self.name,
             history=self.history,
+            tags=self.tags,
             value=self.value,
             constraint=self.constraint,
             __class__=self.__class__,  # undocumented on purpose
@@ -1071,11 +1119,12 @@ class IntegerProxy(NumberProxy):
         value=None,
         history: None | tuple = None,
         constraint: None | CONSTRAINT = None,
+        tags: set | None = None,
     ):
         # NOTE bools are also integers in Python
         python_type = bool if isinstance(value, bool) else int
         NumberProxy.__init__(
-            self, name=name, value=value, python_type=python_type, history=history, constraint=constraint
+            self, name=name, value=value, python_type=python_type, history=history, constraint=constraint, tags=tags
         )
 
     def replace(self, **changes):
@@ -1085,6 +1134,7 @@ class IntegerProxy(NumberProxy):
         kwargs = dict(
             name=self.name,
             history=self.history,
+            tags=self.tags,
             value=self.value,
             constraint=self.constraint,
             __class__=self.__class__,
@@ -1109,8 +1159,17 @@ class IntegerProxy(NumberProxy):
 
 # TODO Review dtype conversions
 class FloatProxy(NumberProxy):
-    def __init__(self, name=None, value=None, history: None | tuple = None, constraint: None | CONSTRAINT = None):
-        NumberProxy.__init__(self, name=name, value=value, python_type=float, history=history, constraint=constraint)
+    def __init__(
+        self,
+        name=None,
+        value=None,
+        history: None | tuple = None,
+        constraint: None | CONSTRAINT = None,
+        tags: set | None = None,
+    ):
+        NumberProxy.__init__(
+            self, name=name, value=value, python_type=float, history=history, constraint=constraint, tags=tags
+        )
 
     def replace(self, **changes):
         r"""Return a copy of the FloatProxy object with new values for the specified fields as given to the constructor as arguments.
@@ -1119,6 +1178,7 @@ class FloatProxy(NumberProxy):
         kwargs = dict(
             name=self.name,
             history=self.history,
+            tags=self.tags,
             value=self.value,
             constraint=self.constraint,
             __class__=self.__class__,  # undocumented on purpose
@@ -1237,8 +1297,9 @@ class FutureTensorProxy(Proxy, TensorProxyInterface):
         dtype: dtypes.dtype | None = None,
         prefix: None | str = None,
         history: None | tuple = None,
+        tags: set | None = None,
     ):
-        super().__init__(name, prefix=prefix, history=history)
+        super().__init__(name, prefix=prefix, history=history, tags=tags)
 
         # NOTE FutureTensorProxies never require grad
         (
@@ -1329,8 +1390,10 @@ class FutureTensorProxy(Proxy, TensorProxyInterface):
         )
         name = changes.get("name", self.name)
         history = changes.get("history", self.history)
+        tags = changes.get("tags", self.tags)
         return FutureTensorProxy(
             name=name,
+            tags=tags,
             shape=shape,
             device=device,
             dtype=dtype,
@@ -1352,9 +1415,10 @@ class TensorProxy(Proxy, TensorProxyInterface):
         prefix: None | str = None,
         distparallel_type: DistParallelType | None = None,
         history: None | tuple = None,
+        tags: set | None = None,
         thunder_fsdp_padding_size: int | None = None,
     ):
-        super().__init__(name, prefix=prefix, history=history)
+        super().__init__(name, prefix=prefix, history=history, tags=tags)
 
         (
             self._shape,
@@ -1450,8 +1514,10 @@ class TensorProxy(Proxy, TensorProxyInterface):
         )
         name = changes.get("name", self.name)
         history = changes.get("history", self.history)
+        tags = changes.get("tags", self.tags)
         return TensorProxy(
             name=name,
+            tags=tags,
             shape=shape,
             device=device,
             dtype=dtype,

--- a/thunder/tests/test_jit_general.py
+++ b/thunder/tests/test_jit_general.py
@@ -1263,3 +1263,24 @@ def test_matmul_nd_times_2d_runs_2d_gemm(device):
     # Check that prim.matmul outputs a 2d tensor
     assert matmul_prim_bsym is not None
     assert matmul_prim_bsym.output.ndim == 2
+
+
+def test_tag_static_memory_location():
+    # not much sense, but hey.
+    m = torch.nn.Sequential(torch.nn.Tanh(), torch.nn.Linear(2, 3), torch.nn.BatchNorm1d(3))
+    jm = thunder.jit(m)
+    jm(torch.randn(5, 2))
+    lt = thunder.last_traces(jm)[-1]
+
+    # input should not be tagged static
+    assert thunder.core.proxies.ProxyTag.STATIC_MEMORY_LOCATION not in lt.args[0].tags
+    # parameters and buffers should be tagged static
+    assert all(thunder.core.proxies.ProxyTag.STATIC_MEMORY_LOCATION in a.tags for a in lt.args[1:])
+
+    # outputs of operations should not be tagged static
+    for bsym in lt.bound_symbols:
+        if bsym.sym == thunder.core.prims.unpack_trivial:
+            continue
+        for a in bsym.flat_outs:
+            if isinstance(a, thunder.Proxy):
+                assert thunder.core.proxies.ProxyTag.STATIC_MEMORY_LOCATION not in a.tags

--- a/thunder/transforms/cudagraph.py
+++ b/thunder/transforms/cudagraph.py
@@ -11,7 +11,7 @@ from thunder.core.transform_common import Transform
 from thunder.core.transforms import eval_trace
 from thunder.extend import FusionExecutor, register_executor
 from thunder.core import utils, prims
-from thunder.core.proxies import Proxy, Variable, unvariableify
+from thunder.core.proxies import Proxy, ProxyTag, Variable, unvariableify
 from thunder.core.symbol import BoundSymbol, Symbol
 from thunder.core.trace import TraceCtx, from_trace, TraceProvenance, get_tracectx, set_tracectx, reset_tracectx
 from thunder.executors.utils import Region
@@ -176,7 +176,9 @@ class CUDAGraphRunner:
         if static_inputs_mask is not None:
             static_inputs_mask = tuple(static_inputs_mask)  # ensure hashability
         else:
-            static_inputs_mask = None
+            static_inputs_mask = tuple(
+                isinstance(i, Proxy) and ProxyTag.STATIC_MEMORY_LOCATION in i.tags for i in inputs
+            )
 
         fn_name = f"CUDAGraph{self.name_counter}"
         self.name_counter += 1

--- a/thunder/transforms/quantization.py
+++ b/thunder/transforms/quantization.py
@@ -215,6 +215,7 @@ class BitsAndBytesLinearQuant4bit(Transform):
                         dtype=thunder.dtypes.to_dtype(qs["absmax.dtype"]),
                         device=thunder.devices.to_device(device),
                         requires_grad=False,
+                        tags=(thunder.core.proxies.ProxyTag.STATIC_MEMORY_LOCATION),
                     )
                     proxy_code = thunder.TensorProxy(
                         name=f"{get_param.output.name}_code",
@@ -222,6 +223,7 @@ class BitsAndBytesLinearQuant4bit(Transform):
                         dtype=thunder.dtypes.to_dtype(qs["code.dtype"]),
                         device=thunder.devices.to_device(device),
                         requires_grad=False,
+                        tags=(thunder.core.proxies.ProxyTag.STATIC_MEMORY_LOCATION),
                     )
                     # get_param.sym = unpack_buffer/parameter as needed
                     new_bsyms.append(get_param.sym.bind(get_param.args[0], n_absmax, output=proxy_absmax))


### PR DESCRIPTION
This is one of the outcomes of the design discussion re #981 .

We add a ProxyTag mechanism (with registration) and introduce STATIC_MEMORY_LOCATION as the first tag.

We then use this tag for knowing the static inputs in the CUDAGraph transform.