### PR TITLE
handle non-persistent buffers in materialization

### DIFF
--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -407,9 +407,7 @@ class Benchmark_litGPT:
             }
 
     def init_model(self):
-        init_device = self.device
-        if self.distributed_mode in FSDP_MODES and (self.compile in ("eager", "inductor") or "dynamo" in self.compile):
-            init_device = torch.device("meta")
+        init_device = torch.device("meta") if self.distributed_mode in FSDP_MODES else self.device
         with init_device:
             model = GPT(self.config)
         model.to(dtype=torch.bfloat16)

--- a/thunder/core/module.py
+++ b/thunder/core/module.py
@@ -176,12 +176,13 @@ class ThunderModule(pytorch.nn.Module):
                             v.to(p.device), requires_grad=p.requires_grad
                         )
             elif full_k in self._overrides_buffers:
-                if p.dtype == v.dtype and p.shape == v.shape:
+                b = self._overrides_buffers[full_k]
+                if b.dtype == v.dtype and b.shape == v.shape:
                     with pytorch.no_grad():
-                        self._overrides_buffers[full_k].copy_(v)
+                        b.copy_(v)
                 else:
                     with pytorch.no_grad():
-                        self._overrides_parameters[full_k] = v.to(p.device).requires_grad_(p.requires_grad)
+                        self._overrides_parameters[full_k] = v.to(b.device).requires_grad_(b.requires_grad)
             else:
                 raise NotImplementedError(f"don't know how to handle {full_k}")
             processed_names.add(full_k)

--- a/thunder/tests/test_transforms.py
+++ b/thunder/tests/test_transforms.py
@@ -86,7 +86,6 @@ def test_materialization():
     # the kvcache is not in the state dict, so it must be cuda to start
     m.set_kv_cache(1, device="cuda", dtype=torch.bfloat16)
     m.max_seq_length = 20
-    m.cos, m.sin = ref_m.cos.clone(), ref_m.sin.clone()
 
     for p in m.parameters():
         p._thunder_device = torch.device("cuda")


### PR DESCRIPTION
Fixes: #1051

@crcrpar 

On my silly hardware (and a not-updated-with-latest-pytorch apex):
```
$ torchrun --nproc-per-node 2 --local-ranks-filter 0 --role rank --tee 3 thunder/benchmarks/benchmark_litgpt.py --model_name Llama-2-7b-hf --distributed_mode fsdp --shard_mode zero2 --compile thunder_inductor_cat_cudnn --n_layer 1
W0909 21:06:48.344000 139927969448000 torch/distributed/run.py:779] 
W0909 21:06:48.344000 139927969448000 torch/distributed/run.py:779] *****************************************
W0909 21:06:48.344000 139927969448000 torch/distributed/run.py:779] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
W0909 21:06:48.344000 139927969448000 torch/distributed/run.py:779] *****************************************
[rank0]:xentropy_cuda failed to import with exception /usr/local/lib/python3.11/dist-packages/xentropy_cuda.cpython-311-x86_64-linux-gnu.so: undefined symbol: _ZN3c106detail14torchCheckFailEPKcS2_jRKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
[rank0]:/usr/local/lib/python3.11/dist-packages/torchao/ops.py:12: FutureWarning: `torch.library.impl_abstract` was renamed to `torch.library.register_fake`. Please use that instead; we will remove `torch.library.impl_abstract` in a future version of PyTorch.
[rank0]:  return torch.library.impl_abstract(f"{name}")(func)
[rank0]:Loading model with {'name': 'Llama-2-7b-hf', 'hf_config': {'org': 'meta-llama', 'name': 'Llama-2-7b-hf'}, 'scale_embeddings': False, 'attention_scores_scalar': None, 'block_size': 4096, 'sliding_window_size': None, 'sliding_window_layer_placing': None, 'vocab_size': 32000, 'padding_multiple': 64, 'padded_vocab_size': 32000, 'n_layer': 1, 'n_head': 32, 'head_size': 128, 'n_embd': 4096, 'rotary_percentage': 1.0, 'parallel_residual': False, 'bias': False, 'lm_head_bias': False, 'n_query_groups': 32, 'shared_attention_norm': False, 'norm_class_name': 'RMSNorm', 'post_attention_norm': False, 'post_mlp_norm': False, 'norm_eps': 1e-05, 'mlp_class_name': 'LLaMAMLP', 'gelu_approximate': 'none', 'intermediate_size': 11008, 'rope_condense_ratio': 1, 'rope_base': 10000, 'n_expert': 0, 'n_expert_per_token': 0, 'attention_logit_softcapping': None, 'final_logit_softcapping': None, 'rope_n_elem': 128}
[rank0]:Time to instantiate model: 0.00 seconds.
[rank0]:iter 0: loss 10.5625, iter time: 9608.00ms, t: 4096
[rank0]:iter 1: loss 9.5000, iter time: 257.01ms, t: 4096
[rank0]:iter 2: loss 6.0625, iter time: 237.63ms, t: 4096
[rank0]:iter 3: loss 4.7812, iter time: 246.06ms, t: 4096
[rank0]:iter 4: loss 4.8750, iter time: 241.47ms, t: 4096
[rank0]:iter 5: loss 4.9062, iter time: 243.95ms, t: 4096
[rank0]:iter 6: loss 4.8438, iter time: 243.73ms, t: 4096
[rank0]:iter 7: loss 4.8438, iter time: 243.96ms, t: 4096
[rank0]:iter 8: loss 4.7812, iter time: 238.05ms, t: 4096
[rank0]:iter 9: loss 4.7500, iter time: 244.18ms, t: 4096
[rank0]:iter 10: loss 4.7188, iter time: 245.04ms, t: 4096
[rank0]:iter 11: loss 4.7188, iter time: 245.55ms, t: 4096
[rank0]:iter 12: loss 4.7500, iter time: 243.14ms, t: 4096
[rank0]:iter 13: loss 4.6875, iter time: 242.38ms, t: 4096
[rank0]:iter 14: loss 4.6875, iter time: 241.09ms, t: 4096
[rank0]:iter 15: loss 4.7188, iter time: 242.80ms, t: 4096
[rank0]:iter 16: loss 4.7188, iter time: 239.40ms, t: 4096
[rank0]:iter 17: loss 4.7188, iter time: 245.47ms, t: 4096
[rank0]:iter 18: loss 4.6875, iter time: 242.08ms, t: 4096
[rank0]:iter 19: loss 4.6875, iter time: 244.28ms, t: 4096
[rank0]:iter 20: loss 4.6875, iter time: 241.22ms, t: 4096
[rank0]:iter 21: loss 4.6875, iter time: 247.83ms, t: 4096
[rank0]:iter 22: loss 4.6875, iter time: 242.63ms, t: 4096
[rank0]:iter 23: loss 4.6562, iter time: 245.70ms, t: 4096
[rank0]:iter 24: loss 4.6562, iter time: 247.16ms, t: 4096
[rank0]:iter 25: loss 4.6250, iter time: 243.05ms, t: 4096
[rank0]:iter 26: loss 4.6562, iter time: 243.72ms, t: 4096
[rank0]:iter 27: loss 4.6875, iter time: 243.64ms, t: 4096
[rank0]:iter 28: loss 4.6875, iter time: 239.22ms, t: 4096
[rank0]:iter 29: loss 4.6250, iter time: 244.64ms, t: 4096
[rank0]:iter 30: loss 4.6562, iter time: 241.98ms, t: 4096
[rank0]:iter 31: loss 4.6562, iter time: 244.79ms, t: 4096
[rank0]:iter 32: loss 4.6562, iter time: 241.67ms, t: 4096
[rank0]:iter 33: loss 4.6250, iter time: 242.77ms, t: 4096
[rank0]:iter 34: loss 4.6562, iter time: 241.48ms, t: 4096
[rank0]:iter 35: loss 4.6562, iter time: 243.65ms, t: 4096
[rank0]:iter 36: loss 4.6562, iter time: 241.08ms, t: 4096
[rank0]:iter 37: loss 4.6250, iter time: 246.04ms, t: 4096
[rank0]:iter 38: loss 4.6250, iter time: 242.39ms, t: 4096
[rank0]:iter 39: loss 4.6562, iter time: 246.93ms, t: 4096
[rank0]:iter 40: loss 4.6250, iter time: 241.97ms, t: 4096
[rank0]:iter 41: loss 4.6562, iter time: 243.64ms, t: 4096
[rank0]:iter 42: loss 4.6562, iter time: 241.36ms, t: 4096
[rank0]:iter 43: loss 4.6562, iter time: 244.50ms, t: 4096
[rank0]:iter 44: loss 4.6562, iter time: 236.33ms, t: 4096
[rank0]:Model name: Llama-2-7b-hf
[rank0]:Seq Length: 4096
[rank0]:Micro BS: 1
[rank0]:Global BS: 2
[rank0]:Number of Layers: 1
[rank0]:Number of parameters: 0.23B
[rank0]:Distributed Mode: fsdp
[rank0]:Sharding Mode: zero2
[rank0]:Bucketing: none
[rank0]:Compiler: thunder_inductor_cat_cudnn
[rank0]:Low Precision Mode: none
[rank0]:Average iter time: 242.76 ms
[rank0]:Memory used: 3.88 GB
[rank0]:Tokens/s: 33747.77
[rank0]:Tokens/s/GPU: 16873.89
[rank0]:TFLOP/s: 74.31
```
