### PR TITLE
Fix refcycle (which led to one of the saved tensor being cleared out with gc.collect)

### DIFF
--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -580,19 +580,7 @@ class Benchmark_litGPT:
                     import torch._dynamo.config as dynamo_config
 
                     dynamo_config.cache_size_limit = 64
-                    if "transformerengine" in self.compile:
-                        # [rank0]:   File "/opt/pytorch/lightning-thunder/thunder/executors/transformer_engineex.py", line 410, in _te_functional_linear_backward_impl
-                        # [rank0]:     grads = _Linear.backward(ctx, g)
-                        # [rank0]:   File "/usr/local/lib/python3.10/dist-packages/transformer_engine/pytorch/module/linear.py", line 449, in backward
-                        # [rank0]:     weight_fp8.transpose_2d(),
-                        # [rank0]:   File "/usr/local/lib/python3.10/dist-packages/transformer_engine/pytorch/float8_tensor.py", line 625, in transpose_2d
-                        # [rank0]:     if self._transpose is None:
-                        # [rank0]:   File "/usr/local/lib/python3.10/dist-packages/transformer_engine/pytorch/float8_tensor.py", line 39, in get_func
-                        # [rank0]:     return self._fp8_attrs[name]
-                        # [rank0]: AttributeError: 'Float8Tensor' object has no attribute '_fp8_attrs'
-                        raise ValueError(
-                            "TransformerEngine executor cannot be used as an executor of Thunder when Thunder is used as torch.compile backend"
-                        )
+
                 backend = ThunderCompiler(executors=executors, **jit_options)
                 # Because Lightning Fabric is imported in this script it monkey patches the torch.compile function
                 # https://github.com/Lightning-AI/pytorch-lightning/blob/828fd998961f6a60f92c35254bb94d6e049ad069/src/lightning/fabric/wrappers.py#L421

--- a/thunder/core/interpreter.py
+++ b/thunder/core/interpreter.py
@@ -6984,6 +6984,7 @@ def _run_frame(
                     tb = TracebackType(e.__traceback__, python_frame, python_frame.f_lasti, python_frame.f_lineno)
                     e = e.with_traceback(tb)
                     runtimectx.curexc = e
+                    del current_exception, python_frame, tb, e, runtimectx
                     return INTERPRETER_SIGNALS.EXCEPTION_RAISED, INTERPRETER_SIGNALS.EXCEPTION_RAISED
 
             # TODO Improve this error message


### PR DESCRIPTION
Fixes: https://github.com/Lightning-AI/lightning-thunder/issues/1137

For context see - https://github.com/Lightning-AI/lightning-thunder/issues/1137#issuecomment-2376824650 and https://github.com/Lightning-AI/lightning-thunder/issues/1137#issuecomment-2376883969

Thank you very much @t-vi with the actual fix and debug session!

Tested with the smaller repro [here](https://github.com/Lightning-AI/lightning-thunder/issues/1137#issuecomment-2362249945)

Also tested by running 10 Layer Llama2 with TE+thunder+dynamo+fsdp2 (as mentioned in #1137) -
NOTE - This was already running before on main (before this patch) - see https://github.com/Lightning-AI/lightning-thunder/issues/1137#issuecomment-2358088076
```
torchrun --nproc_per_node=2 --no-python python thunder/benchmarks/benchmark_litgpt.py --model_name Llama-2-7b-hf --distributed_mode fsdp2 --shard_mode zero3 --compile dynamo_thunder --checkpoint_activations True --low_precision_mode fp8-delayed-te --micro_batch_size 1  --n_layer 10
```