### PR TITLE
support list[int] as shape for torch.randn

### DIFF
--- a/thunder/clang/__init__.py
+++ b/thunder/clang/__init__.py
@@ -277,7 +277,7 @@ def full(
         dtype = dtypes.numbertype_to_dtype(dtypes.to_dtype(fill_value))
     device = devices.to_device(device)
 
-    return prims.full(shape, fill_value, device=device, dtype=dtype)
+    return prims.full(tuple(shape), fill_value, device=device, dtype=dtype)
 
 
 @clangop()

--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -2645,7 +2645,9 @@ exogenous_like = make_prim(
 #   Logically these tensors are constructed intermediate to a trace, so there's no mechanism for a user to
 #   extract their grad, but we could support compiling forward and backward and accessing grad attributes
 #   in the future
-def _full_meta(shape: Sequence[int], fill_value: Number, *, device: devices.Device, dtype: dtypes.dtype) -> TensorProxy:
+def _full_meta(
+    shape: tuple[int, ...], fill_value: Number, *, device: devices.Device, dtype: dtypes.dtype
+) -> TensorProxy:
     # Checks inputs
     utils.check_type(fill_value, (Number, NumberProxy))
 
@@ -2656,6 +2658,8 @@ def _full_meta(shape: Sequence[int], fill_value: Number, *, device: devices.Devi
         lambda: f"Can't safely cast fill_value of numbertype {fill_value_dtype} to dtype {dtype}",
     )
 
+    utils.check_type(shape, tuple)
+    utils.check_valid_shape(shape)
     return TensorProxy(shape=shape, device=device, dtype=dtype, requires_grad=False)
 
 

--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -5862,6 +5862,9 @@ def fixed_value_tensor_creation_op_sample_generator(op, device, dtype, requires_
         (4, 4),
         (8, 1, 6),
         (8, 7, 5, 1),
+        [
+            4,
+        ],  # Using `list[int]` should also work.
     )
 
     for shape in cases:

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -600,7 +600,7 @@ def full(
 ) -> TensorLike:
     device = to_device(maybe_get_default_device(device))
     dtype = _infer_full_dtype(fill_value, dtype)
-    return clang.full(tuple(shape), fill_value, device=device, dtype=dtype)
+    return clang.full(shape, fill_value, device=device, dtype=dtype)
 
 
 @torchsymbol(torch.full_like)

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -600,7 +600,7 @@ def full(
 ) -> TensorLike:
     device = to_device(maybe_get_default_device(device))
     dtype = _infer_full_dtype(fill_value, dtype)
-    return clang.full(shape, fill_value, device=device, dtype=dtype)
+    return clang.full(tuple(shape), fill_value, device=device, dtype=dtype)
 
 
 @torchsymbol(torch.full_like)
@@ -750,7 +750,7 @@ def randn(
 
     device = to_device(maybe_get_default_device(device))
     dtype = to_dtype(maybe_get_default_dtype(dtype))
-    shape = utils.extract_shape_from_varargs(shape)
+    shape = tuple(utils.extract_shape_from_varargs(shape))
     return prims.randn(shape, device=device, dtype=dtype)
 
 


### PR DESCRIPTION
Fixes https://github.com/Lightning-AI/lightning-thunder/issues/604

We also update prims.full to only accept `tuple[int]` as shape as that is better for CSE.

