### PR TITLE
call torch._dynamo.reset before every test in test_dynamo

### DIFF
--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -8,6 +8,20 @@ import torch
 import pytest
 
 
+# This will be applied to all tests in this file.
+@pytest.fixture(scope="function", autouse=True)
+def reset_torch_dynamo():
+    # Without this, if a frame is compiled multiple times
+    # potentially due to matrix of inputs then it will hit cache_size_limit
+    # and fallback to eager.
+    #
+    # [0/8] torch._dynamo hit config.cache_size_limit (8)
+    # [0/8]    function: 'func' (lightning-thunder/thunder/tests/test_dynamo.py:26)
+    # [0/8]    last reason: 0/0:
+    # [0/8] To log all recompilation reasons, use TORCH_LOGS="recompiles".
+    torch._dynamo.reset()
+
+
 @instantiate(
     dtypes=NOTHING,
     executors=[DynamoThunderExecutor],

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -11,7 +11,10 @@ import pytest
 # This will be applied to all tests in this file.
 @pytest.fixture(scope="function", autouse=True)
 def reset_torch_dynamo():
-    # Without this, if a frame is compiled multiple times
+    # From torch.compile docs - https://pytorch.org/docs/stable/generated/torch.compile.html
+    # > Multiple compiled results can be associated with a frame up to torch._dynamo.config.cache_size_limit, which defaults to 8; at which point we will fall back to eager.
+    #
+    # Without this fixture, if a function frame is compiled multiple times
     # potentially due to matrix of inputs then it will hit cache_size_limit
     # and fallback to eager.
     #


### PR DESCRIPTION
Repro - `pytest thunder/tests/test_dynamo.py --count 3` (requires [pytest-repeat plugin](https://pypi.org/project/pytest-repeat/) to run the repro command)

Error
```python
>       assert out.grad_fn.name() == "ThunderFunctionBackward"
E       AssertionError: assert 'AddBackward0' == 'ThunderFunctionBackward'
E         
E         - ThunderFunctionBackward
E         + AddBackward0

thunder/tests/test_dynamo.py:46: AssertionError
====================================================================================================================== short test summary info =======================================================================================================================
FAILED thunder/tests/test_dynamo.py::test_basic_DynamoThunder_cpu_None[auto-3-3] - AssertionError: assert 'AddBackward0' == 'ThunderFunctionBackward'
FAILED thunder/tests/test_dynamo.py::test_basic_DynamoThunder_cuda_None[dynamic-1-3] - AssertionError: assert 'AddBackward0' == 'ThunderFunctionBackward'
FAILED thunder/tests/test_dynamo.py::test_basic_DynamoThunder_cuda_None[dynamic-2-3] - AssertionError: assert 'AddBackward0' == 'ThunderFunctionBackward'
FAILED thunder/tests/test_dynamo.py::test_basic_DynamoThunder_cuda_None[dynamic-3-3] - AssertionError: assert 'AddBackward0' == 'ThunderFunctionBackward'
FAILED thunder/tests/test_dynamo.py::test_basic_DynamoThunder_cuda_None[static-1-3] - AssertionError: assert 'AddBackward0' == 'ThunderFunctionBackward'
FAILED thunder/tests/test_dynamo.py::test_basic_DynamoThunder_cuda_None[static-2-3] - AssertionError: assert 'AddBackward0' == 'ThunderFunctionBackward'
FAILED thunder/tests/test_dynamo.py::test_basic_DynamoThunder_cuda_None[static-3-3] - AssertionError: assert 'AddBackward0' == 'ThunderFunctionBackward'
FAILED thunder/tests/test_dynamo.py::test_basic_DynamoThunder_cuda_None[auto-1-3] - AssertionError: assert 'AddBackward0' == 'ThunderFunctionBackward'
FAILED thunder/tests/test_dynamo.py::test_basic_DynamoThunder_cuda_None[auto-2-3] - AssertionError: assert 'AddBackward0' == 'ThunderFunctionBackward'
FAILED thunder/tests/test_dynamo.py::test_basic_DynamoThunder_cuda_None[auto-3-3] - AssertionError: assert 'AddBackward0' == 'ThunderFunctionBackward'
============================================================================================================= 10 failed, 44 passed, 22 warnings in 2.29s ============================================================================================================
```

With this PR
```
================ 54 passed, 42 warnings in 3.65s ================
```