### PR TITLE
update fsdp tutorial notebook as per latest PT nightly

### DIFF
--- a/notebooks/dev_tutorials/fsdp_tutorial.ipynb
+++ b/notebooks/dev_tutorials/fsdp_tutorial.ipynb
@@ -53,6 +53,7 @@
     "import torch.distributed\n",
     "import thunder\n",
     "import thunder.distributed\n",
+    "from looseversion import LooseVersion\n",
     "from IPython.display import Code"
    ]
   },
@@ -210,9 +211,15 @@
    "outputs": [],
    "source": [
     "# Create a process group\n",
-    "options = torch.distributed.distributed_c10d.ProcessGroup.Options(backend=\"nccl\")\n",
-    "process_group = torch.distributed.distributed_c10d.ProcessGroup(torch.distributed.distributed_c10d.Store(),\n",
-    "                                                     global_rank, world_size, options)\n",
+    "\n",
+    "if LooseVersion(torch.__version__) > LooseVersion(\"2.6\"):\n",
+    "    # ProcessGroup constructor has been updated since https://github.com/pytorch/pytorch/pull/135653/\n",
+    "    process_group = torch.distributed.distributed_c10d.ProcessGroup(torch.distributed.distributed_c10d.Store(),\n",
+    "                                                                    global_rank, world_size)\n",
+    "else:\n",
+    "    options = torch.distributed.distributed_c10d.ProcessGroup.Options(backend=\"nccl\")\n",
+    "    process_group = torch.distributed.distributed_c10d.ProcessGroup(torch.distributed.distributed_c10d.Store(),\n",
+    "                                                                    global_rank, world_size, options)\n",
     "torch.distributed.distributed_c10d.GroupMember.WORLD = process_group"
    ]
   },


### PR DESCRIPTION
In PyTorch PR https://github.com/pytorch/pytorch/pull/135653, the API for ProcessGroup constructor has changed. (This affects 
nightly CI running the NBs)

Fix - Update the NB accordingly