### PR TITLE
thunder + dynamo : use recompile instead of real_recompile

### DIFF
--- a/thunder/dynamo/compiler.py
+++ b/thunder/dynamo/compiler.py
@@ -12,6 +12,14 @@ def _warn_thunder_compiler():
     )
 
 
+def recompile_graph(gm: torch.fx.GraphModule):
+    # NOTE - `gm` could also be the `_LazyGraphModule`, in which case calling `recompile` is not enough as it marks the `GraphModule`
+    # and actual recompilation happens when either `forward` or `code` (or when user tries to observe the GraphModule).
+    # See for more details - https://github.com/pytorch/pytorch/blob/39935e0fdef02c67ba808175dcc800d0695bfe1b/torch/fx/_lazy_graph_module.py#L65-L89
+    gm.recompile()
+    gm.code
+
+
 class ThunderCompiler:
     def __init__(self, **thunder_options):
         """
@@ -63,7 +71,7 @@ class ThunderCompiler:
 
         # Dynamo uses lazy generation of the underlying Python code, so we need to
         # force recompilation of the GraphModule before passing it to Thunder.
-        gm.real_recompile()
+        recompile_graph(gm)
 
         # Here in the future we could add some logic to check if the GraphModule
         # is executable by Thunder, but for now we simply compile it and return

--- a/thunder/dynamo/compiler.py
+++ b/thunder/dynamo/compiler.py
@@ -1,4 +1,5 @@
 import torch
+from torch.fx._lazy_graph_module import _LazyGraphModule
 import warnings
 
 from thunder.core.baseutils import run_once
@@ -14,10 +15,11 @@ def _warn_thunder_compiler():
 
 def recompile_graph(gm: torch.fx.GraphModule):
     # NOTE - `gm` could also be the `_LazyGraphModule`, in which case calling `recompile` is not enough as it marks the `GraphModule`
-    # and actual recompilation happens when either `forward` or `code` (or when user tries to observe the GraphModule).
+    # and actual recompilation happens when `real_recompile` is called or either `forward` or `code` (or when user tries to observe the GraphModule).
     # See for more details - https://github.com/pytorch/pytorch/blob/39935e0fdef02c67ba808175dcc800d0695bfe1b/torch/fx/_lazy_graph_module.py#L65-L89
-    gm.recompile()
-    gm.code
+    if isinstance(gm, torch.fx._lazy_graph_module._LazyGraphModule):
+        return gm.real_recompile()
+    return gm.recompile()
 
 
 class ThunderCompiler:

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -6,7 +6,6 @@ from thunder import last_traces
 
 import torch
 import pytest
-from unittest.mock import patch
 
 
 # This will be applied to all tests in this file.

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -62,7 +62,7 @@ def test_basic(executor, device: str, dtype: dtypes.dtype, dynamic: bool | None)
     dtypes=NOTHING,
     executors=[DynamoThunderExecutor],
 )
-def test_recompile(executor, device: str, dtype: dtypes.dtype):
+def test_force_skip_lazy_graph_module(executor, device: str, dtype: dtypes.dtype):
     with torch.fx._lazy_graph_module._force_skip_lazy_graph_module():
         backend = ThunderCompiler()
         x = torch.ones(2, dtype=dtype, device=device, requires_grad=True)


### PR DESCRIPTION
Fixes: https://github.com/Lightning-AI/lightning-thunder/issues/1091

Depending on the setting, Dynamo's output_graph maybe `GraphModule` or it's derived class `_LazyGraphModule` (only this subclass provides `real_recompile` method).  The difference between the two classes is that calling `recompile` on `_LazyGraphModule` just marks it for recompilation and it actually does recompilation when a code that will observe it is called like `forward` method or `code` attribute.

In this PR, we call `recompile` followed by `code` attribute which is supported by both classes.

Doc for `_LazyGraphModule` -
https://github.com/pytorch/pytorch/blob/39935e0fdef02c67ba808175dcc800d0695bfe1b/torch/fx/_lazy_graph_module.py#L38-L62
Point where dynamo may create `GraphModule` or `_LazyGraphModule` -
https://github.com/pytorch/pytorch/blob/39935e0fdef02c67ba808175dcc800d0695bfe1b/torch/_dynamo/output_graph.py#L1331

Test - new test in `thunder/tests/test_dynamo.py` and `thunder/tests/test_networks.py -k Dynamo`.