### PR TITLE
try removing `ltorch.copy_`

### DIFF
--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -2071,7 +2071,8 @@ def copy_(
 ) -> Any:
     nvcopy_from = getnv(copy_from, fd, lc_to_nv_map)
     nvcopy_to = getnv(copy_to, fd, lc_to_nv_map)
-    fd.add_output(nvcopy_from, alias_input=nvcopy_to)
+    alias_output = fd.ops.set(nvcopy_from)
+    fd.add_output(alias_output, alias_input=nvcopy_to)
     return nvcopy_to
 
 

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -2071,8 +2071,7 @@ def copy_(
 ) -> Any:
     nvcopy_from = getnv(copy_from, fd, lc_to_nv_map)
     nvcopy_to = getnv(copy_to, fd, lc_to_nv_map)
-    alias_output = fd.ops.set(nvcopy_from)
-    fd.add_output(alias_output, alias_input=nvcopy_to)
+    fd.add_output(nvcopy_from, alias_input=nvcopy_to)
     return nvcopy_to
 
 

--- a/thunder/tests/test_inplace_copy.py
+++ b/thunder/tests/test_inplace_copy.py
@@ -182,9 +182,4 @@ def test_inplace_copy_dst_copy_returned_issue_1109(executor, device, dtype):
 
     assert_close(t0, expected)
     assert_close(actual_t2, expected_t2)
-    # FIXME(crcrpar): Since there's no `ltorch.Tensor.copy_`, functions like `func` would not
-    # be observed and executed with pytorch eager mode. Though there should be either an audit of
-    # `prims.copy_` in a nvfuser region and/or what #1110 did.
-    assert actual_t1.data_ptr() == actual_t2.data_ptr()
-    with pytest.raises(AssertionError):
-        assert_close(actual_t1, expected_t1)
+    assert_close(actual_t1, expected_t1)

--- a/thunder/tests/test_inplace_copy.py
+++ b/thunder/tests/test_inplace_copy.py
@@ -155,27 +155,27 @@ def test_inplace_copy_sanity_check(executor, device, dtype):
             traced_foo(a, b)
 
 
-@instantiate(executors=(nvFuserExecutor,), dtypes=(thunder.float32,))	
-def test_inplace_copy_dst_copy_returned_issue_1109(executor, device, dtype):	
-    def func(T0):	
-        T1 = torch.sin(T0)	
+@instantiate(executors=(nvFuserExecutor,), dtypes=(thunder.float32,))
+def test_inplace_copy_dst_copy_returned_issue_1109(executor, device, dtype):
+    def func(T0):
+        T1 = torch.sin(T0)
         prims.copy_(T1, T0)
         T2 = torch.cos(T1)
         prims.copy_(T2, T0)
-        # T1 & T2 should be returned as separate buffer, instead of sharing	
-        # storage with T0	
-        return T1, T2	
+        # T1 & T2 should be returned as separate buffer, instead of sharing
+        # storage with T0
+        return T1, T2
 
-    tdtype = ttorch.to_torch_dtype(dtype)	
-    # This pattern is unsafe in general. Disabling sanity check to silence	
-    # exception for testing	
-    traced_foo = executor.make_callable(func, disable_inplace_copy_check=True)	
-    a = make_tensor((4, 4), device=device, dtype=tdtype)	
-    a_ref = a.clone()	
+    tdtype = ttorch.to_torch_dtype(dtype)
+    # This pattern is unsafe in general. Disabling sanity check to silence
+    # exception for testing
+    traced_foo = executor.make_callable(func, disable_inplace_copy_check=True)
+    a = make_tensor((4, 4), device=device, dtype=tdtype)
+    a_ref = a.clone()
 
-    o_thunder = traced_foo(a)	
-    o_eager = func(a_ref)	
+    o_thunder = traced_foo(a)
+    o_eager = func(a_ref)
 
-    assert_close(a_ref, a)	
-    for o, o_ref in zip(o_thunder, o_eager):	
-        assert_close(o, o_ref)	
+    assert_close(a_ref, a)
+    for o, o_ref in zip(o_thunder, o_eager):
+        assert_close(o, o_ref)

--- a/thunder/tests/test_inplace_copy.py
+++ b/thunder/tests/test_inplace_copy.py
@@ -152,29 +152,3 @@ def test_inplace_copy_sanity_check(executor, device, dtype):
             match=r"If you are sure you don't want to use this check, it can be disabled by setting `disable_inplace_copy_check=True` in `thunder.jit`.$",
         ):
             traced_foo(a, b)
-
-
-@instantiate(executors=(nvFuserExecutor,), dtypes=(thunder.float32,))
-def test_inplace_copy_dst_copy_returned_issue_1109(executor, device, dtype):
-    def func(T0):
-        T1 = torch.sin(T0)
-        T0.copy_(T1)  # destination.copy_(source)
-        T2 = torch.cos(T1)
-        T0.copy_(T2)
-        # T1 & T2 should be returned as separate buffer, instead of sharing
-        # storage with T0
-        return T1, T2
-
-    tdtype = ttorch.to_torch_dtype(dtype)
-    # This pattern is unsafe in general. Disabling sanity check to silence
-    # exception for testing
-    traced_foo = executor.make_callable(func, disable_inplace_copy_check=True)
-    a = make_tensor((4, 4), device=device, dtype=tdtype)
-    a_ref = a.clone()
-
-    o_thunder = traced_foo(a)
-    o_eager = func(a_ref)
-
-    assert_close(a_ref, a)
-    for o, o_ref in zip(o_thunder, o_eager):
-        assert_close(o, o_ref)

--- a/thunder/tests/test_inplace_copy.py
+++ b/thunder/tests/test_inplace_copy.py
@@ -5,6 +5,7 @@ import torch
 from torch.testing import assert_close, make_tensor
 
 import thunder
+from thunder.core import prims
 import thunder.core.dtypes as datatypes
 import thunder.torch as ttorch
 from thunder.tests.framework import instantiate, nvFuserExecutor
@@ -152,3 +153,29 @@ def test_inplace_copy_sanity_check(executor, device, dtype):
             match=r"If you are sure you don't want to use this check, it can be disabled by setting `disable_inplace_copy_check=True` in `thunder.jit`.$",
         ):
             traced_foo(a, b)
+
+
+@instantiate(executors=(nvFuserExecutor,), dtypes=(thunder.float32,))	
+def test_inplace_copy_dst_copy_returned_issue_1109(executor, device, dtype):	
+    def func(T0):	
+        T1 = torch.sin(T0)	
+        prims.copy_(T1, T0)
+        T2 = torch.cos(T1)
+        prims.copy_(T2, T0)
+        # T1 & T2 should be returned as separate buffer, instead of sharing	
+        # storage with T0	
+        return T1, T2	
+
+    tdtype = ttorch.to_torch_dtype(dtype)	
+    # This pattern is unsafe in general. Disabling sanity check to silence	
+    # exception for testing	
+    traced_foo = executor.make_callable(func, disable_inplace_copy_check=True)	
+    a = make_tensor((4, 4), device=device, dtype=tdtype)	
+    a_ref = a.clone()	
+
+    o_thunder = traced_foo(a)	
+    o_eager = func(a_ref)	
+
+    assert_close(a_ref, a)	
+    for o, o_ref in zip(o_thunder, o_eager):	
+        assert_close(o, o_ref)	

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -1945,11 +1945,6 @@ def copysign_(a, b, /):
     return prims.copy_(copysign(a, b), a)
 
 
-@torchsymbol(torch.Tensor.copy_, is_method=True)  # , tags=(prims.OpTags.IN_PLACE,))
-def copy_(a, b, /):
-    return prims.copy_(b, a)
-
-
 # TODO Implement div
 @torchsymbol(torch.div, is_method=True)
 def div(


### PR DESCRIPTION
It seems that I've added `ltorch.copy_` in #1063 but I don't remember exactly why I did so.
I even am speculating that was an unwanted change with some cost.
So in this PR, I just want to try reverting the change and see if things can be simplified.