### PR TITLE
TE - fix - removal of with_transpose argument

### DIFF
--- a/thunder/executors/transformer_engineex.py
+++ b/thunder/executors/transformer_engineex.py
@@ -38,7 +38,6 @@ TE_AVAILABLE: bool = package_available("transformer_engine")
 # Ex. addition of a positional argument for cpu_offloading (not as the last argument)
 # between version 1.2 and 1.3.
 # Hence, we have these guards based on version.
-TE_VERSION_1_8_PLUS: bool = False
 TE_VERSION_1_11_PLUS: bool = False
 
 te: None | Any = None
@@ -51,20 +50,19 @@ if TE_AVAILABLE:
         from transformer_engine.pytorch.fp8 import FP8GlobalStateManager
         from transformer_engine.pytorch.utils import check_dim_for_fp8_exec
         from transformer_engine.pytorch.cpu_offload import CPUOffloadEnabled
+        import transformer_engine_torch as tex
     except Exception as ex:
         warnings.warn(f"transformer_engine failed to import with exception {ex}")
         TE_AVAILABLE = False
 
-    TE_VERSION_1_8_PLUS = LooseVersion(version("transformer_engine")) > LooseVersion("1.8")
+    TE_VERSION_1_9_PLUS = LooseVersion(version("transformer_engine")) > LooseVersion("1.9")
     TE_VERSION_1_11_PLUS = LooseVersion(version("transformer_engine")) > LooseVersion("1.11")
-    if not TE_VERSION_1_8_PLUS:
+    if not TE_VERSION_1_9_PLUS:
         warnings.warn(
             f"Installed version of transformer_engine {version('transformer_engine')} is not supported, please upgrade. `transformer_engine_ex` will not be used."
         )
         TE_AVAILABLE = False
 
-    if TE_VERSION_1_8_PLUS:
-        import transformer_engine_torch as tex
 
 if not TE_AVAILABLE:
     TransformerEngineBaseModule = object
@@ -177,12 +175,8 @@ class TELinear(TransformerEngineBaseModule):
         if FP8GlobalStateManager.with_fp8_parameters():
             raise RuntimeError("Primary weights in FP8 is not supported under `thunder.jit`.")
 
-        if not TE_VERSION_1_8_PLUS:
-            # Required by `get_fp8_weights_scratchpad`
-            self.fp8_weight_shapes.append(torch.Size((self.out_features, self.in_features)))
-
-        # This is available only v1.8 onwards
-        if _should_shard_intermediate() and TE_VERSION_1_8_PLUS:
+        # NOTE - This is available only v1.8 onwards
+        if _should_shard_intermediate():
             self.pg = get_compile_data().process_group_for_ddp
         else:
             self.pg = None
@@ -225,7 +219,6 @@ class TELinear(TransformerEngineBaseModule):
                 "ctx": ctx,
                 "weight": weight,
                 "weight_fp8": weight_fp8,
-                "weight_t_fp8": weight_t_fp8,
                 "inp": inp,
                 "bias": torch.tensor([]) if not use_bias else bias,
                 "use_bias": bias is not None,
@@ -241,11 +234,8 @@ class TELinear(TransformerEngineBaseModule):
                 "activation_dtype": inp.dtype,
                 "parallel_mode": None,
                 "is_grad_enabled": is_grad_enabled,
-                "primary_weights_in_fp8": False,
                 "ub_name": None,
                 "cpu_offloading": CPUOffloadEnabled,
-                # ref: https://github.com/NVIDIA/TransformerEngine/blame/7c1828f80edc1405d4ef1a7780c9e0046beab5c7/transformer_engine/pytorch/module/linear.py#L70
-                "skip_fp8_weight_update": None,
                 # ref: https://github.com/NVIDIA/TransformerEngine/blame/7c1828f80edc1405d4ef1a7780c9e0046beab5c7/transformer_engine/pytorch/module/linear.py#L84-L85
                 "ub_overlap_rs": False,
                 "ub_overlap_ag": False,
@@ -263,10 +253,6 @@ class TELinear(TransformerEngineBaseModule):
 
             # Remove kwargs if they are not used in the current version.
             unused_kwargs = set(kwargs.keys()) - set(params)
-            if TE_VERSION_1_8_PLUS:
-                # Sincev1.8 onwards, these args are not part of the _Linear API.
-                assert unused_kwargs == {"skip_fp8_weight_update", "primary_weights_in_fp8", "weight_t_fp8"}
-
             for unused_kwarg in unused_kwargs:
                 kwargs.pop(unused_kwarg)
 
@@ -279,25 +265,20 @@ class TELinear(TransformerEngineBaseModule):
         weight_t_fp8: torch.Tensor = None
         weight_fp8: torch.Tensor = None
         # Fetch the fp8 weights placeholders (for linear/gemm)
-        if not TE_VERSION_1_8_PLUS:
-            weight_fp8, weight_t_fp8 = self.get_fp8_weights_scratchpad(is_first_microbatch)
-        else:
-            # Initialize FP8 weights workspace if needed
+        # Initialize FP8 weights workspace if needed
+        # FP8 cast to workspace buffer
+        update_workspace = is_first_microbatch is None or is_first_microbatch
+        skip_fp8_weight_update = None
 
-            # FP8 cast to workspace buffer
-            with_transpose = is_grad_enabled
-            update_workspace = is_first_microbatch is None or is_first_microbatch
-            skip_fp8_weight_update = None
-
-            weight_fp8 = self.get_fp8_workspace(
-                tensor=weight,
-                fp8_meta_forward=True,
-                fp8_meta_index=tex.FP8FwdTensors.GEMM1_WEIGHT,
-                cache_name=(None if is_first_microbatch is None else "weight"),
-                update_workspace=update_workspace,
-                skip_update_flag=skip_fp8_weight_update,
-                with_transpose=with_transpose,
-            )
+        weight_fp8 = self.get_fp8_workspace(
+            tensor=weight,
+            fp8_meta_forward=True,
+            fp8_meta_index=tex.FP8FwdTensors.GEMM1_WEIGHT,
+            cache_name=(None if is_first_microbatch is None else "weight"),
+            update_workspace=update_workspace,
+            skip_update_flag=skip_fp8_weight_update,
+            **{"with_transpose": is_grad_enabled} if not TE_VERSION_1_11_PLUS else {},
+        )
 
         return weight_fp8, weight_t_fp8
 
@@ -404,10 +385,7 @@ def _te_functional_linear_backward_impl(
 
     # Due to different in `_Linear.forward` API, position of
     # returned grad has changed.
-    if TE_VERSION_1_8_PLUS:
-        grad_inputs = (grads[2], grads[0], grads[3])
-    else:
-        grad_inputs = (grads[3], grads[0], grads[4])
+    grad_inputs = (grads[2], grads[0], grads[3])
     return grad_inputs
 
 

--- a/thunder/tests/distributed/test_ddp.py
+++ b/thunder/tests/distributed/test_ddp.py
@@ -21,7 +21,6 @@ from thunder.executors.transformer_engineex import (
     transformer_engine_ex,
     TE_AVAILABLE,
     te_sync_fp8_meta_bwd,
-    TE_VERSION_1_8_PLUS,
 )
 
 

--- a/thunder/tests/distributed/test_fsdp.py
+++ b/thunder/tests/distributed/test_fsdp.py
@@ -24,7 +24,6 @@ from thunder.tests.framework import instantiate, TorchExecutor
 from thunder.executors.transformer_engineex import (
     transformer_engine_ex,
     TE_AVAILABLE,
-    TE_VERSION_1_8_PLUS,
 )
 
 
@@ -1073,7 +1072,7 @@ def test_native_fsdp(executor, devices, dtype, fsdp_bucketing_strategy):
                 (FSDPType.ZERO2, False),
                 (FSDPType.ZERO3, False),
                 # Intermediate sharding is only availabe TE v1.8 onwards
-                *(((FSDPType.ZERO3, True),) if TE_VERSION_1_8_PLUS else ()),
+                (FSDPType.ZERO3, True),
             ),
         ),
         pytest.mark.skipif(not TE_AVAILABLE, reason="TransformerEngine is not installed."),


### PR DESCRIPTION
Fixes https://github.com/Lightning-AI/lightning-thunder/issues/1149

In latest TE main, PR https://github.com/NVIDIA/TransformerEngine/pull/1127 removed `with_transpose` argument from the method `get_fp8_workspace`. We update our code accordingly.

Besides this, we remove the version switch variable based on TE v1.8 and update minimum supported version to v1.9.

Tested with
```bash
pytest thunder/tests/test_transformer_engine_executor.py -v
pytest thunder/tests/distributed/test_ddp.py -k transformer -v
pytest thunder/tests/distributed/test_fsdp.py -k transformer -v
```

On version [v1.9](https://github.com/NVIDIA/TransformerEngine/releases/tag/v1.9), [v1.10](https://github.com/NVIDIA/TransformerEngine/releases/tag/v1.10) (current stable released 5 days ago) and v1.11 (current main).

