### PR TITLE
patching inplace update nvfuser translation

### DIFF
--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -2016,7 +2016,8 @@ def copy_(
 ) -> Any:
     nvcopy_from = getnv(copy_from, fd, lc_to_nv_map)
     nvcopy_to = getnv(copy_to, fd, lc_to_nv_map)
-    fd.add_output(nvcopy_from, alias_input=nvcopy_to)
+    alias_output = fd.ops.set(nvcopy_from)
+    fd.add_output(alias_output, alias_input=nvcopy_to)
     return nvcopy_to
 
 

--- a/thunder/tests/test_inplace_copy.py
+++ b/thunder/tests/test_inplace_copy.py
@@ -158,7 +158,7 @@ def test_inplace_copy_sanity_check(executor, device, dtype):
 def test_inplace_copy_dst_copy_returned_issue_1109(executor, device, dtype):
     def func(T0):
         T1 = torch.sin(T0)
-        T0.copy_(T1) # destination.copy_(source)
+        T0.copy_(T1)  # destination.copy_(source)
         T2 = torch.cos(T1)
         T0.copy_(T2)
         # T1 & T2 should be returned as separate buffer, instead of sharing


### PR DESCRIPTION
Fixes #1109 

`copy_` shouldn't lead to `copy_from` aliasing `copy_to`.