### PR TITLE
After adding recomputing_symbols, sort the new consumer according to the data flow

### DIFF
--- a/thunder/core/rematerialization.py
+++ b/thunder/core/rematerialization.py
@@ -181,6 +181,9 @@ def apply_rematerialization_for_consumer(
         if x.name in all_args and x.name not in (x.name for x in new_consumer_args) and x.name not in all_outs
     )
 
+    # The recomputing_symbols may originate from multiple producers.
+    # Directly adding these symbols at the beginning of the consumer can disrupt the topological order of subsymbols. To ensure
+    # correct execution order, we reorder the new_subsymbols here.
     _, leaves = bsym_list_to_dag(list(new_subsymbols))
     new_subsymbols = toposort_bsym_dag(leaves, TOPOSORT_ORDER.BOTTOM_UP)
     proxy_order = order_proxies(new_subsymbols)

--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -140,7 +140,9 @@ def bsym_list_to_dag(
     for bsym_id, node in bsym_id_to_node_map.items():
         has_parents: bool = False
         for inp in node.bsym.flat_proxy_args:
-            producer = producers[inp]
+            producer = producers.get(inp, None)
+            if producer is None:
+                continue
             producer_node = bsym_id_to_node_map[producer]
             parent = bsym_id_to_node_map[producer]
 

--- a/thunder/tests/test_core.py
+++ b/thunder/tests/test_core.py
@@ -983,6 +983,11 @@ def test_bsym_toposort(executor: TestExecutor, device: str, dtype: dtypes.dtype)
     assert top_down_reshape_bsym.sym.id == "torch.reshape"
     assert bottom_up_reshape_bsym.sym.id == "torch.reshape"
 
+    # Tests when the symbol list doesn't contain unpack operator
+    bsyms_without_unpack = trc.bound_symbols[1:]
+    roots, leaves = bsym_list_to_dag(bsyms_without_unpack)
+    assert len(leaves) == 1 and leaves[0].bsym.sym.id == prims.PrimIDs.RETURN
+
 
 # Verifies that using only some of the results of a function works as expected
 #   (the other results are dce'd)

--- a/thunder/tests/test_nvfuser.py
+++ b/thunder/tests/test_nvfuser.py
@@ -207,7 +207,7 @@ def test_redundant_cast_nvfusion(executor, device: str, dtype: dtypes.dtype):
     assert len(fusions[0].subsymbols) == 3
 
     # Verifies the intermediate consumer
-    assert fusions[1].subsymbols[-1].args[0].name == "t5"
+    assert fusions[1].subsymbols[-2].args[0].name == "t5"
 
 
 @instantiate(executors=(nvFuserExecutor,), dtypes=(thunder.float32,))

--- a/thunder/tests/test_nvfuser_remat.py
+++ b/thunder/tests/test_nvfuser_remat.py
@@ -174,11 +174,11 @@ def test_apply_rematerialization_consumer(executor, device, _):
     assert new_consumer.subsymbols[0].sym.name == "exp"
     assert new_consumer.subsymbols[0].args[0].name == cut[0]
 
-    assert new_consumer.subsymbols[1].sym.name == "exp"
-    assert new_consumer.subsymbols[1].args[0].name == new_consumer.subsymbols[0].output.name
+    assert new_consumer.subsymbols[2].sym.name == "exp"
+    assert new_consumer.subsymbols[2].args[0].name == new_consumer.subsymbols[0].output.name
 
     # The rest of the subsymbols should be the same as in the original consumer
-    assert tuple(new_consumer.subsymbols[2:]) == tuple(consumer.subsymbols)
+    assert (new_consumer.subsymbols[1], *new_consumer.subsymbols[3:]) == tuple(consumer.subsymbols)
 
     # Test case when duplicated symbols appear in producer and consumer
     duplicated_sym = [sym for sym in producer.subsymbols if sym.output.name == "t3"]

--- a/thunder/tests/test_nvfuser_remat.py
+++ b/thunder/tests/test_nvfuser_remat.py
@@ -177,7 +177,8 @@ def test_apply_rematerialization_consumer(executor, device, _):
     assert new_consumer.subsymbols[2].sym.name == "exp"
     assert new_consumer.subsymbols[2].args[0].name == new_consumer.subsymbols[0].output.name
 
-    # The rest of the subsymbols should be the same as in the original consumer
+    # The subsymbols are reordered according to the topological order.
+    # The rest of the subsymbols should be the same as in the original consumer, in this case the symbols except at position 0 and 2.
     assert (new_consumer.subsymbols[1], *new_consumer.subsymbols[3:]) == tuple(consumer.subsymbols)
 
     # Test case when duplicated symbols appear in producer and consumer


### PR DESCRIPTION
During rematerialization, considering a consumer need to find the `recomputing_symbols` of several producers and the `recomputing_symbols` are copied into the beginning of the consumer, it's possible the order of symbols are not in topological sort anymore, we need to reorder the subsymbols of new consumer after the `recomputing_symbols` are added to it.

Fixes #1038.
