### PR TITLE
(Experimental) Make nvFuser executor treat `ltorch.copy_` differently from `prims.copy_`

### DIFF
--- a/thunder/clang/__init__.py
+++ b/thunder/clang/__init__.py
@@ -1861,6 +1861,11 @@ def copysign(a, b):
     return maybe_convert_to_dtype(result, result_dtype)
 
 
+@clangop()
+def copy_(src, dst):
+    return prims.copy_(src, dst)
+
+
 @clangop(method_name="eq")
 def eq(a, b):
     return _elementwise_binary_wrapper(

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -2048,9 +2048,27 @@ def _copy__check(
     return are_supported_tensors(copy_from, copy_to)
 
 
+# prims.copy_(copy_from, copy_to)
 def copy_(
     copy_from: TensorProxy,
     copy_to: TensorProxy,
+    *,
+    fd: FusionDefinition,
+    lc_to_nv_map: dict,
+) -> Any:
+    nvcopy_from = getnv(copy_from, fd, lc_to_nv_map)
+    nvcopy_to = getnv(copy_to, fd, lc_to_nv_map)
+    fd.add_output(nvcopy_from, alias_input=nvcopy_to)
+    return nvcopy_to
+
+
+register_supported(PrimIDs.COPY_, copy_, _copy__check)
+
+
+# copy_to.copy_(copy_from)
+def ltorch_copy_(
+    copy_to: TensorProxy,
+    copy_from: TensorProxy,
     *,
     fd: FusionDefinition,
     lc_to_nv_map: dict,
@@ -2062,7 +2080,7 @@ def copy_(
     return nvcopy_to
 
 
-register_supported(PrimIDs.COPY_, copy_, _copy__check)
+register_supported(ltorch.copy_.id, ltorch_copy_, _copy__check)
 
 
 # Removes excessive float casts, like those that occur when autocasting

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -1917,9 +1917,11 @@ def copysign_(a, b, /):
     return prims.copy_(copysign(a, b), a)
 
 
-@torchsymbol(torch.Tensor.copy_, is_method=True)  # , tags=(prims.OpTags.IN_PLACE,))
-def copy_(a, b, /):
-    return prims.copy_(b, a)
+# Currently copy_ is not treated as an inplace op
+@torchsymbol(torch.Tensor.copy_, is_method=True)
+def copy_(dst, src, /):
+    # dst.copy_(src) translates into clang.copy_(src, dst)
+    return prims.copy_(src, dst)
 
 
 # TODO Implement div


### PR DESCRIPTION
Fixes #1173. I implemented the idea mentioned in https://github.com/Lightning-AI/lightning-thunder/issues/1173#issuecomment-2362895907. This PR makes the nvFuser executor absorb `ltorch.copy_` separately from `prims.copy_` (which appears within in-place ops).

This PR is experimental. It works (if the tests pass), but it is not a good solution in that some transform may walk in and replace `ltorch.copy_` with something equivalent. A complete solution would be to track all `fd.add_output` generated so far and insert `fd.ops.set` where needed.