### PR TITLE
Remove interpreter-based identity transform

### DIFF
--- a/thunder/tests/test_core.py
+++ b/thunder/tests/test_core.py
@@ -1558,54 +1558,6 @@ def test_eval_trace(executor, device, _):
 
 @instantiate(
     dtypes=NOTHING,
-    executors=[
-        TorchExecutor,
-    ],
-)
-def test_transforms_identity(executor, device, _):
-    # This test ensures that identity() can be called from within a traced
-    # function without leaking the trace context.
-    # Also tests that identity() can be nested.
-    # Also tests that identity() can be used with "torch" executor.
-    from thunder.core.transforms import identity, Transforms
-
-    # from thunder import _get_executor
-
-    def func(a, b, *, c=5):
-        return clang.mul(clang.mul(clang.add(a, b), 1), c)
-
-    nested_id_func = identity(identity(identity(func)))
-
-    a = make_tensor((2, 2), device=device, dtype=torch.float32)
-    b = make_tensor((2, 2), device=device, dtype=torch.float32)
-    c = 4.0
-
-    nested_id_trace = thunder.trace()(nested_id_func, a, b, c=c)
-    # one annotating symbol per input and one actual symbol
-    assert len(nested_id_trace.bound_symbols) == 6
-    assert nested_id_trace.bound_symbols[-2].sym.id == Transforms.IdentityOp
-
-    trace = nested_id_trace.bound_symbols[-2].kwargs.get("trace", None)
-    for _ in range(2):
-        assert len(trace.bound_symbols) == 6
-        assert trace.bound_symbols[-2].sym.id == Transforms.IdentityOp
-        trace = trace.bound_symbols[-2].kwargs.get("trace", None)
-
-    assert len(trace.bound_symbols) == 7
-    assert trace.bound_symbols[-4].sym.name == "add"
-    assert trace.bound_symbols[-3].sym.name == "mul"
-    assert trace.bound_symbols[-2].sym.name == "mul"
-
-    # TODO: RuntimeError: Could not find executor for bound symbol __f =
-    # thunder.core.transforms.identity_call
-    # fusion = executor.make_callable(nested_id_trace)
-    # actual = fusion(a, b, c=c)
-    # expected = executor.make_callable(func)(a, b, c=c)
-    # torch.testing.assert_close(actual, expected)
-
-
-@instantiate(
-    dtypes=NOTHING,
     executors=(
         TorchExecutor,
         # TODO: nvFuser executor does not support full(shape=()) yet
@@ -1620,21 +1572,6 @@ def test_transforms_vmap_axis_size(executor, device, _):
 
     actual = executor.make_callable(vmap(lambda x: x, axis_size=4), disable_torch_autograd=True)(2)
     assert_close(actual, expected)
-
-
-# TODO Re-enable this, broken by raising NotImplementedError from bool(tensor)
-# @instantiate(
-#     dtypes=NOTHING,
-# )
-# def test_transforms_vmap_identity(executor, device, _):
-#     from thunder.core.transforms import identity, vmap
-
-#     def func(a):
-#         return clang.sin(a)
-
-#     a = torch.randn(2, 2)
-
-#     thunder._make_trace(vmap(identity(func)))(a)
 
 
 # @instantiate(
@@ -2415,30 +2352,8 @@ def test_default_method(executor, device: str, dtype: dtypes.dtype):
 # @instantiate(
 #     dtypes=NOTHING,
 # )
-# def test_transforms_jvp(executor, device, _):
-#     from thunder.core.transforms import jvp, inline, identity
-
-#     def func(a, b):
-#         c = tlang.sin(a)
-#         return tlang.mul(tlang.add(c, b), 1)
-
-#     a = torch.ones(2, 3, device=device, dtype=torch.float32)
-#     b = torch.ones(2, 3, device=device, dtype=torch.float32) * 2
-
-#     primals = (a, b)
-#     tangents = (a, b)
-#     out_p, out_t = thunder.make_traced(identity(jvp(identity(func))), executor=executor)(primals, tangents)
-#     expected_out_p = torch.sin(a) + b
-#     expected_out_t = torch.cos(a) + b
-#     assert_close(out_p, expected_out_p)
-#     assert_close(out_t, expected_out_t)
-
-
-# @instantiate(
-#     dtypes=NOTHING,
-# )
 # def test_transforms_jvp_no_inline(executor, device, _):
-#     from thunder.core.transforms import jvp, inline, identity
+#     from thunder.core.transforms import jvp
 
 #     def func(a, b):
 #         c = tlang.sin(a)


### PR DESCRIPTION
Removing old experiments with interpreter-based transforms.

See https://github.com/Lightning-AI/lightning-thunder/pull/1116 for removing `vmap`.
See https://github.com/Lightning-AI/lightning-thunder/pull/1117 for removing `jvp`.