### PR TITLE
handle empty autograd.Function

### DIFF
--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -166,6 +166,7 @@ class PrimIDs(Enum):
     TRANSPOSE = auto()
     UNFOLD = auto()
     VIEW = auto()
+    SHALLOW_COPY = auto()  # a view copy
     # Memory layout prims (Experimental)
     STRIDE_ORDER = auto()
     # Elementwise unary prims
@@ -1658,7 +1659,7 @@ def return_printer(
 ):
     utils.check(
         len(kwarg_printables) == 0,
-        lambda: f"Expected no kwargs for del but got {kwarg_printables}",
+        lambda: f"Expected no kwargs for return but got {kwarg_printables}",
         exception_type=AssertionError,
     )
 
@@ -3536,6 +3537,17 @@ transpose = make_prim(PrimIDs.TRANSPOSE, "transpose", meta=transpose_meta, tags=
 
 
 view = make_prim(PrimIDs.VIEW, "view", meta=reshape_meta, tags=(OpTags.SHAPE_OP,))
+
+
+def shallow_copy_meta(a: TensorProxy, /) -> TensorProxy:
+    return TensorProxy(like=a)
+
+
+shallow_copy = make_prim(PrimIDs.SHALLOW_COPY, "shallow_copy", meta=shallow_copy_meta, tags=(OpTags.SHAPE_OP,))
+
+
+def shallow_copy_meta(a: TensorProxy, /) -> TensorProxy:
+    return TensorProxy(like=a)
 
 
 def unfold_meta(a: TensorProxy, /, dim: int, size: int, step: int) -> TensorProxy:

--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -3546,10 +3546,6 @@ def shallow_copy_meta(a: TensorProxy, /) -> TensorProxy:
 shallow_copy = make_prim(PrimIDs.SHALLOW_COPY, "shallow_copy", meta=shallow_copy_meta, tags=(OpTags.SHAPE_OP,))
 
 
-def shallow_copy_meta(a: TensorProxy, /) -> TensorProxy:
-    return TensorProxy(like=a)
-
-
 def unfold_meta(a: TensorProxy, /, dim: int, size: int, step: int) -> TensorProxy:
     dim = utils.canonicalize_dim(a.ndim, dim)
     max_size = 1 if a.ndim == 0 else a.shape[dim]

--- a/thunder/executors/torchex.py
+++ b/thunder/executors/torchex.py
@@ -2169,3 +2169,6 @@ def _shape_impl(t):
 
 shape = ex.register_operator("shape", meta=prims.shape_meta, fn=_shape_impl)
 _register_implementation(prims.shape, shape, checker=_always_executable)
+
+shallow_copy = ex.register_operator("shallow_copy", meta=prims.shallow_copy, fn=lambda x: x)
+_register_implementation(prims.shallow_copy, shallow_copy, checker=_always_executable)

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -5812,6 +5812,7 @@ _syms_returning_views: set[Symbol] = {
     tensor_split,
     chunk,
     getitem,
+    prims.shallow_copy,
 }
 
 # Add all auto-registered torch operators symbol that return tensor views to _syms_returning_views


### PR DESCRIPTION
This does two things
- reworks the autograd.Function.apply lookaside a bit to make it more principled with scopes and how the symbol is used,
   - use push_scope and pop_scope
   - call the function symbol to record it in the trace
   - create a meta-function from the trace
- adds a copy_shallow prim giving us a copy of the tensorproxy. This is needed to handle outputs which are identical to the tensors except for the backward, in particular "empty"/identify forwards.

Fixes: #1187 

@crcrpar removing the BoundSymbol is (a bit more than) what I meant with removing `..._ctx`.