### PR TITLE
Remove thunder+nvfuser+torch.compile executor from default list in targets.py

### DIFF
--- a/thunder/benchmarks/targets.py
+++ b/thunder/benchmarks/targets.py
@@ -145,13 +145,11 @@ executors = (
     torch_executor,
     torch_compile_executor,
     thunder_executor,
-    thunder_sdpa_torch_compile_nvfuser_executor,
 )
 executors_ids = (
     "torch",
     "torch.compile",
     "thunder",
-    "thunder+nvfuser+torch.compile",
 )
 
 apex_executors = (thunder_apex_executor, thunder_apex_nvfuser_executor)


### PR DESCRIPTION
Since https://github.com/Lightning-AI/lightning-thunder/pull/974 torch.compile concatenation executor is part of the default executor list and it's the same as "Thunder" executor option in these benchmarks.

cc @crcrpar