### PR TITLE
Add a parametrized benchmark for swiglu

### DIFF
--- a/thunder/benchmarks/targets.py
+++ b/thunder/benchmarks/targets.py
@@ -257,6 +257,7 @@ swiglu_executors_ids = (
     "torch.compile+liger",
 )
 
+
 # Sample command to run this benchmark:
 # pytest thunder/benchmarks/targets.py -k "test_litgpt_swiglu" --benchmark-group-by='param:config,param:bs,param:compute_type'
 @pytest.mark.parametrize(
@@ -276,9 +277,7 @@ swiglu_executors_ids = (
     "config,",
     get_configs_for_swiglu(),
 )
-def test_litgpt_swiglu(
-    benchmark, executor: Callable, use_liger: bool, bs: int, compute_type: ComputeType, config: str
-):
+def test_litgpt_swiglu(benchmark, executor: Callable, use_liger: bool, bs: int, compute_type: ComputeType, config: str):
     if use_liger and not LIGER_FUSED_SWIGLU_AVAILABLE:
         pytest.skip("Liger fused swiglu is unavailable")
 


### PR DESCRIPTION
Adds a new benchmark case for the activation function of Llama MLP `torch.nn.functional.silu(x_fc_1) * x_fc_2`: https://github.com/Lightning-AI/litgpt/blob/fdf6a120056d1363287285599eb84907f6c589b9/litgpt/model.py#L372

Here are the results for Llama 3 8B configuration with batch sizes 1 and 2 on H100:
```py
------------------------------------------------------------------------------- benchmark 'config=Llama-3-8B bs=1 compute_type=ComputeType.INFERENCE': 5 tests -------------------------------------------------------------------------------
Name (time in us)                                                         Min                 Max                Mean             StdDev              Median               IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_litgpt_swiglu[Llama-3-8B-inference-bs1-torch.compile]           257.3853 (1.0)      965.2159 (2.02)     263.9498 (1.0)      28.3068 (1.27)     259.1284 (1.0)      1.1027 (1.0)        63;145        3.7886 (1.0)        1294           3
test_litgpt_swiglu[Llama-3-8B-inference-bs1-thunder]                 290.5978 (1.13)     478.7864 (1.0)      301.4902 (1.14)     29.4405 (1.32)     293.8556 (1.13)     2.2789 (2.07)      100;184        3.3169 (0.88)       1722           2
test_litgpt_swiglu[Llama-3-8B-inference-bs1-torch.compile+liger]     347.6646 (1.35)     524.2405 (1.09)     356.9562 (1.35)     28.7152 (1.28)     350.1298 (1.35)     1.8347 (1.66)       69;161        2.8015 (0.74)       1440           2
test_litgpt_swiglu[Llama-3-8B-inference-bs1-torch+liger]             407.6082 (1.58)     579.2063 (1.21)     417.2114 (1.58)     28.4499 (1.27)     410.2103 (1.58)     1.5330 (1.39)       69;117        2.3969 (0.63)       1226           2
test_litgpt_swiglu[Llama-3-8B-inference-bs1-torch]                   425.7597 (1.65)     566.0141 (1.18)     432.5596 (1.64)     22.3737 (1.0)      427.4822 (1.65)     1.2242 (1.11)        54;88        2.3118 (0.61)       1176           2
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

---------------------------------------------------------------------------- benchmark 'config=Llama-3-8B bs=1 compute_type=ComputeType.TRAINING_BACKWARD': 5 tests ---------------------------------------------------------------------------
Name (time in us)                                                        Min                   Max                Mean             StdDev              Median               IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_litgpt_swiglu[Llama-3-8B-backward-bs1-torch.compile+liger]     437.5298 (1.0)        778.0874 (1.31)     449.5022 (1.0)      37.5744 (1.55)     440.8751 (1.00)     2.8007 (1.66)        64;96        2.2247 (1.0)        1145           2
test_litgpt_swiglu[Llama-3-8B-backward-bs1-torch+liger]             437.8119 (1.00)       792.9578 (1.34)     449.7995 (1.00)     38.2624 (1.58)     440.7582 (1.0)      2.5779 (1.53)       64;129        2.2232 (1.00)       1142           2
test_litgpt_swiglu[Llama-3-8B-backward-bs1-thunder]                 440.7037 (1.01)       592.7235 (1.0)      451.3652 (1.00)     24.2165 (1.0)      445.8232 (1.01)     1.7269 (1.03)        53;86        2.2155 (1.00)       1133           2
test_litgpt_swiglu[Llama-3-8B-backward-bs1-torch.compile]           443.1829 (1.01)       604.9434 (1.02)     452.9044 (1.01)     24.5046 (1.01)     447.2826 (1.01)     1.6827 (1.0)         54;97        2.2080 (0.99)       1133           2
test_litgpt_swiglu[Llama-3-8B-backward-bs1-torch]                   763.9043 (1.75)     1,068.2344 (1.80)     782.6279 (1.74)     50.5286 (2.09)     770.5027 (1.75)     5.7174 (3.40)        64;83        1.2777 (0.57)       1308           1
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

-------------------------------------------------------------------------- benchmark 'config=Llama-3-8B bs=1 compute_type=ComputeType.TRAINING_FORWARD': 5 tests ---------------------------------------------------------------------------
Name (time in us)                                                       Min                 Max                Mean             StdDev              Median               IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_litgpt_swiglu[Llama-3-8B-forward-bs1-torch.compile]           260.5872 (1.0)      368.2021 (1.0)      267.3313 (1.0)      19.4477 (1.0)      262.2250 (1.0)      1.2239 (1.0)        74;151        3.7407 (1.0)        1281           3
test_litgpt_swiglu[Llama-3-8B-forward-bs1-thunder]                 292.7175 (1.12)     493.9158 (1.34)     304.7740 (1.14)     31.6844 (1.63)     296.4023 (1.13)     2.6994 (2.21)       98;196        3.2811 (0.88)       1708           2
test_litgpt_swiglu[Llama-3-8B-forward-bs1-torch.compile+liger]     352.3454 (1.35)     532.8665 (1.45)     361.8789 (1.35)     27.8529 (1.43)     355.3806 (1.36)     1.9565 (1.60)       57;158        2.7634 (0.74)       1419           2
test_litgpt_swiglu[Llama-3-8B-forward-bs1-torch+liger]             407.8010 (1.56)     570.8663 (1.55)     417.1312 (1.56)     27.8638 (1.43)     410.1861 (1.56)     1.4780 (1.21)       70;127        2.3973 (0.64)       1226           2
test_litgpt_swiglu[Llama-3-8B-forward-bs1-torch]                   426.9052 (1.64)     573.2719 (1.56)     434.5051 (1.63)     24.0051 (1.23)     429.0077 (1.64)     1.4110 (1.15)        56;70        2.3015 (0.62)       1172           2
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

-------------------------------------------------------------------------------- benchmark 'config=Llama-3-8B bs=2 compute_type=ComputeType.INFERENCE': 5 tests --------------------------------------------------------------------------------
Name (time in us)                                                         Min                   Max                Mean             StdDev              Median               IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_litgpt_swiglu[Llama-3-8B-inference-bs2-torch.compile]           498.0722 (1.0)        661.1804 (1.0)      506.6948 (1.0)      26.4782 (1.0)      500.5887 (1.0)      1.7488 (1.0)        47;103        1.9736 (1.0)        1005           2
test_litgpt_swiglu[Llama-3-8B-inference-bs2-thunder]                 579.1243 (1.16)       934.2823 (1.41)     600.0532 (1.18)     57.7522 (2.18)     585.2776 (1.17)     4.8866 (2.79)       91;192        1.6665 (0.84)       1728           1
test_litgpt_swiglu[Llama-3-8B-inference-bs2-torch.compile+liger]     686.0271 (1.38)       966.3347 (1.46)     706.2979 (1.39)     56.1896 (2.12)     691.5294 (1.38)     4.1462 (2.37)       91;108        1.4158 (0.72)       1458           1
test_litgpt_swiglu[Llama-3-8B-inference-bs2-torch+liger]             805.7933 (1.62)     1,107.1023 (1.67)     821.9818 (1.62)     49.7734 (1.88)     810.3140 (1.62)     3.0571 (1.75)       59;108        1.2166 (0.62)       1241           1
test_litgpt_swiglu[Llama-3-8B-inference-bs2-torch]                   847.1049 (1.70)     1,159.5711 (1.75)     863.2481 (1.70)     49.5070 (1.87)     852.1667 (1.70)     2.7930 (1.60)        53;81        1.1584 (0.59)       1180           1
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

------------------------------------------------------------------------------ benchmark 'config=Llama-3-8B bs=2 compute_type=ComputeType.TRAINING_BACKWARD': 5 tests -----------------------------------------------------------------------------
Name (time in us)                                                          Min                   Max                  Mean             StdDev                Median               IQR            Outliers         OPS            Rounds  Iterations
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_litgpt_swiglu[Llama-3-8B-backward-bs2-torch+liger]               866.7819 (1.0)      1,580.8884 (1.34)       895.1602 (1.00)     74.2108 (1.50)       877.1718 (1.00)     7.7207 (1.99)       66;107  1,117.1185 (1.00)       1150           1
test_litgpt_swiglu[Llama-3-8B-backward-bs2-torch.compile+liger]       869.4883 (1.00)     1,549.4768 (1.31)       893.5480 (1.0)      75.0931 (1.52)       875.5457 (1.0)      7.5251 (1.94)       65;103  1,119.1340 (1.0)        1152           1
test_litgpt_swiglu[Llama-3-8B-backward-bs2-thunder]                   875.8195 (1.01)     1,179.4809 (1.0)        901.4811 (1.01)     55.3433 (1.12)       886.4449 (1.01)     5.6308 (1.45)        72;80  1,109.2856 (0.99)       1140           1
test_litgpt_swiglu[Llama-3-8B-backward-bs2-torch.compile]             876.3615 (1.01)     1,211.2986 (1.03)       904.2943 (1.01)     58.5262 (1.19)       888.1735 (1.01)     7.2438 (1.87)        70;88  1,105.8347 (0.99)       1134           1
test_litgpt_swiglu[Llama-3-8B-backward-bs2-torch]                   1,439.2752 (1.66)     1,740.2600 (1.48)     1,456.4058 (1.63)     49.3826 (1.0)      1,444.8445 (1.65)     3.8790 (1.0)         35;47    686.6218 (0.61)        695           1
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--------------------------------------------------------------------------- benchmark 'config=Llama-3-8B bs=2 compute_type=ComputeType.TRAINING_FORWARD': 5 tests ----------------------------------------------------------------------------
Name (time in us)                                                       Min                   Max                Mean             StdDev              Median               IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_litgpt_swiglu[Llama-3-8B-forward-bs2-torch.compile]           503.6686 (1.0)        692.2465 (1.0)      515.3695 (1.0)      33.6449 (1.0)      506.5673 (1.0)      1.8505 (1.0)        57;118        1.9404 (1.0)         992           2
test_litgpt_swiglu[Llama-3-8B-forward-bs2-thunder]                 584.1590 (1.16)     1,014.1116 (1.46)     609.5276 (1.18)     66.9922 (1.99)     591.9486 (1.17)     6.5845 (3.56)       92;196        1.6406 (0.85)       1710           1
test_litgpt_swiglu[Llama-3-8B-forward-bs2-torch.compile+liger]     698.1157 (1.39)     1,101.9502 (1.59)     722.4015 (1.40)     69.6525 (2.07)     704.0892 (1.39)     3.7793 (2.04)       89;150        1.3843 (0.71)       1434           1
test_litgpt_swiglu[Llama-3-8B-forward-bs2-torch+liger]             809.2802 (1.61)     1,170.8327 (1.69)     827.0002 (1.60)     56.7790 (1.69)     813.6835 (1.61)     3.2717 (1.77)       60;104        1.2092 (0.62)       1237           1
test_litgpt_swiglu[Llama-3-8B-forward-bs2-torch]                   848.6677 (1.68)     1,166.4554 (1.69)     864.2204 (1.68)     49.0663 (1.46)     853.4053 (1.68)     2.8200 (1.52)        53;71        1.1571 (0.60)       1178           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
```

Relevant references:
* There's a request to add Liger kernels as executors: https://github.com/Lightning-AI/lightning-thunder/issues/1103. This PR uses swiglu kernel from Liger project for performance comparison with other alternatives.
* There's a request to cover all MLP variants from LitGPT: https://github.com/Lightning-AI/lightning-thunder/issues/742

cc @crcrpar