### PR TITLE
softmax - fix backward with dtype

### DIFF
--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -2181,13 +2181,14 @@ def softmax_aug_fwd(a: Proxy, dim: int, dtype: dtypes.dtype | None = None) -> VJ
     from thunder.torch import softmax
 
     primal = softmax(a, dim, dtype=dtype)
-    residuals = (primal, dim)
+    residuals = (primal, dim, a.dtype)
     return VJPDual(primal, residuals)
 
 
 @register_backward("torch.softmax")
-def softmax_backward(primal, dim, g):
-    return primal * (g - (primal * g).sum(dim, keepdim=True))
+def softmax_backward(primal, dim, input_dtype, g):
+    grad = primal * (g - (primal * g).sum(dim, keepdim=True))
+    return grad.to(input_dtype) if grad.dtype != input_dtype else grad
 
 
 def iter_bound_symbols(bound_symbols):

--- a/thunder/tests/test_grad.py
+++ b/thunder/tests/test_grad.py
@@ -1718,3 +1718,24 @@ def test_inconsistent_output_length_grad_transform():
         match="number of outputs of the original forward function must be the same as the number of primal outputs",
     ):
         _ = jf(a)
+
+
+@pytest.mark.parametrize("device", ("cuda", "cpu"))
+def test_grad_softmax_dtype(device):
+    def forward(x):
+        topk, _idxs = x.topk(2)
+        return topk.softmax(dim=1, dtype=torch.float)
+
+    jforward = thunder.jit(forward)
+
+    x = torch.randn([8, 2], dtype=torch.bfloat16, device="cuda", requires_grad=True)
+
+    actual = jforward(x)
+    expected = forward(x)
+    torch.testing.assert_close(actual, expected)
+
+    grad_o = torch.randn_like(actual)
+
+    actual_grad = torch.autograd.grad(actual, x, grad_o)
+    expected_grad = torch.autograd.grad(expected, x, grad_o)
+    torch.testing.assert_close(actual_grad, expected_grad)


### PR DESCRIPTION
Fixes https://github.com/Lightning-AI/lightning-thunder/issues/1093

Repro
```python
import torch
import thunder

def forward(x):
    topk, _idxs = x.topk(2)
    return topk.softmax(dim=1, dtype=torch.float)

jforward = thunder.jit(forward)

x = torch.randn([8, 2], dtype=torch.bfloat16, device='cuda', requires_grad=True)

actual = jforward(x)
```

<details>

<summary>Error Stack Trace</summary>

Error
```python
#   File "/home/kkalambarkar/lightning-thunder/thunder/torch/__init__.py", line 2861, in scatter_add
#     return clang.scatter_add(a, indices=index, value=src, dim=dim)
#   File "/home/kkalambarkar/lightning-thunder/thunder/core/langctxs.py", line 136, in _fn
#     result = fn(*args, **kwargs)
#   File "/home/kkalambarkar/lightning-thunder/thunder/clang/__init__.py", line 1215, in scatter_add
#     return prims.scatter_add(a, indices, value, dim)
#   File "/home/kkalambarkar/lightning-thunder/thunder/core/symbol.py", line 316, in __call__
#     result = self.meta(*args, **kwargs)
#   File "/home/kkalambarkar/lightning-thunder/thunder/core/langctxs.py", line 136, in _fn
#     result = fn(*args, **kwargs)
#   File "/home/kkalambarkar/lightning-thunder/thunder/core/prims.py", line 3400, in scatter_add_meta
#     utils.check_same_dtype(a, value)
#   File "/home/kkalambarkar/lightning-thunder/thunder/core/utils.py", line 240, in check_same_dtype
#     check(
#   File "/home/kkalambarkar/lightning-thunder/thunder/core/baseutils.py", line 103, in check
#     raise exception_type(s())
# RuntimeError: Expected dtype thunder.dtypes.bfloat16 but found thunder.dtypes.float32!
```

</details>

Problem - `softmax` with dtype argument returns gradients with dtype of the `dtype` argument not the original input.
```python
import torch
import thunder

def forward(x):
    return x.softmax(dim=1, dtype=torch.float)

jforward = thunder.jit(forward)

x = torch.randn([8, 2], dtype=torch.bfloat16, device='cuda', requires_grad=True)

actual = jforward(x)

print(thunder.last_backward_traces(jforward)[0])
```

Backward Trace - note that the dtype of `t16` is float.
```python
# Constructed by Backward pass
import thunder
import thunder.torch as ltorch
import torch
from thunder.executors.torchex import no_autocast

@torch.no_grad()
@no_autocast
def backward_fn(saved_for_backward, cotangents):
  # saved_for_backward: "Collection"
  # cotangents: "Collection"
  C0, C1, = saved_for_backward
  t10, = cotangents
  t9, = C0
  # C1 (empty sequence)
  t11 = ltorch.mul(t9, t10)  # t11: "cuda:0 f32[8, 2]"
    # t11 = prims.mul(t9, t10)  # t11: "cuda:0 f32[8, 2]"
  t13 = ltorch.sum(t11, 1, True, dtype=None)  # t13: "cuda:0 f32[8, 1]"
    # t12 = prims.sum(t11, (1,))  # t12: "cuda:0 f32[8]"
    # t13 = prims.broadcast_in_dim(t12, [8, 1], [0])  # t13: "cuda:0 f32[8, 1]"
  t15 = ltorch.sub(t10, t13, alpha=None)  # t15: "cuda:0 f32[8, 2]"
    # t14 = prims.broadcast_in_dim(t13, (8, 2), (0, 1))  # t14: "cuda:0 f32[8, 2]"
    # t15 = prims.sub(t10, t14)  # t15: "cuda:0 f32[8, 2]"
  t16 = ltorch.mul(t9, t15)  # t16: "cuda:0 f32[8, 2]"
    # t16 = prims.mul(t9, t15)  # t16: "cuda:0 f32[8, 2]"
  return (t16,)
```

Solution - Move gradient to input dtype if it isn't already.

Test - We already have a test in OpInfo with dtype argument but it doesn't catch this because PyTorch's autograd takes care of converting grads to original input dtype internally (see snippet below) 😮. So we add a new test in `test_grad.py`

Interest PyTorch behaviour -
```python
import torch
import thunder

class Identity(torch.autograd.Function):
    @staticmethod
    def forward(ctx, x):
        ctx.org_dtype = x.dtype
        return x

    @staticmethod
    def backward(ctx, g):
        print("IDENTITY BACKWARD", g.dtype)  # IDENTITY BACKWARD torch.bfloat16
        assert ctx.org_dtype == g.dtype
        return g

def forward(x):
    return x.softmax(dim=1, dtype=torch.float)

jforward = thunder.jit(forward)

x = torch.randn([8, 2], dtype=torch.bfloat16, device='cuda', requires_grad=True)

actual = jforward(x)
actual.sum().backward()
print(x.grad.dtype)  # torch.bfloat16


x = torch.randn([8, 2], dtype=torch.bfloat16, device='cuda', requires_grad=True)

actual = jforward(Identity.apply(x))
actual.sum().backward()
print(x.grad.dtype)  # torch.bfloat16
```

Most likely happens due to https://github.com/pytorch/pytorch/blob/4cde5096c4dd8dc2fcdc108e5ef6a800baacb1f2/torch/csrc/autograd/engine.cpp#L892-L896