### PR TITLE
avoid renames proxies in forward trace during grad transform

### DIFF
--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -3657,9 +3657,7 @@ def forward_and_backward_from_trace(trace: Trace, torch_autograd=False) -> Forwa
         else:
             return None
 
-    forward_trace = construct_trace()(augmented_forward_fn, *trace.args, **trace.kwargs)
-    # We set forward trace to construct proxies because we need these proxies to
-    # have different names than the ones in the forward trace.
+    forward_trace = construct_trace(rename_proxies=False)(augmented_forward_fn, *trace.args, **trace.kwargs)
     try:
         tracectx_token = set_tracectx(forward_trace)
         # We don't want to record those ones_like calls in the forward trace.


### PR DESCRIPTION
With side branch (#1027 dynamic shape)
test_grad.py::test_update_forward_with_new_saved_for_backward_numberproxy_nvfuser_cuda_None

generates forward trace:
```
@torch.no_grad()
@no_autocast
def augmented_forward_fn(a, i0, i1, b):
  # a: "cuda:0 f32[[IntegerProxy name=i0, value=2, static=CONSTRAINT.CONSTRAINABLE], [IntegerProxy name=i1, value=2, static=CONSTRA
INT.CONSTRAINABLE]]"
  # i0: "int 2"
  # i1: "int 2"
  # b: "float 3.0"
  t4 = ltorch.mul(a, b)  # t4: "cuda:0 f32[[IntegerProxy name=i0, value=2, static=CONSTRAINT.CONSTRAINABLE], [IntegerProxy name=i1, value=2, static=CONSTRAINT.CONSTRAINABLE]]"
    # b0 = prims.eq(i1, 1)  # b0: "bool False"
    # b1 = prims.eq(i1, i1)  # b1: "bool True"
    # b2 = prims.eq(i0, 1)  # b2: "bool False"
    # b3 = prims.eq(i0, i0)  # b3: "bool True"
    # t4 = prims.mul(a, b)  # t4: "cuda:0 f32[[IntegerProxy name=i0, value=2, static=CONSTRAINT.CONSTRAINABLE], [IntegerProxy name=i1, value=2, static=CONSTRAINT.CONSTRAINABLE]]"
  return ({'output': t4, 'flat_args': [a, i0, i1, b], 'flat_output': (t4,)}, (((a, b), None, ([b],)),))
```

Without the change, forward trace will be constructed as
```
@torch.no_grad()
@no_autocast
def augmented_forward_fn(a, i0, i1, b):
  # a: "cuda:0 f32[[IntegerProxy name=i0, value=2, static=CONSTRAINT.CONSTRAINABLE], [IntegerProxy name=i1, value=2, static=CONSTRAINT.CONSTRAINABLE]]"
  # i4: "int 2"
  # i5: "int 2"
  # b: "float 3.0"
  t10 = ltorch.mul(a, b)  # t10: "cuda:0 f32[[IntegerProxy name=i0, value=2, static=CONSTRAINT.CONSTRAINABLE], [IntegerProxy name=i1, value=2, static=CONSTRAINT.CONSTRAINABLE]]"
    # b6 = prims.eq(i1, 1)  # b6: "bool False"
    # b7 = prims.eq(i1, i1)  # b7: "bool True"
    # b8 = prims.eq(i0, 1)  # b8: "bool False"
    # b9 = prims.eq(i0, i0)  # b9: "bool True"
    # t10 = prims.mul(a, b)  # t10: "cuda:0 f32[[IntegerProxy name=i0, value=2, static=CONSTRAINT.CONSTRAINABLE], [IntegerProxy nam
e=i1, value=2, static=CONSTRAINT.CONSTRAINABLE]]"
  return ({'output': t10, 'flat_args': [a, i4, i5, b], 'flat_output': (t10,)}, (((a, b), None, ([b],)),))
```

giving me an error on undefined proxy `i4` (and `i5` here as well)