### PR TITLE
[CI Fix] Update check-package to v0.11.7

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -21,7 +21,7 @@ jobs:
       azure-dir: ".azure"
 
   check-package:
-    uses: Lightning-AI/utilities/.github/workflows/check-package.yml@v0.11.6
+    uses: Lightning-AI/utilities/.github/workflows/check-package.yml@v0.11.7
     with:
       actions-ref: v0.11.3.post0
       import-name: "thunder"


### PR DESCRIPTION
Workflow `check-package` in `Lightning-AI/utilities/` has been updated to version 0.11.7. This update includes
> ### Fixed
>
> - CI: pass `include-hidden-files: true` to upload created packages ([#303](https://github.com/Lightning-AI/utilities/pull/303))
>
> https://github.com/blob/main/CHANGELOG.md

This is needed for `check-package` to pass, as detailed in https://github.com/Lightning-AI/utilities/issues/302.