### PR TITLE
Cleaning up nvFuser's repro script api.

### DIFF
--- a/thunder/examine/__init__.py
+++ b/thunder/examine/__init__.py
@@ -263,6 +263,9 @@ def get_nvfuser_repro(trace: TraceCtx, fusion_name: str, /) -> str:
         )
 
     fd = fusion.last_used
+    # The API for nvFuser version >=2.14
+    get_repro = getattr(fd, "repro_script_for", None)
+    # The legacy nvFuser API
     get_repro = getattr(fd, "getReproString", None)
     if get_repro is None:
         raise RuntimeError("The installed version of nvFuser does not support repro generation unless on crash.")

--- a/thunder/examine/__init__.py
+++ b/thunder/examine/__init__.py
@@ -266,7 +266,8 @@ def get_nvfuser_repro(trace: TraceCtx, fusion_name: str, /) -> str:
     # The API for nvFuser version >=2.14
     get_repro = getattr(fd, "repro_script_for", None)
     # The legacy nvFuser API
-    get_repro = getattr(fd, "getReproString", None)
+    if get_repro is None:
+        get_repro = getattr(fd, "getReproString", None)
     if get_repro is None:
         raise RuntimeError("The installed version of nvFuser does not support repro generation unless on crash.")
 

--- a/thunder/tests/test_nvfuser.py
+++ b/thunder/tests/test_nvfuser.py
@@ -1051,7 +1051,7 @@ def test_sdpa(
     # Check nv_sdpfa_fwd is not in bwd_fusion -> that would indicate rematerialization
     assert "nv_sdpfa_bwd" in bwd_fusion[-1][-1].name and "nv_sdpfa_fwd" not in bwd_fusion[-1][-1].name
 
-    nvf_fd = bwd_fusion[-1][-1].last_used 
+    nvf_fd = bwd_fusion[-1][-1].last_used
     repro_script = None
     if nvfuser_version() < LooseVersion("0.2.14"):
         repro_script = nvf_fd.getReproString()

--- a/thunder/tests/test_nvfuser.py
+++ b/thunder/tests/test_nvfuser.py
@@ -1053,15 +1053,14 @@ def test_sdpa(
 
     nvf_fd = bwd_fusion[-1][-1].last_used
     repro_script = None
+    # Legacy repro script API
     if nvfuser_version() < LooseVersion("0.2.14"):
         repro_script = nvf_fd.getReproString()
     else:
         repro_script = nvf_fd.repro_script_for()
-    if nvfuser_version() < LooseVersion("0.2.14"):
-       assert (
-           repro_script.count("is_cpu=True") == 2
-       ), "Expected philox_seed and philox_offset inputs to be CPU scalar tensors."
-    else :
+    assert (
+        repro_script.count("is_cpu=True") == 2
+    ), "Expected philox_seed and philox_offset inputs to be CPU scalar tensors."
 
     # Torch reference computation
     # Clone the inputs to verify gradients with torch reference

--- a/thunder/tests/test_nvfuser.py
+++ b/thunder/tests/test_nvfuser.py
@@ -1050,9 +1050,18 @@ def test_sdpa(
 
     # Check nv_sdpfa_fwd is not in bwd_fusion -> that would indicate rematerialization
     assert "nv_sdpfa_bwd" in bwd_fusion[-1][-1].name and "nv_sdpfa_fwd" not in bwd_fusion[-1][-1].name
-    assert (
-        bwd_fusion[-1][-1].last_used.getReproString().count("is_cpu=True") == 2
-    ), "Expected philox_seed and philox_offset inputs to be CPU scalar tensors."
+
+    nvf_fd = bwd_fusion[-1][-1].last_used 
+    repro_script = None
+    if nvfuser_version() < LooseVersion("0.2.14"):
+        repro_script = nvf_fd.getReproString()
+    else:
+        repro_script = nvf_fd.repro_script_for()
+    if nvfuser_version() < LooseVersion("0.2.14"):
+       assert (
+           repro_script.count("is_cpu=True") == 2
+       ), "Expected philox_seed and philox_offset inputs to be CPU scalar tensors."
+    else :
 
     # Torch reference computation
     # Clone the inputs to verify gradients with torch reference


### PR DESCRIPTION
This PR is the version gating in Thunder necessary to enable a [PR in nvFuser](https://github.com/NVIDIA/Fuser/pull/2831) which is an API cleanup and extension of @riccardofelluga work to add a way to dump a runnable reproduction script to debug nvFuser's `FusionDefinition`s.  The only thing this PR is doing in Thunder is version gating the following nvFuser `FusionDefinition` method that was changed to match the naming found with other related APIs.

```python
fd.getReproString(inputs)
```
to
```python
fd.repro_script_for(inputs)
```
