### PR TITLE
Add `prims.copy_to_out_`

### DIFF
--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -652,9 +652,6 @@ def jit(
 
             if backward_trc is None:
                 computation_trc = thunder.executors.passes.del_last_used(computation_trc)
-
-            if not compile_options.get("disable_inplace_copy_check", False):
-                thunder.core.transform_common._inplace_copy_sanity_check(computation_trc)
                 computation_traces.append(computation_trc)
 
             for transform in transforms:
@@ -680,6 +677,9 @@ def jit(
                 # We do not have to return auxiliary tensors, which will only be useful in backward pass
                 computation_trc = unwrap_return_value(computation_trc)
                 computation_traces.append(computation_trc)
+
+            if not compile_options.get("disable_inplace_copy_check", False):
+                thunder.core.transform_common._inplace_copy_sanity_check(computation_trc)
 
             computation_trc = transform_to_torch_types(computation_trc)
             comp = computation_trc.python_callable()

--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -269,6 +269,7 @@ class PrimIDs(Enum):
     # Memory access methods
     ITEM = auto()
     COPY_ = auto()
+    COPY_TO_OUT_ = auto()
     #
     SINK = auto()
 
@@ -4028,6 +4029,22 @@ def copy__meta(
 
 
 copy_ = make_prim(PrimIDs.COPY_, "copy_", meta=copy__meta, tags=(OpTags.DONT_DCE,))
+
+
+def copy_to_out__meta(
+    computed: TensorProxy,
+    *,
+    out: TensorProxy,
+):
+    utils.check_type(computed, TensorProxy)
+    utils.check_type(out, TensorProxy)
+    utils.check_same_device(computed, out)
+    utils.check_same_shape(computed, out)
+    utils.check_same_dtype(computed, out)
+    return TensorProxy(like=out)
+
+
+copy_to_out_ = make_prim(PrimIDs.COPY_TO_OUT_, "copy_to_out_", meta=copy_to_out__meta, tags=(OpTags.DONT_DCE,))
 
 
 def sink_meta(*args, **kwargs):

--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -1565,6 +1565,7 @@ augmented_forward_impls = {
     prims.PrimIDs.ZETA: lambda x, y: (prims.zeta(x, y), (x, y)),
     prims.PrimIDs.FMOD: lambda x, y: (prims.fmod(x, y), (x, y)),
     prims.PrimIDs.COPY_: lambda x, y: (prims.copy_(x, y), tuple()),
+    prims.PrimIDs.COPY_TO_OUT_: lambda computed, out: (prims.copy_to_out_(computed, out=out), tuple()),
     prims.PrimIDs.CLONE: lambda x: (prims.clone(x), tuple()),
 }
 
@@ -1595,6 +1596,7 @@ backward_impls = {
     prims.PrimIDs.FMOD: lambda x, y, g: (g, -g * prims.trunc(x / y)),
     # The copy should not be differentiable. We return None to enable the generation of the backward graph through them.
     prims.PrimIDs.COPY_: lambda g: (None, None),
+    prims.PrimIDs.COPY_TO_OUT_: lambda g: (None, None),
     prims.PrimIDs.CLONE: lambda g: g,
 }
 

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -2065,6 +2065,30 @@ def copy_(
 register_supported(PrimIDs.COPY_, copy_, _copy__check)
 
 
+def _copy_to_out__check(
+    result: TensorProxy,
+    *,
+    out: TensorProxy,
+) -> bool:
+    return are_supported_tensors(result, out)
+
+
+def copy_to_out_(
+    result: TensorProxy,
+    *,
+    out: TensorProxy,
+    fd: FusionDefinition,
+    lc_to_nv_map: dict,
+) -> Any:
+    nvresult = getnv(result, fd, lc_to_nv_map)
+    nvout = getnv(out, fd, lc_to_nv_map)
+    fd.add_output(nvresult, alias_input=nvout)
+    return nvout
+
+
+register_supported(PrimIDs.COPY_TO_OUT_, copy_to_out_, _copy_to_out__check)
+
+
 # Removes excessive float casts, like those that occur when autocasting
 # NOTE This passes actually changes a program's semantics, because it will take a sequence like
 #   fp32 -> fp16 -> fp32 and remove all the operations, but casting fp32 values to fp16 can

--- a/thunder/executors/torchex.py
+++ b/thunder/executors/torchex.py
@@ -2142,6 +2142,17 @@ copy_ = ex.register_operator("copy_", meta=prims.copy_, tags=(prims.OpTags.DONT_
 _register_implementation(prims.copy_, copy_, checker=_always_executable)
 
 
+def _copy_to_out__impl(result, *, out):
+    out.copy_(result)
+    return out
+
+
+copy_to_out_ = ex.register_operator(
+    "copy_to_out_", meta=prims.copy_to_out_, tags=(prims.OpTags.DONT_DCE,), fn=_copy_to_out__impl
+)
+_register_implementation(prims.copy_to_out_, copy_to_out_, checker=_always_executable)
+
+
 def _shape_impl(t):
     return t.shape
 

--- a/thunder/tests/test_jit_general.py
+++ b/thunder/tests/test_jit_general.py
@@ -760,7 +760,9 @@ def test_litgpt_variants_kvcache(name, device):
 
     with device:
         model.set_kv_cache(batch_size=1)
-    tom = thunder.jit(model, executors=executors)  # , disable_torch_autograd_support=True
+    tom = thunder.jit(
+        model, executors=executors, disable_inplace_copy_check=True
+    )  # , disable_torch_autograd_support=True
 
     # kv cache prefill
     thunder_logits_1 = tom(x, torch.tensor([0, 1], device=device))

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -960,7 +960,7 @@ def setitem(inp, idx, val):
 
 @torchsymbol(torch.Tensor.__setitem__, id="setitem_", is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def setitem_(inp, idx, val):
-    prims.copy_(setitem(inp, idx, val), inp)
+    clang.copy_to_out_(setitem(inp, idx, val), out=inp)
 
 
 @torchsymbol(torch.Tensor.__getitem__, id="torch.Tensor.__getitem__", method_name="getitem")
@@ -1340,7 +1340,7 @@ def abs(a: NumberLike | TensorLike, /) -> Number | TensorLike:
 
 @torchsymbol(torch.abs_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def abs_(a: NumberLike | TensorLike, /) -> Number | TensorLike:
-    return prims.copy_(abs(a), a)
+    return clang.copy_to_out_(abs(a), out=a)
 
 
 @torchsymbol(torch.acos, is_method=True)
@@ -1350,7 +1350,7 @@ def acos(a: NumberLike | TensorLike, /) -> Number | TensorLike:
 
 @torchsymbol(torch.acos_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def acos_(a: TensorLike, /) -> TensorLike:
-    return prims.copy_(acos(a), a)
+    return clang.copy_to_out_(acos(a), out=a)
 
 
 @torchsymbol(torch.acosh, is_method=True)
@@ -1360,7 +1360,7 @@ def acosh(a):
 
 @torchsymbol(torch.acosh_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def acosh_(a):
-    return prims.copy_(acosh(a), a)
+    return clang.copy_to_out_(acosh(a), out=a)
 
 
 @torchsymbol(torch.asin, is_method=True)
@@ -1370,7 +1370,7 @@ def asin(a):
 
 @torchsymbol(torch.asin_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def asin_(a):
-    return prims.copy_(asin(a), a)
+    return clang.copy_to_out_(asin(a), out=a)
 
 
 @torchsymbol(torch.asinh, is_method=True)
@@ -1380,7 +1380,7 @@ def asinh(a):
 
 @torchsymbol(torch.asinh_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def asinh_(a):
-    return prims.copy_(asinh(a), a)
+    return clang.copy_to_out_(asinh(a), out=a)
 
 
 @torchsymbol(torch.atan, is_method=True)
@@ -1390,7 +1390,7 @@ def atan(a):
 
 @torchsymbol(torch.atan_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def atan_(a):
-    return prims.copy_(atan(a), a)
+    return clang.copy_to_out_(atan(a), out=a)
 
 
 @torchsymbol(torch.atanh, is_method=True)
@@ -1400,7 +1400,7 @@ def atanh(a):
 
 @torchsymbol(torch.atanh_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def atanh_(a):
-    return prims.copy_(atanh(a), a)
+    return clang.copy_to_out_(atanh(a), out=a)
 
 
 @torchsymbol(torch.bitwise_not, is_method=True)
@@ -1410,7 +1410,7 @@ def bitwise_not(a):
 
 @torchsymbol(torch.Tensor.bitwise_not_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def bitwise_not_(a):
-    return prims.copy_(bitwise_not(a), a)
+    return clang.copy_to_out_(bitwise_not(a), out=a)
 
 
 @torchsymbol(torch.ceil, is_method=True)
@@ -1420,7 +1420,7 @@ def ceil(a):
 
 @torchsymbol(torch.ceil_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def ceil_(a):
-    return prims.copy_(ceil(a), a)
+    return clang.copy_to_out_(ceil(a), out=a)
 
 
 @torchsymbol(torch.cos, is_method=True)
@@ -1430,7 +1430,7 @@ def cos(a):
 
 @torchsymbol(torch.cos_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def cos_(a):
-    return prims.copy_(cos(a), a)
+    return clang.copy_to_out_(cos(a), out=a)
 
 
 @torchsymbol(torch.cosh, is_method=True)
@@ -1440,7 +1440,7 @@ def cosh(a):
 
 @torchsymbol(torch.cosh_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def cosh_(a):
-    return prims.copy_(cosh(a), a)
+    return clang.copy_to_out_(cosh(a), out=a)
 
 
 @torchsymbol(torch.digamma, torch.special.digamma, is_method=True)
@@ -1450,7 +1450,7 @@ def digamma(a):
 
 @torchsymbol(torch.Tensor.digamma_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def digamma_(a):
-    return prims.copy_(digamma(a), a)
+    return clang.copy_to_out_(digamma(a), out=a)
 
 
 @torchsymbol(torch.erf, is_method=True)
@@ -1460,7 +1460,7 @@ def erf(a):
 
 @torchsymbol(torch.erf_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def erf_(a):
-    return prims.copy_(erf(a), a)
+    return clang.copy_to_out_(erf(a), out=a)
 
 
 @torchsymbol(torch.erfc, is_method=True)
@@ -1470,7 +1470,7 @@ def erfc(a):
 
 @torchsymbol(torch.erfc_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def erfc_(a):
-    return prims.copy_(erfc(a), a)
+    return clang.copy_to_out_(erfc(a), out=a)
 
 
 @torchsymbol(torch.erfinv, is_method=True)
@@ -1480,7 +1480,7 @@ def erfinv(a):
 
 @torchsymbol(torch.Tensor.erfinv_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def erfinv_(a):
-    return prims.copy_(erfinv(a), a)
+    return clang.copy_to_out_(erfinv(a), out=a)
 
 
 @torchsymbol(torch.exp, is_method=True)
@@ -1490,7 +1490,7 @@ def exp(a):
 
 @torchsymbol(torch.exp_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def exp_(a):
-    return prims.copy_(exp(a), a)
+    return clang.copy_to_out_(exp(a), out=a)
 
 
 @torchsymbol(torch.exp2, is_method=True)
@@ -1500,7 +1500,7 @@ def exp2(a):
 
 @torchsymbol(torch.exp2_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def exp2_(a):
-    return prims.copy_(exp2(a), a)
+    return clang.copy_to_out_(exp2(a), out=a)
 
 
 # fake out of place variant
@@ -1534,7 +1534,7 @@ def exponential(a: Tensor, rate: float = 1, *, generator: None | torch.Generator
 
 @torchsymbol(torch.Tensor.exponential_, id="exponential_", is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def exponential_(a: Tensor, rate: float = 1, *, generator: None | torch.Generator = None) -> Tensor:
-    return prims.copy_(exponential(a, rate=rate, generator=generator), a)
+    return clang.copy_to_out_(exponential(a, rate=rate, generator=generator), out=a)
 
 
 @torchsymbol(torch.expm1, is_method=True)
@@ -1544,7 +1544,7 @@ def expm1(a):
 
 @torchsymbol(torch.expm1_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def expm1_(a):
-    return prims.copy_(expm1(a), a)
+    return clang.copy_to_out_(expm1(a), out=a)
 
 
 @torchsymbol(torch.floor, is_method=True)
@@ -1554,7 +1554,7 @@ def floor(a):
 
 @torchsymbol(torch.floor_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def floor_(a):
-    return prims.copy_(floor(a), a)
+    return clang.copy_to_out_(floor(a), out=a)
 
 
 @torchsymbol(torch.isfinite, is_method=True)
@@ -1569,7 +1569,7 @@ def lgamma(a):
 
 @torchsymbol(torch.Tensor.lgamma_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def lgamma_(a):
-    return prims.copy_(lgamma(a), a)
+    return clang.copy_to_out_(lgamma(a), out=a)
 
 
 @torchsymbol(torch.log, is_method=True)
@@ -1579,7 +1579,7 @@ def log(a):
 
 @torchsymbol(torch.log_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def log_(a):
-    return prims.copy_(log(a), a)
+    return clang.copy_to_out_(log(a), out=a)
 
 
 @torchsymbol(torch.log10, is_method=True)
@@ -1589,7 +1589,7 @@ def log10(a):
 
 @torchsymbol(torch.log10_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def log10_(a):
-    return prims.copy_(log10(a), a)
+    return clang.copy_to_out_(log10(a), out=a)
 
 
 @torchsymbol(torch.log1p, is_method=True)
@@ -1599,7 +1599,7 @@ def log1p(a):
 
 @torchsymbol(torch.log1p_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def log1p_(a):
-    return prims.copy_(log1p(a), a)
+    return clang.copy_to_out_(log1p(a), out=a)
 
 
 @torchsymbol(torch.log2, is_method=True)
@@ -1609,7 +1609,7 @@ def log2(a):
 
 @torchsymbol(torch.log2_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def log2_(a):
-    return prims.copy_(log2(a), a)
+    return clang.copy_to_out_(log2(a), out=a)
 
 
 # TODO Move to special
@@ -1625,7 +1625,7 @@ def neg(a):
 
 @torchsymbol(torch.neg_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def neg_(a):
-    return prims.copy_(neg(a), a)
+    return clang.copy_to_out_(neg(a), out=a)
 
 
 @torchsymbol(torch.reciprocal, is_method=True)
@@ -1635,7 +1635,7 @@ def reciprocal(a):
 
 @torchsymbol(torch.reciprocal_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def reciprocal_(a):
-    return prims.copy_(reciprocal(a), a)
+    return clang.copy_to_out_(reciprocal(a), out=a)
 
 
 @torchsymbol(torch.round, is_method=True)
@@ -1645,7 +1645,7 @@ def round(a):
 
 @torchsymbol(torch.round_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def round_(a):
-    return prims.copy_(round(a), a)
+    return clang.copy_to_out_(round(a), out=a)
 
 
 @torchsymbol(torch.rsqrt, is_method=True)
@@ -1655,7 +1655,7 @@ def rsqrt(a):
 
 @torchsymbol(torch.rsqrt_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def rsqrt_(a):
-    return prims.copy_(rsqrt(a), a)
+    return clang.copy_to_out_(rsqrt(a), out=a)
 
 
 # TODO Complain about complex numbers like PyTorch does?
@@ -1667,7 +1667,7 @@ def sign(a):
 
 @torchsymbol(torch.Tensor.sign_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def sign_(a):
-    return prims.copy_(sign(a), a)
+    return clang.copy_to_out_(sign(a), out=a)
 
 
 @torchsymbol(torch.signbit, is_method=True)
@@ -1682,7 +1682,7 @@ def sin(a):
 
 @torchsymbol(torch.sin_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def sin_(a):
-    return prims.copy_(sin(a), a)
+    return clang.copy_to_out_(sin(a), out=a)
 
 
 @torchsymbol(torch.sinh, is_method=True)
@@ -1692,7 +1692,7 @@ def sinh(a):
 
 @torchsymbol(torch.sinh_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def sinh_(a):
-    return prims.copy_(sinh(a), a)
+    return clang.copy_to_out_(sinh(a), out=a)
 
 
 @torchsymbol(torch.sqrt, is_method=True)
@@ -1702,7 +1702,7 @@ def sqrt(a):
 
 @torchsymbol(torch.sqrt_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def sqrt_(a):
-    return prims.copy_(sqrt(a), a)
+    return clang.copy_to_out_(sqrt(a), out=a)
 
 
 @torchsymbol(torch.tan, is_method=True)
@@ -1712,7 +1712,7 @@ def tan(a):
 
 @torchsymbol(torch.tan_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def tan_(a):
-    return prims.copy_(tan(a), a)
+    return clang.copy_to_out_(tan(a), out=a)
 
 
 @torchsymbol(torch.tanh, is_method=True)
@@ -1722,7 +1722,7 @@ def tanh(a):
 
 @torchsymbol(torch.tanh_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def tanh_(a):
-    return prims.copy_(tanh(a), a)
+    return clang.copy_to_out_(tanh(a), out=a)
 
 
 @torchsymbol(torch.trunc, is_method=True)
@@ -1732,7 +1732,7 @@ def trunc(a):
 
 @torchsymbol(torch.trunc_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def trunc_(a):
-    return prims.copy_(trunc(a), a)
+    return clang.copy_to_out_(trunc(a), out=a)
 
 
 @torchsymbol(torch.real, is_method=False)
@@ -1766,7 +1766,7 @@ def relu(a: TensorLike, /, inplace: bool = False) -> TensorLike:
 
     out = where(a > 0, a, 0)
     if inplace:
-        return prims.copy_(out, a)
+        return clang.copy_to_out_(out, out=a)
     return out
 
 
@@ -1778,7 +1778,7 @@ def relu_(
     a: TensorLike,
     /,
 ) -> TensorLike:
-    return prims.copy_(relu(a, False), a)
+    return clang.copy_to_out_(relu(a, False), out=a)
 
 
 # The default value of `inplace` is False, so no need to tweak args/kwargs
@@ -1790,7 +1790,7 @@ _inplace_to_out_of_place[relu_] = relu, -1
 def relu6(a: TensorProxy, /, inplace: bool = False) -> TensorLike:
     out = clamp(a, 0, 6)
     if inplace:
-        return prims.copy_(out, a)
+        return clang.copy_to_out_(out, out=a)
     return out
 
 
@@ -1806,7 +1806,7 @@ def hardswish(a: TensorProxy, /, inplace: bool = False) -> TensorLike:
     )
     out = a * relu6(a + 3) / 6
     if inplace:
-        return prims.copy_(out, a)
+        return clang.copy_to_out_(out, out=a)
     return out
 
 
@@ -1823,7 +1823,7 @@ def selu(a: TensorProxy, /, inplace: bool = False) -> TensorLike:
 
     out = scale * where(a > 0, a, rhs)
     if inplace:
-        return prims.copy_(out, a)
+        return clang.copy_to_out_(out, out=a)
     return out
 
 
@@ -1834,7 +1834,7 @@ _inplace_to_out_of_place[selu] = selu, 1
 def silu(a: TensorLike, /, inplace: bool = False) -> TensorLike:
     out = clang.silu(a)
     if inplace:
-        return prims.copy_(out, a)
+        return clang.copy_to_out_(out, out=a)
     return out
 
 
@@ -1864,7 +1864,7 @@ def add_(
     *,
     alpha: None | Number | TensorLike = None,
 ) -> TensorLike:
-    return prims.copy_(add(a, b, alpha=alpha), a)
+    return clang.copy_to_out_(add(a, b, alpha=alpha), out=a)
 
 
 @torchsymbol(torch.atan2, is_method=True)
@@ -1874,7 +1874,7 @@ def atan2(a, b, /):
 
 @torchsymbol(torch.Tensor.atan2_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def atan2_(a, b, /):
-    return prims.copy_(atan2(a, b), a)
+    return clang.copy_to_out_(atan2(a, b), out=a)
 
 
 @torchsymbol(torch.bitwise_and, is_method=True)
@@ -1884,7 +1884,7 @@ def bitwise_and(a, b, /):
 
 @torchsymbol(torch.Tensor.bitwise_and_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def bitwise_and_(a, b, /):
-    return prims.copy_(bitwise_and(a, b), a)
+    return clang.copy_to_out_(bitwise_and(a, b), out=a)
 
 
 @torchsymbol(torch.bitwise_or, is_method=True)
@@ -1894,7 +1894,7 @@ def bitwise_or(a, b, /):
 
 @torchsymbol(torch.Tensor.bitwise_or_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def bitwise_or_(a, b, /):
-    return prims.copy_(bitwise_or(a, b), a)
+    return clang.copy_to_out_(bitwise_or(a, b), out=a)
 
 
 @torchsymbol(torch.bitwise_xor, is_method=True)
@@ -1904,7 +1904,7 @@ def bitwise_xor(a, b, /):
 
 @torchsymbol(torch.Tensor.bitwise_xor_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def bitwise_xor_(a, b, /):
-    return prims.copy_(bitwise_xor(a, b), a)
+    return clang.copy_to_out_(bitwise_xor(a, b), out=a)
 
 
 @torchsymbol(torch.copysign, is_method=True)
@@ -1914,12 +1914,15 @@ def copysign(a, b, /):
 
 @torchsymbol(torch.Tensor.copysign_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def copysign_(a, b, /):
-    return prims.copy_(copysign(a, b), a)
+    return clang.copy_to_out_(copysign(a, b), out=a)
 
 
 @torchsymbol(torch.Tensor.copy_, is_method=True)  # , tags=(prims.OpTags.IN_PLACE,))
 def copy_(a, b, /):
-    return prims.copy_(b, a)
+    return prims.copy_(b, copy_to=a)
+
+
+# _inplace_to_out_of_place[copy_] = None, -1
 
 
 # TODO Implement div
@@ -1952,7 +1955,7 @@ def div_(
     *,
     rounding_mode: None | str = None,
 ) -> TensorLike:
-    return prims.copy_(div(a, b), a)
+    return clang.copy_to_out_(div(a, b), out=a)
 
 
 @torchsymbol(torch.eq, is_method=True)
@@ -1962,7 +1965,7 @@ def eq(a, b, /):
 
 @torchsymbol(torch.Tensor.eq_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def eq_(a, b, /):
-    return prims.copy_(eq(a, b), a)
+    return clang.copy_to_out_(eq(a, b), out=a)
 
 
 @torchsymbol(torch.floor_divide, is_method=True)
@@ -1972,7 +1975,7 @@ def floor_divide(a, b, /):
 
 @torchsymbol(torch.Tensor.floor_divide_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def floor_divide_(a, b, /):
-    return prims.copy_(floor_divide(a, b), a)
+    return clang.copy_to_out_(floor_divide(a, b), out=a)
 
 
 @torchsymbol(torch.fmod, is_method=True)
@@ -1982,7 +1985,7 @@ def fmod(a, b, /):
 
 @torchsymbol(torch.Tensor.fmod_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def fmod_(a, b, /):
-    return prims.copy_(fmod(a, b), a)
+    return clang.copy_to_out_(fmod(a, b), out=a)
 
 
 @torchsymbol(torch.ge, is_method=True)
@@ -1992,7 +1995,7 @@ def ge(a, b, /):
 
 @torchsymbol(torch.Tensor.ge_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def ge_(a, b, /):
-    return prims.copy_(ge(a, b), a)
+    return clang.copy_to_out_(ge(a, b), out=a)
 
 
 @torchsymbol(torch.gt, is_method=True)
@@ -2002,7 +2005,7 @@ def gt(a, b, /):
 
 @torchsymbol(torch.Tensor.gt_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def gt_(a, b, /):
-    return prims.copy_(gt(a, b), a)
+    return clang.copy_to_out_(gt(a, b), out=a)
 
 
 @torchsymbol(torch.logical_and, is_method=True)
@@ -2012,7 +2015,7 @@ def logical_and(a, b, /):
 
 @torchsymbol(torch.Tensor.logical_and_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def logical_and_(a, b, /):
-    return prims.copy_(logical_and(a, b), a)
+    return clang.copy_to_out_(logical_and(a, b), out=a)
 
 
 @torchsymbol(torch.logical_not, is_method=True)
@@ -2022,7 +2025,7 @@ def logical_not(a: TensorLike, /) -> TensorLike:
 
 @torchsymbol(torch.Tensor.logical_not_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def logical_not_(a: TensorLike, /) -> TensorLike:
-    return prims.copy_(logical_not(a), a)
+    return clang.copy_to_out_(logical_not(a), out=a)
 
 
 @torchsymbol(torch.le, is_method=True)
@@ -2032,7 +2035,7 @@ def le(a, b, /):
 
 @torchsymbol(torch.Tensor.le_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def le_(a, b, /):
-    return prims.copy_(le(a, b), a)
+    return clang.copy_to_out_(le(a, b), out=a)
 
 
 @torchsymbol(torch.lt, is_method=True)
@@ -2042,7 +2045,7 @@ def lt(a, b, /):
 
 @torchsymbol(torch.Tensor.lt_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def lt_(a, b, /):
-    return prims.copy_(lt(a, b), a)
+    return clang.copy_to_out_(lt(a, b), out=a)
 
 
 @torchsymbol(torch.maximum, is_method=True)
@@ -2063,7 +2066,7 @@ def mod(a, b):
 
 
 def mod_(a, b):
-    return prims.copy_(mod(a, b), a)
+    return clang.copy_to_out_(mod(a, b), out=a)
 
 
 @torchsymbol(torch.mul, is_method=True)
@@ -2073,7 +2076,7 @@ def mul(a, b, /):
 
 @torchsymbol(torch.Tensor.mul_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def mul_(a, b, /):
-    return prims.copy_(mul(a, b), a)
+    return clang.copy_to_out_(mul(a, b), out=a)
 
 
 @torchsymbol(torch.ne, is_method=True)
@@ -2083,7 +2086,7 @@ def ne(a, b, /):
 
 @torchsymbol(torch.Tensor.ne_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def ne_(a, b, /):
-    return prims.copy_(ne(a, b), a)
+    return clang.copy_to_out_(ne(a, b), out=a)
 
 
 @torchsymbol(torch.nextafter, is_method=True)
@@ -2093,7 +2096,7 @@ def nextafter(a, b, /):
 
 @torchsymbol(torch.Tensor.nextafter_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def nextafter_(a, b, /):
-    return prims.copy_(nextafter(a, b), a)
+    return clang.copy_to_out_(nextafter(a, b), out=a)
 
 
 # TODO Extend to tensor x tensor
@@ -2116,7 +2119,7 @@ def polygamma(n: int, a: TensorLike, /) -> TensorLike:
 
 @torchsymbol(torch.Tensor.polygamma_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def polygamma_(n: int, a: TensorLike, /) -> TensorLike:
-    return prims.copy_(polygamma(n, a), a)
+    return clang.copy_to_out_(polygamma(n, a), out=a)
 
 
 @torchsymbol(torch.pow, is_method=True)
@@ -2126,7 +2129,7 @@ def pow(a, b, /):
 
 @torchsymbol(torch.Tensor.pow_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def pow_(a, b, /):
-    return prims.copy_(pow(a, b), a)
+    return clang.copy_to_out_(pow(a, b), out=a)
 
 
 @torchsymbol(torch.remainder, is_method=True)
@@ -2136,7 +2139,7 @@ def remainder(a, b, /):
 
 @torchsymbol(torch.Tensor.remainder_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def remainder_(a, b, /):
-    return prims.copy_(remainder(a, b), a)
+    return clang.copy_to_out_(remainder(a, b), out=a)
 
 
 @torchsymbol(torch.sub, is_method=True)
@@ -2149,7 +2152,7 @@ def sub(a, b, /, *, alpha=None):
 
 @torchsymbol(torch.Tensor.sub_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def sub_(a, b, /, *, alpha=None):
-    return prims.copy_(sub(a, b, alpha=alpha), a)
+    return clang.copy_to_out_(sub(a, b, alpha=alpha), out=a)
 
 
 @torchsymbol(torch.true_divide, is_method=True)
@@ -2159,7 +2162,7 @@ def true_divide(a: NumberLike | TensorLike, b: NumberLike | TensorLike, /) -> Nu
 
 @torchsymbol(torch.Tensor.true_divide_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def true_divide_(a: TensorLike, b: NumberLike | TensorLike, /) -> TensorLike:
-    return prims.copy_(true_divide(a, b))
+    return clang.copy_to_out_(true_divide(a, b), out=b)
 
 
 @torchsymbol(torch.special.zeta)
@@ -2198,7 +2201,7 @@ def addcmul(a: TensorLike, b: TensorLike, c: TensorLike, /, *, value: None | Num
 
 @torchsymbol(torch.Tensor.addcmul_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def addcmul_(a: TensorLike, b: TensorLike, c: TensorLike, /, *, value: None | Number = None) -> TensorLike:
-    return prims.copy_(addcmul(a, b, c, value=value), a)
+    return clang.copy_to_out_(addcmul(a, b, c, value=value), out=a)
 
 
 @torchsymbol(torch.addcdiv, is_method=True)
@@ -2208,7 +2211,7 @@ def addcdiv(a: TensorLike, b: TensorLike, c: TensorLike, /, *, value: None | Num
 
 @torchsymbol(torch.Tensor.addcdiv_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def addcdiv_(a: TensorLike, b: TensorLike, c: TensorLike, /, *, value: None | Number = None) -> TensorLike:
-    return prims.copy_(addcdiv(a, b, c, value=value), a)
+    return clang.copy_to_out_(addcdiv(a, b, c, value=value), out=a)
 
 
 @torchsymbol(torch.lerp, is_method=True)
@@ -2218,7 +2221,7 @@ def lerp(start: TensorLike, end: TensorLike, weight: Number | TensorLike) -> Ten
 
 @torchsymbol(torch.Tensor.lerp_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def lerp_(start: TensorLike, end: TensorLike, weight: Number | TensorLike) -> TensorLike:
-    return prims.copy_(lerp(start, end, weight), start)
+    return clang.copy_to_out_(lerp(start, end, weight), out=start)
 
 
 #
@@ -2265,7 +2268,7 @@ def clamp(
 def clamp_(
     a: TensorLike, /, min: None | Number | TensorLike = None, max: None | Number | TensorLike = None
 ) -> TensorLike:
-    return prims.copy_(clamp(a, min, max), a)
+    return clang.copy_to_out_(clamp(a, min, max), out=a)
 
 
 def _mask_tensor(a, mask, fill_value):
@@ -2298,7 +2301,7 @@ def masked_fill(a: TensorLike, /, mask: TensorLike, value: NumberLike | TensorLi
 
 @torchsymbol(torch.Tensor.masked_fill_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def masked_fill_(a: TensorLike, /, mask: TensorLike, value: NumberLike | TensorLike) -> TensorLike:
-    return prims.copy_(masked_fill(a, mask, value), a)
+    return clang.copy_to_out_(masked_fill(a, mask, value), out=a)
 
 
 # NOTE The key to understanding tril is that it generates a mask
@@ -2325,7 +2328,7 @@ def tril(a: TensorLike, /, diagonal: int = 0, *, fill_value: None | Number = Non
 
 @torchsymbol(torch.Tensor.tril_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def tril_(a: TensorLike, /, diagonal: int = 0, *, fill_value: None | Number = None) -> TensorLike:
-    return prims.copy_(tril(a, diagonal, fill_value=fill_value), a)
+    return clang.copy_to_out_(tril(a, diagonal, fill_value=fill_value), out=a)
 
 
 @torchsymbol(torch.where, is_method=True)
@@ -2742,7 +2745,7 @@ def cumsum(a: TensorLike, dim: int, *, dtype: None | dtypeLike = None) -> Tensor
 
 @torchsymbol(torch.Tensor.cumsum_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def cumsum_(a: TensorLike, dim: int, *, dtype: None | dtypeLike = None) -> TensorLike:
-    return prims.copy_(cumsum(a, dim, dtype=dtype), a)
+    return clang.copy_to_out_(cumsum(a, dim, dtype=dtype), out=a)
 
 
 @torchsymbol(torch.var, is_method=True)
@@ -2824,7 +2827,7 @@ def index_add(a: TensorLike, /, dim: int, index: TensorLike, source: TensorLike)
 
 @torchsymbol(torch.Tensor.index_add_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def index_add_(a: TensorLike, /, dim: int, index: TensorLike, source: TensorLike) -> TensorLike:
-    return prims.copy_(index_add(a, dim, index, source), a)
+    return clang.copy_to_out_(index_add(a, dim, index, source), out=a)
 
 
 @torchsymbol(torch.index_copy, is_method=True)
@@ -2834,7 +2837,7 @@ def index_copy(a: TensorLike, /, dim: int, index: TensorLike, source: TensorLike
 
 @torchsymbol(torch.Tensor.index_copy_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def index_copy_(a: TensorLike, /, dim: int, index: TensorLike, source: TensorLike) -> TensorLike:
-    return prims.copy_(index_copy(a, dim, index, source), a)
+    return clang.copy_to_out_(index_copy(a, dim, index, source), out=a)
 
 
 @torchsymbol(torch.index_select, is_method=True)
@@ -2898,7 +2901,7 @@ def scatter_(
     if src is None:
         src = value
 
-    return prims.copy_(clang.scatter(a, index, src, dim), a)
+    return clang.copy_to_out_(clang.scatter(a, index, src, dim), out=a)
 
 
 # NOTE PyTorch's scatter_add has a parameter named 'src', not 'source'
@@ -2909,7 +2912,7 @@ def scatter_add(a: TensorLike, /, dim: int, index: TensorLike, src: TensorLike) 
 
 @torchsymbol(torch.Tensor.scatter_add_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def scatter_add_(a: TensorLike, /, dim: int, index: TensorLike, src: TensorLike) -> TensorLike:
-    return prims.copy_(scatter_add(a, dim, index, src), a)
+    return clang.copy_to_out_(scatter_add(a, dim, index, src), out=a)
 
 
 @torchsymbol(torch.take_along_dim)
@@ -2932,7 +2935,7 @@ def index_put_(
     values: TensorLike,
     accumulate: bool = False,
 ) -> TensorLike:
-    return prims.copy_(index_put(a, indices, values, accumulate), a)
+    return clang.copy_to_out_(index_put(a, indices, values, accumulate), out=a)
 
 
 #
@@ -3652,14 +3655,14 @@ def _native_batch_norm(
             new_running_mean = (1 - momentum) * running_mean + momentum * mean
             if not utils.are_same_dtypes(new_running_mean, running_mean):
                 new_running_mean = to(new_running_mean, running_mean.dtype)
-            prims.copy_(new_running_mean, running_mean)
+            clang.copy_to_out_(new_running_mean, out=running_mean)
         if running_var is not None:
             n = a.numel() / a.shape[1]
             unbiased_var = biased_var * (n / (n - 1))
             new_running_var = (1 - momentum) * running_var + momentum * unbiased_var
             if not utils.are_same_dtypes(new_running_var, running_var):
                 new_running_var = to(new_running_var, running_var.dtype)
-            prims.copy_(new_running_var, running_var)
+            clang.copy_to_out_(new_running_var, out=running_var)
     else:
         running_var_acc = to(running_var, computation_dtype)
         rstd = rsqrt(running_var_acc + eps)
@@ -4550,10 +4553,10 @@ def dropout(a: TensorProxy, /, p: NumberLike = 0.5, training: bool = True, inpla
     scale = 1 / (1 - p)
     dropout_mask = _dropout_helper(a, 1 - p)
 
-    out = a * dropout_mask * scale
+    result = a * dropout_mask * scale
     if inplace:
-        return prims.copy_(out, a)
-    return out
+        return clang.copy_to_out_(result, out=a)
+    return result
 
 
 _inplace_to_out_of_place[dropout] = dropout, 3
@@ -5276,12 +5279,12 @@ if torch.distributed.is_available():
         result_numel = input_tensor._numel * group.size()
         utils.check(result_numel == output_tensor._numel, lambda: f"{output_tensor._numel=} should be {result_numel=}")
         group = group if group is not None else torch.distributed.new_group()
-        out_or_work = dist_prims.all_gather(input_tensor, group, async_op, dim=None)
+        result_or_work = dist_prims.all_gather(input_tensor, group, async_op, dim=None)
         if async_op:
-            out = dist_prims.wait(out_or_work)
+            result = dist_prims.wait(result_or_work)
         else:
-            out = out_or_work
-        return prims.copy_(out.view(output_tensor.shape), output_tensor)
+            result = result_or_work
+        return clang.copy_to_out_(result.view(output_tensor.shape), out=output_tensor)
 
     # NOTE torch.distributed.all_reduce is an inplace operation (although the underlying NCCL
     #   call does not need to be inplace). This, however, is modeled as an out-of-place functional
@@ -5334,8 +5337,8 @@ if torch.distributed.is_available():
         op = to_thunder_distributed_reduce_op(op)
         group = group if group is not None else torch.distributed.new_group()
 
-        out = dist_prims.all_reduce(a, op, group, async_op, skip_clone=True)
-        return prims.copy_(out, a)
+        result = dist_prims.all_reduce(a, op, group, async_op, skip_clone=True)
+        return clang.copy_to_out_(result, out=a)
 
     @torchsymbol(
         is_method=False,
@@ -5384,12 +5387,12 @@ if torch.distributed.is_available():
         group = group if group is not None else torch.distributed.new_group()
         result_numel = input._numel // group.size()
         utils.check(result_numel == output._numel, lambda: f"{output._numel=} should be {result_numel=}")
-        out_or_work = dist_prims.reduce_scatter(input, op, group, async_op, dim=None)
+        result_or_work = dist_prims.reduce_scatter(input, op, group, async_op, dim=None)
         if async_op:
-            out = dist_prims.wait(out_or_work)
+            result = dist_prims.wait(result_or_work)
         else:
-            out = out_or_work
-        return prims.copy_(out.view(output.shape), output)
+            result = result_or_work
+        return clang.copy_to_out_(result.view(output.shape), out=output)
 
     @torchsymbol(
         torch.ops._c10d_functional.wait_tensor,


### PR DESCRIPTION
Fixes #1173. This adds a new primitive `prims.copy_to_out_(computed, *, out)`, which is used instead of `prims.copy_` for the update in in-place ops. Unlike `prims.copy_`, `prims.copy_to_out_(computed, *, out)` assumes that `computed` is not used by subsequent ops, so `out` can simply alias `computed`.

main: 63887b3d020932d5a45ade4cac96f6376e59d602
#1193: 2781a201044ec3671f685a493052111a18c45e53
||compilation (s)|execution (ms)|
|:-|-:|-:|
|eager|0.0|10.86|
|`torch.compile(adam.step, backend=thunder)` `main`|94.0|11.52|
|`torch.compile(adam.step, backend=thunder)`, #1193|48.0|6.00|

The rule with `prims.copy_to_out_` is ([link](https://github.com/shino16/lightning-thunder/blob/eb61e6a6636ce0e4fc46c213e7d86ea0aed10491/thunder/clang/__init__.py#L1889-L1891)):
```py
# WARN: `computed` must be an intermediate tensor used solely for this `copy_to_out_` call,
# e.g. copy_to_out_(add(a, b), out=a). Thunder does not guarantee that `computed` remains to have
# the correct values after copy_to_out_ returns. For general-purpose copy, use prims.copy_ instead
```

This rule comes from the fact that any copies onto `out` will be propagated to its alias, `computed`.

To prevent users from using `prims.copy_to_out_` inappropriately, I made the [sanity check](https://github.com/shino16/lightning-thunder/blob/eb61e6a6636ce0e4fc46c213e7d86ea0aed10491/thunder/core/transform_common.py#L63) on `prims.copy_to_out_` rather conservative. When enabled, it raises an error when `computed` is
* used as an input to another ops within the nvFuser region
* defined outside of the region (because it may be modified in-place), or
* used outside of the region (because it may not have the correct value).

See [tests](https://github.com/shino16/lightning-thunder/blob/eb61e6a6636ce0e4fc46c213e7d86ea0aed10491/thunder/tests/test_inplace_copy.py#L175) for examples.