### PR TITLE
Proxify `FunctionCtx`, define `BoundSymbol`, and define and register augmented rule for `torch.autograd.Function`

### DIFF
--- a/thunder/core/baseutils.py
+++ b/thunder/core/baseutils.py
@@ -75,6 +75,10 @@ class TensorProxyInterface:
     pass
 
 
+class TorchAutogradFunctionXtxProxyInterface:
+    pass
+
+
 class SymbolInterface:
     name: str
     is_prim: bool

--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -709,7 +709,7 @@ def _general_jit_torch_autograd_function_apply_lookaside(obj: Any, *args, **kwar
     bwd_trace_impl = TraceCtx()
     for bsym in custom_bwd_bsyms:
         bwd_trace_impl.add_bound_symbol(bsym)
-    bwd_trace_impl.add_bound_symbol(prims.python_return.bind(*unwrap(custom_backward_result), output=()))
+    bwd_trace_impl.add_bound_symbol(prims.python_return.bind(*sequencify(unwrap(custom_backward_result)), output=()))
     bwd_trace_impl._siginfo = bwd_si
     bwd_impl_callable = bwd_trace_impl.python_callable(include_decorators=False)
 

--- a/thunder/core/proxies.py
+++ b/thunder/core/proxies.py
@@ -16,7 +16,12 @@ import torch
 from thunder.core.compile_data import using_symbolic_values, using_jit
 from thunder.core.interpreter import is_jitting
 from thunder.core.trace import VariableInterface, get_tracectx, TraceCtx
-from thunder.core.baseutils import ProxyInterface, NumberProxyInterface, TensorProxyInterface
+from thunder.core.baseutils import (
+    ProxyInterface,
+    NumberProxyInterface,
+    TensorProxyInterface,
+    TorchAutogradFunctionXtxProxyInterface,
+)
 import thunder.core.baseutils as baseutils
 from thunder.core.langctxs import resolve_method, get_langctx
 import thunder.core.devices as devices
@@ -145,6 +150,8 @@ class Proxy(VariableInterface, ProxyInterface):
                 prefix = "lst"
             elif isinstance(self, DictProxy):
                 prefix = "d"
+            elif isinstance(self, TorchAutogradFunctionCtxProxy):
+                prefix = "fc"
             else:
                 prefix = "p"
 
@@ -1851,6 +1858,63 @@ class TensorProxy(Proxy, TensorProxyInterface):
         return method(self)
 
 
+class TorchAutogradFunctionCtxProxy(Proxy, TorchAutogradFunctionXtxProxyInterface):
+    def __init__(
+        self,
+        ctx: torch.autograd.function.FunctionCtx,
+        /,
+        *,
+        name: str | None = None,
+        history: tuple[Any, ...] | None = None,
+        tags: set[ProxyTag, ...] | None = None,
+    ):
+        self._ctx = ctx
+        self._tensors: list[TensorProxy] = []
+        self._const_for_backward: dict[str, Any] = {}
+        super().__init__(name=name, history=history, tags=tags)
+
+    def type_string(self) -> str:
+        return "TorchAutogradFunctionCtxProxy"
+
+    def __repr__(self) -> str:
+        return f"<TorchAutogradFunctionCtxProxy '{self.name}', '{self.saved_tensors=}', '{self._const_for_backward=}'>"
+
+    def replace(self, **changes):
+        kwargs = dict(
+            name=self.name,
+            history=self.history,
+            tags=self.tags,
+        )
+        kwargs.update(**changes)
+        return TorchAutogradFunctionCtxProxy(
+            self._ctx,
+            **kwargs,
+        )
+
+    @property
+    def saved_tensors(self) -> tuple[TensorProxy, ...]:
+        return tuple(self._tensors)
+
+    @property
+    def saved_consts(self) -> tuple[Any, ...]:
+        return tuple(self._const_for_backward.values())
+
+    def save_for_backward(self, *tensors):
+        self._tensors.extend(tensors)
+
+    def __setattr__(self, name, value):
+        super().__setattr__(name, value)
+        if hasattr(self, "_const_for_backward") and name not in {
+            "_name",
+            "_has_weak_name",
+            "history",
+            "_tags",
+            "_const_for_backward",
+            "_tensors",
+        }:
+            self._const_for_backward[name] = value
+
+
 #
 # Helpers for creating and working with proxies
 #
@@ -1953,6 +2017,8 @@ def proxy(x: Any, *, name: str | None = None, history: None | tuple = None) -> A
         return AnyProxy(x, name=name, history=history)
     if isinstance(x, torch.device):
         return AnyProxy(x, name=name, history=history)
+    if isinstance(x, torch.autograd.function.FunctionCtx):
+        return TorchAutogradFunctionCtxProxy(x, name=name, history=history)
     if isinstance(x, torch.memory_format):
         return AnyProxy(x, name=name, history=history)
 

--- a/thunder/tests/test_jit_general.py
+++ b/thunder/tests/test_jit_general.py
@@ -1167,7 +1167,8 @@ def test_custom_autograd_function():
     model = Model().to(dtype=torch.float64)
     jitted = thunder.jit(model)
 
-    gradcheck(jitted, (x,))
+    with pytest.raises(GradcheckError):
+        gradcheck(jitted, (x,))
     with pytest.raises(GradcheckError):
         gradcheck(model, (x,))
 

--- a/thunder/tests/test_jit_general.py
+++ b/thunder/tests/test_jit_general.py
@@ -1174,17 +1174,19 @@ def test_custom_autograd_function():
 
     class MyLinear(torch.autograd.Function):
         @staticmethod
-        def forward(ctx, x: torch.Tensor, weight: torch.Tensor, shape: tuple) -> torch.Tensor:
+        def forward(ctx, x: torch.Tensor, weight: torch.Tensor, shape: tuple[int, int]) -> torch.Tensor:
             ctx.shape = shape
             ctx.save_for_backward(x, weight)
             ctx.pretty_attr = 100
+            ctx.scaler = 1.0
             return torch.matmul(x, weight.t())
 
         @staticmethod
         def backward(ctx, grad_output):
             (x, weight) = ctx.saved_tensors
             assert weight.shape == ctx.shape  # really bogus, just to use ctx.shape
-            return torch.matmul(grad_output, weight), torch.matmul(grad_output.t(), x)
+            scaler2 = ctx.shape[0] / ctx.shape[1]
+            return torch.matmul(grad_output, weight) * ctx.scaler, torch.matmul(grad_output.t(), x) / scaler2
 
     class Model(torch.nn.Module):
         def __init__(self):


### PR DESCRIPTION
## What does this PR do?

Address #1017.

- ~~[ ] Translate lines involving `ctx` into bsyms, especially in backward to correctly use non-tensor saved intermediates.~~ It seems that non-tensor attributes of `ctx` are folded into a trace.