### PR TITLE
properly discard return values in STORE_ITEM (and STORE_SLICE)

### DIFF
--- a/thunder/core/interpreter.py
+++ b/thunder/core/interpreter.py
@@ -5780,6 +5780,7 @@ def _store_attr_handler(
     res = _interpret_call(impl, tos, name, tos1)
     if res is INTERPRETER_SIGNALS.EXCEPTION_RAISED:
         return res
+    # otherwise, the return value is discarded
 
 
 # https://docs.python.org/3.10/library/dis.html#opcode-STORE_DEREF
@@ -5906,7 +5907,10 @@ def _store_slice_handler(inst: dis.Instruction, /, stack: InterpreterStack, **kw
     def impl(container, start, end, values):
         return container.__setitem__(slice(start, end), values)
 
-    return _interpret_call_with_unwrapping(impl, container, start, end, values)
+    res = _interpret_call_with_unwrapping(impl, container, start, end, values)
+    if res is INTERPRETER_SIGNALS.EXCEPTION_RAISED:
+        return res
+    # otherwise, the return value is discarded
 
 
 # https://docs.python.org/3.10/library/dis.html#opcode-STORE_SUBSCR
@@ -5919,7 +5923,10 @@ def _store_subscr_handler(inst: dis.Instruction, /, stack: InterpreterStack, **k
     def impl(tos, tos1, tos2):
         return tos1.__setitem__(tos, tos2)
 
-    return _interpret_call_with_unwrapping(impl, tos, tos1, tos2)
+    res = _interpret_call_with_unwrapping(impl, tos, tos1, tos2)
+    if res is INTERPRETER_SIGNALS.EXCEPTION_RAISED:
+        return res
+    # otherwise, the return value is discarded
 
 
 # https://docs.python.org/3.10/library/dis.html#opcode-UNARY_INVERT

--- a/thunder/tests/test_interpreter.py
+++ b/thunder/tests/test_interpreter.py
@@ -3324,6 +3324,33 @@ def test_class_setattr():
     assert A.FOO
 
 
+def test_setitem_setattr():
+    class A:
+        def __init__(self, l):
+            super().__setattr__("l", l)  # avoid hitting our setattr
+
+        def __setattr__(self, name, val):
+            self.l.append((name, val))
+            return (name, val)  # unexpected
+
+        def __setitem__(self, idx, val):
+            self.l.append((idx, val))
+            return (idx, val)  # unexpected
+
+    def foo():
+        l = []
+        a = A(l)
+        a.attr = 3
+        a[1] = 2
+        return l
+
+    jfoo = thunder.jit(foo)
+    res = jfoo()
+    expected = foo()
+
+    assert res == expected
+
+
 def test_freeing_of_tensors():
     # this guards against ref cycles preventing reeing of tensors
     # see https://github.com/Lightning-AI/lightning-thunder/issues/886


### PR DESCRIPTION
In Python, when `__setitem__` returns a value, it is silently discarded.
The interpreter broke with the weirdest error. Let's do as Python and properly discard it (with raccolta differenziata).