### PR TITLE
Preserve tags when swapping proxies

### DIFF
--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -1576,9 +1576,11 @@ def _get_process_group_from(*fn_and_args) -> Optional["ProcessGroup"]:
             raise NotImplementedError("jitting modules with different ProcessGroup is not supported currently.")
     return found_pg
 
+
 def update_tags(proxy_swapmap: dict[Variable, Proxy]) -> None:
     for old, new in proxy_swapmap.items():
         new.tags.update(unvariableify(old).tags)
+
 
 def thunder_general_jit(
     fn: Callable,

--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -1576,6 +1576,9 @@ def _get_process_group_from(*fn_and_args) -> Optional["ProcessGroup"]:
             raise NotImplementedError("jitting modules with different ProcessGroup is not supported currently.")
     return found_pg
 
+def update_tags(proxy_swapmap: dict[Variable, Proxy]) -> None:
+    for old, new in proxy_swapmap.items():
+        new.tags.update(unvariableify(old).tags)
 
 def thunder_general_jit(
     fn: Callable,
@@ -1681,6 +1684,8 @@ def thunder_general_jit(
 
     # Update prologue trace by renaming proxies which are passed from prologue to the computation trace
     prologue_trace = _apply_trace_proxy_rename(prologue_trace, restrict_proxy_swapmap(pro_to_comp_proxies))
+
+    update_tags(ctx._proxy_swapmap)
 
     # Update computation trace by renaming proxies which are in the ctx._proxy_swapmap
     computation_trace = _apply_trace_proxy_rename(computation_trace, ctx._proxy_swapmap, "computation")


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

While testing LitGPT Llama 3 8b, we ran into an issue where one of the kv-cache symbols had its name updated without carrying the `ProxyTag.STATIC_MEMORY_LOCATION` tag. 

This causes `CUDAGraphsTransform` to avoid updating the kv-cache of that layer after each inference step, resulting in bad outputs.

This PR makes cloning a Proxy perform a reference assignment on tags instead of copying.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
