### PR TITLE
thunder + dynamo : splitter - fix support for cat

### DIFF
--- a/thunder/dynamo/utils.py
+++ b/thunder/dynamo/utils.py
@@ -9,7 +9,6 @@ import torch
 from thunder.torch.default_torch_ops import torch_auto_registered_ops
 from thunder.torch import _torch_to_thunder_function_map
 
-
 auto_register_ops = set(itertools.chain(*torch_auto_registered_ops.values()))
 
 
@@ -164,8 +163,8 @@ def try_execute_thunder_symbol(thunder_symbol: "Symbol", node: torch.fx.Node) ->
                     # This is int, float, etc.
                     return arg_node
 
-                proxy_args = tuple(map(make_tensor_proxy, node.args))
-                proxy_kwargs = {k: make_tensor_proxy(v) for k, v in node.kwargs.items()}
+                proxy_args = torch.fx.map_arg(node.args, make_tensor_proxy)
+                proxy_kwargs = {k: torch.fx.map_arg(v, make_tensor_proxy) for k, v in node.kwargs.items()}
             except Exception as e:
                 return False, SplitReason(
                     SplitReasonType.EXCEPTION_PROXY_THUNDER_OP,

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -296,15 +296,11 @@ def test_cat(executor, device: str, dtype: dtypes.dtype, cat_kwarg):
 
     out = func(x)
 
-    # out should have grad_fn and its name should be ThunderFunctionBackward
-    assert out.grad_fn is not None
-    assert out.grad_fn.name() == "ThunderFunctionBackward"
-
     # We record the GraphModules that was compiled by ThunderCompiler
     assert len(backend.subgraph_infos) == 1
 
     for subgraph_info in backend.subgraph_infos:
-        assert len(subgraph_info.split_reasons) == 0
+        assert len(subgraph_info.split_reasons) == 0  # Verify there were no splits
         assert isinstance(subgraph_info.original_graph_module, torch.fx.GraphModule)
         assert len(subgraph_info.thunder_compiled_fns)  # There was atleast one function compiled with thunder.
         for thunder_fn in subgraph_info.thunder_compiled_fns:

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -275,8 +275,9 @@ def test_force_skip_lazy_graph_module(executor, device: str, dtype: dtypes.dtype
 @instantiate(
     dtypes=NOTHING, executors=[DynamoThunderExecutor], decorators=(pytest.mark.parametrize("cat_kwarg", (True, False)),)
 )
-def test_cat(executor, device: str, dtype: dtypes.dtype, cat_kwarg):
-
+def test_cat_no_split(executor, device: str, dtype: dtypes.dtype, cat_kwarg):
+    # fx.Node for `torch.cat` receives `torch.fx.immutable_collections.immutable_list` as Node.args.
+    # This test verifies that we don't cause a split because of this.
     backend = ThunderCompiler()
     x = torch.ones(2, dtype=dtype, device=device, requires_grad=True)
 


### PR DESCRIPTION
Repro - 
```python
import torch
import thunder

def my_cat(x):
    y = torch.cat(tensors=[x, x])
    return y.sin()

from thunder.dynamo import ThunderCompiler

backend = ThunderCompiler()
jfn = torch.compile(my_cat, backend=backend)

o = jfn(torch.randn(3, 3))
print(backend.subgraph_infos[0].split_reasons)
```

Output
```python
[SplitReason(type=<SplitReasonType.EXCEPTION_META_THUNDER_OP: 4>, info='Failed while running meta for node with name: y and target: <built-in method cat of type object at 0x7296b46e2ea0>, see exception field', exception=ValueError("l_x_ had an unexpected type <class 'torch.fx.node.Node'>. Supported types are (<class 'thunder.core.proxies.TensorProxy'>, <class 'numbers.Number'>, <class 'thunder.core.proxies.NumberProxy'>)"))]
```

It happens because the `node.args` for `torch.cat` node is `<class 'torch.fx.immutable_collections.immutable_list'>` and we don't handle it correctly.

Solution - We use `map_arg` from `torch.fx` to apply `make_tensor_proxy` correctly to all input `fx.Node`.

`map_arg` - https://github.com/pytorch/pytorch/blob/bbc3fdbbde3f35467b40cf06ec4926adca1876d4/torch/fx/node.py#L777-L784