### PR TITLE
Auto-registered ops: Add ops returning views to `_syms_returning_views`

### DIFF
--- a/thunder/core/functionalization.py
+++ b/thunder/core/functionalization.py
@@ -60,11 +60,11 @@ def check_inplace_to_views(computation_trace: Trace) -> dict[VariableInterface, 
             continue
 
         check(
-            prod_bsym.sym not in ltorch._syms_returning_runtime_dependently_views,
+            prod_bsym.sym not in ltorch._syms_that_may_return_views,
             lambda: (
                 f"in-place op of `{bsym.sym.id}` to `{prod_bsym.sym.id}` output `{in_tensor}` is not "
                 f"supported. It's unclear if the output of "
-                f"{tuple(s.id for s in ltorch._syms_returning_runtime_dependently_views)} is "
+                f"{tuple(s.id for s in ltorch._syms_that_may_return_views)} is "
                 f"a copy, a view, or the input itself, as per https://pytorch.org/docs/stable/tensor_view.html"
             ),
             NotImplementedError,
@@ -110,16 +110,16 @@ def _get_prod_bsym_with_arg(
     in_tensor: TensorProxy,
 ) -> BoundSymbol | None:
     from thunder.torch import _syms_returning_views
-    from thunder.torch import _syms_returning_runtime_dependently_views
+    from thunder.torch import _syms_that_may_return_views
 
     def inplace_or_view(bsym) -> bool:
         sym = bsym.sym
         check(
-            sym not in _syms_returning_runtime_dependently_views,
+            sym not in _syms_that_may_return_views,
             lambda: (
                 f"in-place op of `{orig_bsym_of_in_tensor.sym.id}` to `{bsym.sym.id}` output `{in_tensor.name}` is not "
                 f"supported. It's unclear if `{in_tensor.name}`, the output of "
-                f"{tuple(s.id for s in _syms_returning_runtime_dependently_views)} is "
+                f"{tuple(s.id for s in _syms_that_may_return_views)} is "
                 "a copy, a view, or the input itself, as per https://pytorch.org/docs/stable/tensor_view.html\n"
                 "Please use `torch.view` to create a view. Cloning the reshaped tensor before the in-place op is not currently supported.\n"
                 "This error can be skipped with `skip_inplace_functionalization=True` passed to `thunder.jit`.\n"

--- a/thunder/tests/test_inplace_functionalization.py
+++ b/thunder/tests/test_inplace_functionalization.py
@@ -706,7 +706,13 @@ def test_reshape_flatten_error_out(executor, device, _):
         y.add_(1)
         return y
 
-    for fn in (f, g):
+    def h(x):
+        tmp = torch.randn((6, 4))
+        y = x.reshape_as(tmp)
+        y.add_(1)
+        return y
+
+    for fn in (f, g, h):
         x = make_tensor((3, 2, 4), device=device, dtype=torch.float32)
         jitted = executor.make_callable(fn)
 

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -5635,9 +5635,11 @@ _torch_to_thunder_complete_map = {
     **{fn: fn for fn in _torch_noinline_functions},
 }
 
-
+# records the torch symbols that may return tensor views
 # ref: https://pytorch.org/docs/stable/tensor_view.html
-_syms_returning_runtime_dependently_views: set[Symbol] = {
+# NOTE Symbols that return tensor views can interfere with in-place operators
+# See :func:`thunder.core.functionalization.check_inplace_to_views` for the details.
+_syms_that_may_return_views: set[Symbol] = {
     reshape,
     contiguous,
     to,

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -52,6 +52,7 @@ from thunder.core.transforms import (
     _check_valid_autocast_dtype,
 )
 import thunder
+from thunder.torch.default_torch_ops import _auto_registered_operators_returning_views
 
 
 __all__ = [
@@ -5636,7 +5637,13 @@ _torch_to_thunder_complete_map = {
 
 
 # ref: https://pytorch.org/docs/stable/tensor_view.html
-_syms_returning_runtime_dependently_views: set[Symbol] = {reshape, contiguous, to, flatten}
+_syms_returning_runtime_dependently_views: set[Symbol] = {
+    reshape,
+    contiguous,
+    to,
+    flatten,
+    _torch_to_thunder_function_map[torch.Tensor.reshape_as],
+}
 
 _syms_returning_views: set[Symbol] = {
     diagonal,
@@ -5660,3 +5667,6 @@ _syms_returning_views: set[Symbol] = {
     chunk,
     getitem,
 }
+
+# Add all auto-registered torch operators symbol that return tensor views to _syms_returning_views
+_syms_returning_views.update({_torch_to_thunder_function_map[x] for x in _auto_registered_operators_returning_views})

--- a/thunder/torch/default_torch_ops.py
+++ b/thunder/torch/default_torch_ops.py
@@ -756,3 +756,28 @@ torch_auto_registered_ops = {
         torch.fft.rfftn,
     ],
 }
+
+_auto_registered_operators_returning_views = [
+    torch.adjoint,
+    torch.Tensor.adjoint,
+    torch.Tensor.as_strided,
+    torch.detach,
+    torch.Tensor.detach,
+    torch.narrow,
+    torch.Tensor.narrow,
+    torch.imag,
+    torch.view_as_real,
+    torch.nn.functional.unfold,
+    torch.Tensor.hsplit,
+    torch.hsplit,
+    torch.Tensor.vsplit,
+    torch.vsplit,
+    torch.Tensor.split_with_sizes,
+    torch.split_with_sizes,
+    torch.Tensor.swapaxes,
+    torch.swapaxes,
+    torch.Tensor.swapdims,
+    torch.swapdims,
+    torch.Tensor.indices,
+    torch.Tensor.values,
+]

--- a/thunder/torch/default_torch_ops.py
+++ b/thunder/torch/default_torch_ops.py
@@ -757,6 +757,10 @@ torch_auto_registered_ops = {
     ],
 }
 
+# Records all the auto-registered Torch operators that return tensor views
+# Ref: https://pytorch.org/docs/stable/tensor_view.html
+# NOTE this list is used to update the `_syms_returning_views`, so that the symbol returning tensor views can be processed correctly when they interact with in-place operators.
+# See :func:`thunder.core.functionalization.check_inplace_to_views` for the details.
 _auto_registered_operators_returning_views = [
     torch.adjoint,
     torch.Tensor.adjoint,


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

As a follow-up to https://github.com/Lightning-AI/lightning-thunder/issues/957 (https://github.com/Lightning-AI/lightning-thunder/issues/957#issuecomment-2293521400)

When auto-registration is added there's no in-place support yet. As mentioned in #957, the operators that return views can interfere with in-place ops. This PR adds the relative auto-registered symbols to `_syms_returning_views` and `_syms_returning_runtime_dependently_views` and let the in-place pass deal with it.
