### PR TITLE
split backward : fix for unused outputs

### DIFF
--- a/thunder/tests/test_grad.py
+++ b/thunder/tests/test_grad.py
@@ -1751,3 +1751,27 @@ def test_grad_softmax_dtype(device):
     actual_grad = torch.autograd.grad(actual, x, grad_o)
     expected_grad = torch.autograd.grad(expected, x, grad_o)
     torch.testing.assert_close(actual_grad, expected_grad)
+
+
+@pytest.mark.parametrize("device", ("cuda", "cpu"))
+def test_grad_split_unused_output(device):
+    # Test to verify that the grad rule for split is
+    # correct even if few of the outputs are unused
+    # (leading to `grad=None` for them).
+    def forward(x):
+        x_1, x_2, x_3 = torch.split(x, 2)
+        return x_1
+
+    jforward = thunder.jit(forward)
+
+    x = torch.randn([5, 2], dtype=torch.bfloat16, device=device, requires_grad=True)
+
+    actual = jforward(x)
+    expected = forward(x)
+    torch.testing.assert_close(actual, expected)
+
+    grad_o = torch.randn_like(actual)
+
+    actual_grad = torch.autograd.grad(actual, x, grad_o)
+    expected_grad = torch.autograd.grad(expected, x, grad_o)
+    torch.testing.assert_close(actual_grad, expected_grad)

--- a/thunder/tests/test_grad.py
+++ b/thunder/tests/test_grad.py
@@ -1758,6 +1758,10 @@ def test_grad_split_unused_output(device):
     # Test to verify that the grad rule for split is
     # correct even if few of the outputs are unused
     # (leading to `grad=None` for them).
+
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA is not available")
+
     def forward(x):
         x_1, x_2, x_3 = torch.split(x, 2)
         return x_1


### PR DESCRIPTION
Fixes https://github.com/Lightning-AI/lightning-thunder/issues/1043

```python
import torch
import thunder

@thunder.jit
def f(a):
    a_1, a_2, a_3 = torch.split(a, 2)
    return a_1

a_1 = f(torch.zeros((5, 2), dtype=torch.float32, requires_grad=True))
a_1.sum().backward()
```

Error
```
ValueError: None had an unexpected type <class 'NoneType'>. Supported types are (<class 'thunder.core.proxies.TensorProxy'>, <class 'numbers.Number'>, <class 'thunder.core.proxies.NumberProxy'>)
```

Script above failed as for the unused outputs, we get None as incoming gradient. However, the rule doesn't handle this case.

https://github.com/Lightning-AI/lightning-thunder/blob/59467aa5e401ea1c4d2c4e6f9e94d1dbe147a19e/thunder/core/transforms.py#L2146-L2150