### PR TITLE
remat - add mechanism to avoid name collision between forward and backward trace proxies

### DIFF
--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -2998,7 +2998,9 @@ def forward_and_backward_from_trace(trace: Trace, torch_autograd=False) -> Forwa
             out = tree_flatten(out)[0]
         return out
 
-    backward_trace = construct_trace(rename_proxies=False)(backward_fn, saved_for_backward, cotangents)
+    backward_trace = construct_trace(rename_proxies=False, _used_names=forward_trace.names)(
+        backward_fn, saved_for_backward, cotangents
+    )
 
     # We are done with constructing the forward and backward passes at this
     # stage. The following is not strictly necessary, but it's good to filter


### PR DESCRIPTION
Found while investigating https://github.com/Lightning-AI/lightning-thunder/issues/1093 (step 1 for the fix)
Also fixes https://github.com/Lightning-AI/lightning-thunder/issues/1013

Repro

```python
import torch
import thunder

def forward(x):
    return x.softmax(dim = 1, dtype=torch.float)

jforward = thunder.jit(forward)

x = torch.randn([32768, 4096], dtype=torch.bfloat16, device='cuda', requires_grad=True)

o = jforward(x)
```

Fails with

<details>

```python
Traceback (most recent call last):
  File "/home/kkalambarkar/lightning-thunder/scratchpad/test.py", line 239, in <module>
    o = jforward(x)
  File "/home/kkalambarkar/lightning-thunder/thunder/__init__.py", line 704, in fn_
    cache_entry, inps, pro_to_epi = get_computation_and_inputs(*args, **kwargs)
  File "/home/kkalambarkar/lightning-thunder/thunder/core/langctxs.py", line 136, in _fn
    result = fn(*args, **kwargs)
  File "/home/kkalambarkar/lightning-thunder/thunder/__init__.py", line 213, in cache_info_wrapper
    res = fn(*args, **kwargs)
  File "/home/kkalambarkar/lightning-thunder/thunder/__init__.py", line 620, in get_computation_and_inputs
    computation_trc, backward_trc = split_forward_backward(computation_trc, cd, cs, *inps)
  File "/home/kkalambarkar/lightning-thunder/thunder/executors/torch_autograd.py", line 233, in split_forward_backward
    fw_extrace, bw_extrace = rematerialize_forward_and_backward(fw_extrace, bw_extrace)
  File "/home/kkalambarkar/lightning-thunder/thunder/core/rematerialization.py", line 607, in rematerialize_forward_and_backward
    joint_extrace = rematerialize(joint_extrace)
  File "/home/kkalambarkar/lightning-thunder/thunder/core/rematerialization.py", line 556, in rematerialize
    updated_consumer = apply_rematerialization_for_consumer(current_producer, current_consumer, cut)
  File "/home/kkalambarkar/lightning-thunder/thunder/core/rematerialization.py", line 190, in apply_rematerialization_for_consumer
    new_consumer_args = tuple(sorted(new_consumer_args, key=lambda x: proxy_order[x.name]))
  File "/home/kkalambarkar/lightning-thunder/thunder/core/rematerialization.py", line 190, in <lambda>
    new_consumer_args = tuple(sorted(new_consumer_args, key=lambda x: proxy_order[x.name]))
KeyError: 't4'
```

</details>

Reason - For rematerialization, there is an expectation that the forward and backward trace shouldn't have tensor proxy name collision except for the proxies passed as saved_for_backward.

However, for the above code the joint trace (passed to rematerialization) looks like the following. Remat finds a cut at `t4` but `t4` in the forward and backward section are different tensors (from different computation).

```python
def joint_fn(args, kwargs, cotangents):
  # L_stack0_: "cuda:0 bf16[32768, 8]"
  [t9] = nvFusion0(L_stack0_)
    # t0 = prims.convert_element_type(L_stack0_, dtypes.float32)  # t0: "cuda:0 f32[32768, 8]"
    # t1 = prims.amax(t0, (1,))  # t1: "cuda:0 f32[32768]"
    # t2 = prims.broadcast_in_dim(t1, [32768, 1], [0])  # t2: "cuda:0 f32[32768, 1]"
    # t3 = prims.broadcast_in_dim(t2, (32768, 8), (0, 1))  # t3: "cuda:0 f32[32768, 8]"
    # t4 = prims.sub(t0, t3)  # t4: "cuda:0 f32[32768, 8]"
    # t5 = prims.exp(t4)  # t5: "cuda:0 f32[32768, 8]"
    # t6 = prims.sum(t5, (1,))  # t6: "cuda:0 f32[32768]"
    # t7 = prims.broadcast_in_dim(t6, [32768, 1], [0])  # t7: "cuda:0 f32[32768, 1]"
    # t8 = prims.broadcast_in_dim(t7, (32768, 8), (0, 1))  # t8: "cuda:0 f32[32768, 8]"
    # t9 = prims.div(t5, t8)  # t9: "cuda:0 f32[32768, 8]"
  # saved_for_backward: "Collection"
  # cotangents: "Collection"
  C0, _, = saved_for_backward
  t10, = cotangents
  t9, = C0
  [t7] = nvFusion0(t9, t10)
    # t2 = prims.mul(t9, t10)  # t2: "cuda:0 f32[32768, 8]"
    # t3 = prims.sum(t2, (1,))  # t3: "cuda:0 f32[32768]"
    # t4 = prims.broadcast_in_dim(t3, [32768, 1], [0])  # t4: "cuda:0 f32[32768, 1]"
    # t5 = prims.broadcast_in_dim(t4, (32768, 8), (0, 1))  # t5: "cuda:0 f32[32768, 8]"
    # t6 = prims.sub(t10, t5)  # t6: "cuda:0 f32[32768, 8]"
    # t7 = prims.mul(t9, t6)  # t7: "cuda:0 f32[32768, 8]"
  return {'output': t9, 'flat_args': [L_stack0_], 'flat_output': (t9,)}, ((t7,),)

```

Fix - We add a new argument `_used_names` to `thunder.trace` which makes sure that these names won't be used in the new trace produced by `thunder.trace`. This is then used to construct `backward_trace` without reusing names from `forward_trace`.

Related discussion - https://github.com/Lightning-AI/lightning-thunder/issues/1093#issuecomment-2338327798 
