### PR TITLE
[jit_ext] check `_interpret_call` result in custom `torch.autograd.Function`

### DIFF
--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -677,7 +677,7 @@ def _general_jit_torch_autograd_function_apply_lookaside(obj: Any, *args, **kwar
     custom_bwd_bsyms: list[BoundSymbol] = []
     jit_ctx.computation_trace.scopes = [custom_bwd_bsyms]
     grads = tree_map(
-        lambda a: TensorProxy(like=a).replace_name(f"grad_{a.name}"),
+        lambda a: a.replace_name(f"grad_{a.name}"),
         sequencify(unwrapped_custom_forward_result),
     )
     wrapped_grads = tree_map(lambda g: wrap(g, provenance=custom_forward_result.provenance), grads)


### PR DESCRIPTION
## What does this PR do?

Improves error message from https://github.com/Lightning-AI/lightning-thunder/blob/0073731b8a7290fcf86fcd992c5763b353ef5d65/thunder/core/jit_ext.py#L594.

If `MyCustomFunc(torch.autograd.Function).forward(ctx, *args, **kwargs)` is not compatible with Thunder, the forward result would be `INTERPRETER_SIGNALS.EXCEPTION_RAISED` instead of one or more wrapped whatever `TensorProxy`s, thus the grads creation around https://github.com/Lightning-AI/lightning-thunder/blob/0073731b8a7290fcf86fcd992c5763b353ef5d65/thunder/core/jit_ext.py#L675-L677 would err out with a bit unclear error message, for example,

```
../../crcrpar/ao/torchao/float8/float8_tensor.py:246: in hp_tensor_and_scale_to_float8
    return _ToFloat8ConstrFunc.apply(
thunder/core/interpreter.py:6778: in _setup_frame_and_run_python_function
    res, status = _run_frame(frame, compilectx, runtimectx)
thunder/core/interpreter.py:6827: in _run_frame
    interpretation_result: None | int | INTERPRETER_SIGNALS = compilectx.interpret(
thunder/core/interpreter.py:412: in interpret
    return self._opcode_interpreter(inst, **interpreter_state)
thunder/core/interpreter.py:1227: in default_opcode_interpreter
    return handler(inst, **interpreter_state)
thunder/core/interpreter.py:3827: in _call_method_handler
    res = _interpret_call(meth, *args)
thunder/core/interpreter.py:6357: in _interpret_call
    rval = _call_dispatch(compilectx, runtimectx, fn, *args, **kwargs)  # type: ignore
thunder/core/interpreter.py:6518: in _call_dispatch
    res = lookaside_fn(*args, **kwargs)
thunder/core/jit_ext.py:675: in _general_jit_torch_autograd_function_apply_lookaside
    grads = tree_map(
../../../../.pyenv/versions/3.10.13/envs/torchdev-3.10/lib/python3.10/site-packages/optree/ops.py:747: in tree_map
    return treespec.unflatten(map(func, *flat_args))
thunder/core/jit_ext.py:676: in <lambda>
    lambda a: TensorProxy(like=a).replace_name(f"grad_{a.name}"), sequencify(unwrapped_custom_forward_result)
thunder/core/proxies.py:1442: in __init__
    ) = _infer_tensor_properties(
thunder/core/proxies.py:1233: in _infer_tensor_properties
    baseutils.check_type(like, (TensorProxy, FutureTensorProxy, TorchAoFloat8TensorProxy))
thunder/core/baseutils.py:111: in check_type
    check(

...

>               raise InterpreterError(msg) from e
E               thunder.core.interpreter.InterpreterError: Encountered exception ValueError: INTERPRETER_SIGNALS.EXCEPTION_RAISED had an unexpected type <enum 'INTERPRETER_SIGNALS'>. Supported types are (<class 'thunder.core.proxies.TensorProxy'>, <class 'thunder.core.proxies.FutureTensorProxy'>, <class 'thunder.core.proxies.TorchAoFloat8TensorProxy'>) while tracing Float8Linear(in_features=64, out_features=32, bias=True, scaling="i:dyn,w:dyn,go:dyn"):

thunder/core/interpreter.py:7120: InterpreterError
```

(for those who are interested in where the message comes from, I by chance found this not lucid one while I was trying to support torchao's float8 tensor