### PR TITLE
VJP rule for `PrimIDs.CLONE`, with some `torch.memory_format` handling logic

### DIFF
--- a/thunder/core/proxies.py
+++ b/thunder/core/proxies.py
@@ -1949,5 +1949,7 @@ def proxy(x: Any, *, name: str | None = None, history: None | tuple = None) -> A
         return AnyProxy(x, name=name, history=history)
     if isinstance(x, torch.device):
         return AnyProxy(x, name=name, history=history)
+    if isinstance(x, torch.memory_format):
+        return AnyProxy(x, name=name, history=history)
 
     return x

--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -1542,7 +1542,7 @@ augmented_forward_impls = {
     prims.PrimIDs.ZETA: lambda x, y: (prims.zeta(x, y), (x, y)),
     prims.PrimIDs.FMOD: lambda x, y: (prims.fmod(x, y), (x, y)),
     prims.PrimIDs.COPY_: lambda x, y: (prims.copy_(x, y), tuple()),
-    prims.PrimIDs.CLONE: lambda x, _: (prims.clone(x), tuple()),
+    prims.PrimIDs.CLONE: lambda x: (prims.clone(x), tuple()),
 }
 
 

--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -1542,6 +1542,7 @@ augmented_forward_impls = {
     prims.PrimIDs.ZETA: lambda x, y: (prims.zeta(x, y), (x, y)),
     prims.PrimIDs.FMOD: lambda x, y: (prims.fmod(x, y), (x, y)),
     prims.PrimIDs.COPY_: lambda x, y: (prims.copy_(x, y), tuple()),
+    prims.PrimIDs.CLONE: lambda x, _: (prims.clone(x), tuple()),
 }
 
 
@@ -1571,6 +1572,7 @@ backward_impls = {
     prims.PrimIDs.FMOD: lambda x, y, g: (g, -g * prims.trunc(x / y)),
     # The copy should not be differentiable. We return None to enable the generation of the backward graph through them.
     prims.PrimIDs.COPY_: lambda g: (None, None),
+    prims.PrimIDs.CLONE: lambda g: g,
 }
 
 

--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -1809,6 +1809,15 @@ real_opinfo = OpInfo(
 elementwise_unary_ops.append(real_opinfo)
 
 
+clone_opinfo = OpInfo(
+    ltorch.clone,
+    sample_input_generator=elementwise_unary_generator,
+    torch_reference=_elementwise_unary_torch(torch.clone),
+    test_directives=(),
+)
+elementwise_unary_ops.append(clone_opinfo)
+
+
 # Puts all opinfos into the "opinfos" list
 opinfos.extend(elementwise_unary_ops)
 


### PR DESCRIPTION
## What does this PR do?

Fixes #1068.