### PR TITLE
[benchmark_litgpt] always `destroy_process_group` with `try-except-finally`

### DIFF
--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -875,8 +875,11 @@ if __name__ == "__main__":
 
     from jsonargparse import CLI
 
-    CLI(benchmark_main)
-
-    # ref: https://github.com/pytorch/pytorch/blob/3af12447/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp#L1110-L1116
-    if world_size > 1:
-        torch_dist.destroy_process_group()
+    try:
+        CLI(benchmark_main)
+    except Exception:
+        raise
+    finally:
+        # ref: https://github.com/pytorch/pytorch/blob/3af12447/torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp#L1110-L1116
+        if world_size > 1:
+            torch_dist.destroy_process_group()


### PR DESCRIPTION
## What does this PR do?

As per title. Currently if an exception is raised, `destroy_process_group` is not called.
