### PR TITLE
Add `is_cpu` flag to `fd.define_tensor`

### DIFF
--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -244,8 +244,9 @@ def create_fd(
                 utils.check_type(y, tuple)
                 symbolic_shape, contiguity, stride_order, dtype = y
                 nvdtype = lcdtype_to_nvdtype(dtypes.to_dtype(dtype))
+                is_cpu = x.device == cpu
                 nv = fd.define_tensor(
-                    shape=symbolic_shape, contiguity=contiguity, dtype=nvdtype, stride_order=stride_order
+                    shape=symbolic_shape, contiguity=contiguity, dtype=nvdtype, stride_order=stride_order, is_cpu=is_cpu
                 )
             elif isinstance(x, TupleProxy):
                 # TODO: discuss the contract here on baked in number from a tuple

--- a/thunder/tests/test_nvfuser.py
+++ b/thunder/tests/test_nvfuser.py
@@ -1048,7 +1048,9 @@ def test_sdpa(
 
     # Check nv_sdpfa_fwd is not in bwd_fusion -> that would indicate rematerialization
     assert "nv_sdpfa_bwd" in bwd_fusion[-1][-1].name and "nv_sdpfa_fwd" not in bwd_fusion[-1][-1].name
-    assert bwd_fusion[-1][-1].last_used.getReproString().count('is_cpu=True') == 2, 'Expected philox_seed and philox_offset inputs to be CPU scalar tensors.'
+    assert (
+        bwd_fusion[-1][-1].last_used.getReproString().count("is_cpu=True") == 2
+    ), "Expected philox_seed and philox_offset inputs to be CPU scalar tensors."
 
     # Torch reference computation
     # Clone the inputs to verify gradients with torch reference

--- a/thunder/tests/test_nvfuser.py
+++ b/thunder/tests/test_nvfuser.py
@@ -1048,6 +1048,7 @@ def test_sdpa(
 
     # Check nv_sdpfa_fwd is not in bwd_fusion -> that would indicate rematerialization
     assert "nv_sdpfa_bwd" in bwd_fusion[-1][-1].name and "nv_sdpfa_fwd" not in bwd_fusion[-1][-1].name
+    assert bwd_fusion[-1][-1].last_used.getReproString().count('is_cpu=True') == 2, 'Expected philox_seed and philox_offset inputs to be CPU scalar tensors.'
 
     # Torch reference computation
     # Clone the inputs to verify gradients with torch reference


### PR DESCRIPTION
By default, `is_cpu=False` when defining tensors for `FusionDefinition`. 
This PR sets the `is_cpu` flag based on `x`.

Motivation: `philox_seed/philox_offset` in SDPA are CPU scalar tensors which are incorrectly declared as CUDA tensors. We do not see an error currently because these variables were marked as CPU scalars in the CPP code [here](https://github.com/NVIDIA/Fuser/blob/de1672c653094062d46125ed622d2b781a50aa77/csrc/ops/composite.cpp#L616-L618) (to be removed after this PR). So even though, these tensors were not marked as CPU scalars in `fd.define_tensor`, the tensorviews have the correct device set before runFusion / evaluateFusionOutputs is called.