### PR TITLE
Define nvFuser `reshape` operations with an inline definition.

### DIFF
--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -3155,7 +3155,7 @@ pad = make_prim(
 )
 
 
-def reshape_meta(a: TensorProxy, /, shape: tuple[int, ...]) -> TensorProxy:
+def reshape_meta(a: TensorProxy, /, shape: tuple[int, NumberProxy, ...]) -> TensorProxy:
     # Validates inputs
     utils.check_type(a, TensorProxy)
     utils.check_valid_shape(shape)

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -1224,7 +1224,7 @@ def reshape(a: TensorProxy, shape: list[int, NumberProxy, ...], *, fd: FusionDef
     nv_a = getnv(a, fd, lc_to_nv_map)
     if any(map(lambda x: isinstance(x, NumberProxy), shape)):
         nv_shape = getnv(shape, fd, lc_to_nv_map)
-    else: 
+    else:
         nv_shape = shape
 
     return fd.ops.reshape(nv_a, nv_shape)

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -1220,10 +1220,14 @@ def _reshape_check(a: TensorProxy, shape: list[int]) -> bool:
     return is_supported_tensor(a)
 
 
-def reshape(a: TensorProxy, shape: list[int], *, fd: FusionDefinition, lc_to_nv_map: dict) -> Any:
+def reshape(a: TensorProxy, shape: list[int, NumberProxy, ...], *, fd: FusionDefinition, lc_to_nv_map: dict) -> Any:
     nv_a = getnv(a, fd, lc_to_nv_map)
+    if any(map(lambda x: isinstance(x, NumberProxy), shape)):
+        nv_shape = getnv(shape, fd, lc_to_nv_map)
+    else: 
+        nv_shape = shape
 
-    return fd.ops.reshape(nv_a, shape)
+    return fd.ops.reshape(nv_a, nv_shape)
 
 
 register_supported(PrimIDs.RESHAPE, reshape, _reshape_check)

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -1214,9 +1214,8 @@ def _reshape_check(a: TensorProxy, shape: list[int]) -> bool:
 
 def reshape(a: TensorProxy, shape: list[int], *, fd: FusionDefinition, lc_to_nv_map: dict) -> Any:
     nv_a = getnv(a, fd, lc_to_nv_map)
-    nv_shape = getnv(shape, fd, lc_to_nv_map)
 
-    return fd.ops.reshape(nv_a, nv_shape)
+    return fd.ops.reshape(nv_a, shape)
 
 
 register_supported(PrimIDs.RESHAPE, reshape, _reshape_check)


### PR DESCRIPTION
This is a debugability improvement to nvFuser definitions from Thunder!

`reshape`s were being defined from Thunder as follows:
```python
    S40 = fd.define_scalar(4, dtype=DataType.Int)
    S41 = fd.define_scalar(64, dtype=DataType.Int)
    S42 = fd.define_scalar(6, dtype=DataType.Int)
    S43 = fd.define_scalar(128, dtype=DataType.Int)
    T45 = fd.ops.reshape(T26, new_shape=[S40, S41, S42, S43])
 ```
 This PR changes it to:
 ```python
    T45 = fd.ops.reshape(T26, new_shape=[4, 64, 6, 128])
 ```
 
 This API has been in nvFuser for a long time but was never updated in Thunder as `broadcast_in_dim` already took advantage of this feature.  The following [nvFuser PR](https://github.com/NVIDIA/Fuser/pull/2643) also allowed for inline printing of definitions that greatly reduces the repro size when printing from Thunder definitions.

This is a one line change to the `reshape` operation in the nvFuser Executor in Thunder!
