### PR TITLE
use `torch.OP##_` if available not `torch.Tensor.OP##_`

### DIFF
--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -1330,7 +1330,7 @@ def abs(a: NumberLike | TensorLike, /) -> Number | TensorLike:
     return clang.abs(a)
 
 
-@torchsymbol(torch.Tensor.abs_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
+@torchsymbol(torch.abs_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def abs_(a: NumberLike | TensorLike, /) -> Number | TensorLike:
     return prims.copy_(abs(a), a)
 
@@ -1340,7 +1340,7 @@ def acos(a: NumberLike | TensorLike, /) -> Number | TensorLike:
     return clang.acos(a)
 
 
-@torchsymbol(torch.Tensor.acos_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
+@torchsymbol(torch.acos_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def acos_(a: TensorLike, /) -> TensorLike:
     return prims.copy_(acos(a), a)
 
@@ -1350,7 +1350,7 @@ def acosh(a):
     return clang.acosh(a)
 
 
-@torchsymbol(torch.Tensor.acosh_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
+@torchsymbol(torch.acosh_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def acosh_(a):
     return prims.copy_(acosh(a), a)
 
@@ -1360,7 +1360,7 @@ def asin(a):
     return clang.asin(a)
 
 
-@torchsymbol(torch.Tensor.asin_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
+@torchsymbol(torch.asin_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def asin_(a):
     return prims.copy_(asin(a), a)
 
@@ -1370,7 +1370,7 @@ def asinh(a):
     return clang.asinh(a)
 
 
-@torchsymbol(torch.Tensor.asinh_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
+@torchsymbol(torch.asinh_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def asinh_(a):
     return prims.copy_(asinh(a), a)
 
@@ -1380,7 +1380,7 @@ def atan(a):
     return clang.atan(a)
 
 
-@torchsymbol(torch.Tensor.atan_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
+@torchsymbol(torch.atan_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def atan_(a):
     return prims.copy_(atan(a), a)
 
@@ -1390,7 +1390,7 @@ def atanh(a):
     return clang.atanh(a)
 
 
-@torchsymbol(torch.Tensor.atanh_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
+@torchsymbol(torch.atanh_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def atanh_(a):
     return prims.copy_(atanh(a), a)
 
@@ -1410,7 +1410,7 @@ def ceil(a):
     return clang.ceil(a)
 
 
-@torchsymbol(torch.Tensor.ceil_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
+@torchsymbol(torch.ceil_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def ceil_(a):
     return prims.copy_(ceil(a), a)
 
@@ -1420,7 +1420,7 @@ def cos(a):
     return clang.cos(a)
 
 
-@torchsymbol(torch.Tensor.cos_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
+@torchsymbol(torch.cos_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def cos_(a):
     return prims.copy_(cos(a), a)
 
@@ -1430,7 +1430,7 @@ def cosh(a):
     return clang.cosh(a)
 
 
-@torchsymbol(torch.Tensor.cosh_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
+@torchsymbol(torch.cosh_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def cosh_(a):
     return prims.copy_(cosh(a), a)
 
@@ -1450,7 +1450,7 @@ def erf(a):
     return clang.erf(a)
 
 
-@torchsymbol(torch.Tensor.erf_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
+@torchsymbol(torch.erf_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def erf_(a):
     return prims.copy_(erf(a), a)
 
@@ -1460,7 +1460,7 @@ def erfc(a):
     return clang.erfc(a)
 
 
-@torchsymbol(torch.Tensor.erfc_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
+@torchsymbol(torch.erfc_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def erfc_(a):
     return prims.copy_(erfc(a), a)
 
@@ -1480,7 +1480,7 @@ def exp(a):
     return clang.exp(a)
 
 
-@torchsymbol(torch.Tensor.exp_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
+@torchsymbol(torch.exp_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def exp_(a):
     return prims.copy_(exp(a), a)
 
@@ -1490,7 +1490,7 @@ def exp2(a):
     return clang.exp2(a)
 
 
-@torchsymbol(torch.Tensor.exp2_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
+@torchsymbol(torch.exp2_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def exp2_(a):
     return prims.copy_(exp2(a), a)
 
@@ -1500,7 +1500,7 @@ def expm1(a):
     return clang.expm1(a)
 
 
-@torchsymbol(torch.Tensor.expm1_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
+@torchsymbol(torch.expm1_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def expm1_(a):
     return prims.copy_(expm1(a), a)
 
@@ -1510,7 +1510,7 @@ def floor(a):
     return clang.floor(a)
 
 
-@torchsymbol(torch.Tensor.floor_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
+@torchsymbol(torch.floor_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def floor_(a):
     return prims.copy_(floor(a), a)
 
@@ -1535,7 +1535,7 @@ def log(a):
     return clang.log(a)
 
 
-@torchsymbol(torch.Tensor.log_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
+@torchsymbol(torch.log_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def log_(a):
     return prims.copy_(log(a), a)
 
@@ -1545,7 +1545,7 @@ def log10(a):
     return clang.log10(a)
 
 
-@torchsymbol(torch.Tensor.log10_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
+@torchsymbol(torch.log10_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def log10_(a):
     return prims.copy_(log10(a), a)
 
@@ -1555,7 +1555,7 @@ def log1p(a):
     return clang.log1p(a)
 
 
-@torchsymbol(torch.Tensor.log1p_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
+@torchsymbol(torch.log1p_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def log1p_(a):
     return prims.copy_(log1p(a), a)
 
@@ -1565,7 +1565,7 @@ def log2(a):
     return clang.log2(a)
 
 
-@torchsymbol(torch.Tensor.log2_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
+@torchsymbol(torch.log2_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def log2_(a):
     return prims.copy_(log2(a), a)
 
@@ -1581,7 +1581,7 @@ def neg(a):
     return clang.neg(a)
 
 
-@torchsymbol(torch.Tensor.neg_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
+@torchsymbol(torch.neg_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def neg_(a):
     return prims.copy_(neg(a), a)
 
@@ -1591,7 +1591,7 @@ def reciprocal(a):
     return clang.reciprocal(a)
 
 
-@torchsymbol(torch.Tensor.reciprocal_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
+@torchsymbol(torch.reciprocal_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def reciprocal_(a):
     return prims.copy_(reciprocal(a), a)
 
@@ -1601,7 +1601,7 @@ def round(a):
     return clang.round(a)
 
 
-@torchsymbol(torch.Tensor.round_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
+@torchsymbol(torch.round_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def round_(a):
     return prims.copy_(round(a), a)
 
@@ -1611,7 +1611,7 @@ def rsqrt(a):
     return clang.rsqrt(a)
 
 
-@torchsymbol(torch.Tensor.rsqrt_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
+@torchsymbol(torch.rsqrt_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def rsqrt_(a):
     return prims.copy_(rsqrt(a), a)
 
@@ -1638,7 +1638,7 @@ def sin(a):
     return clang.sin(a)
 
 
-@torchsymbol(torch.Tensor.sin_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
+@torchsymbol(torch.sin_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def sin_(a):
     return prims.copy_(sin(a), a)
 
@@ -1648,7 +1648,7 @@ def sinh(a):
     return clang.sinh(a)
 
 
-@torchsymbol(torch.Tensor.sinh_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
+@torchsymbol(torch.sinh_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def sinh_(a):
     return prims.copy_(sinh(a), a)
 
@@ -1658,7 +1658,7 @@ def sqrt(a):
     return clang.sqrt(a)
 
 
-@torchsymbol(torch.Tensor.sqrt_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
+@torchsymbol(torch.sqrt_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def sqrt_(a):
     return prims.copy_(sqrt(a), a)
 
@@ -1668,7 +1668,7 @@ def tan(a):
     return clang.tan(a)
 
 
-@torchsymbol(torch.Tensor.tan_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
+@torchsymbol(torch.tan_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def tan_(a):
     return prims.copy_(tan(a), a)
 
@@ -1678,7 +1678,7 @@ def tanh(a):
     return clang.tanh(a)
 
 
-@torchsymbol(torch.Tensor.tanh_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
+@torchsymbol(torch.tanh_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def tanh_(a):
     return prims.copy_(tanh(a), a)
 
@@ -1688,7 +1688,7 @@ def trunc(a):
     return clang.trunc(a)
 
 
-@torchsymbol(torch.Tensor.trunc_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
+@torchsymbol(torch.trunc_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def trunc_(a):
     return prims.copy_(trunc(a), a)
 
@@ -2209,7 +2209,7 @@ def clamp(
     return a
 
 
-@torchsymbol(torch.Tensor.clamp_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
+@torchsymbol(torch.clamp_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def clamp_(
     a: TensorLike, /, min: None | Number | TensorLike = None, max: None | Number | TensorLike = None
 ) -> TensorLike:
@@ -2864,7 +2864,7 @@ def index_put(
     return clang.index_put(a, indices, values, accumulate)
 
 
-@torchsymbol(torch.Tensor.index_put_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
+@torchsymbol(torch.index_put_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def index_put_(
     a: TensorLike,
     /,


### PR DESCRIPTION
## What does this PR do?

Fixes #1072.

```python
import torch

import thunder
from thunder.examine import examine

def f(a):
    return torch.exp_(a)

def g(a):
    return a.exp_()

a = torch.randn(2)
b = thunder.jit(f)(a)
b = thunder.jit(g)(a)
```

Current main is not capable of functionalizing `f`, which should be unexpected.
