### PR TITLE
Lookaside for `torch.ops.higher_order.autograd_function_apply`

### DIFF
--- a/thunder/tests/test_jit_general.py
+++ b/thunder/tests/test_jit_general.py
@@ -1233,9 +1233,6 @@ def test_autograd_function_apply():
     torch.testing.assert_close(y, y_ref)
 
     initial_computation_trace = thunder.last_traces(jitted)[0]
-    bsym_str_ids = tuple(
-        bsym.sym.id for bsym in initial_computation_trace.bound_symbols if isinstance(bsym.sym.id, str)
-    )
     assert any(
         bsym.sym.id == "torch.ops.higher_order.autograd_function_apply"
         for bsym in initial_computation_trace.bound_symbols

--- a/thunder/tests/test_jit_general.py
+++ b/thunder/tests/test_jit_general.py
@@ -1236,7 +1236,11 @@ def test_autograd_function_apply():
     bsym_str_ids = tuple(
         bsym.sym.id for bsym in initial_computation_trace.bound_symbols if isinstance(bsym.sym.id, str)
     )
-    assert any(bsid.startswith("autograd_function_apply") for bsid in bsym_str_ids), bsym_str_ids
+    assert any(
+        bsym.sym.id == "torch.ops.higher_order.autograd_function_apply"
+        for bsym in initial_computation_trace.bound_symbols
+        if isinstance(bsym.sym.id, str)
+    )
 
     grad = torch.rand_like(y)
     actual_grad = torch.autograd.grad(y, x, grad)

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -5597,6 +5597,46 @@ else:
         utils.check(False, lambda: "torch.distributed is not available")
 
 
+# ref: https://github.com/pytorch/pytorch/blob/b99ef1a/torch/_functorch/autograd_function.py#L715-L752
+@torchsymbol(
+    torch.ops.higher_order.autograd_function_apply,
+    id="torch.ops.higher_order.autograd_function_apply",
+    is_method=False,
+)
+def autograd_function_apply(
+    fwd: Callable[list[TensorProxy], TensorProxy | tuple[TensorProxy, ...]],
+    bwd: Callable[list[TensorProxy], TensorProxy | tuple[TensorProxy, ...]],
+    *args: Any,
+    args_tensor_mask: Sequence[bool] | None,
+    non_differentiable_idx: Sequence[int] | None = None,
+) -> TensorProxy | tuple[TensorProxy, ...]:
+    result, saved_for_backward = fwd(None, *args)
+    return result
+
+
+@register_augmented_forward("torch.ops.higher_order.autograd_function_apply")
+def augmented_forward_autograd_function_apply(
+    fwd: Callable[list[Any | TensorProxy], TensorProxy | tuple[TensorProxy, ...]],
+    bwd: Callable[list[Any | TensorProxy], tuple[TensorProxy, ...]],
+    *args: Any,
+    args_tensor_mask: Sequence[bool],
+    non_differentiable_idx: Sequence[int] | None = None,
+) -> tuple[TensorProxy | tuple[TensorProxy, ...], tuple[Any, ...]]:
+    result, saved_for_backward = fwd(None, *args)
+    return result, (saved_for_backward, bwd, args_tensor_mask, non_differentiable_idx)
+
+
+@register_backward("torch.ops.higher_order.autograd_function_apply")
+def backward_autograd_function_apply(
+    saved_for_backward: tuple[Any, ...],
+    bwd: Callable[list[Any | TensorProxy], tuple[TensorProxy, ...]],
+    args_tensor_mask: Sequence[bool],
+    non_differentiable_idx: Sequence[int] | None = None,
+    *grad_output: Sequence[TensorProxy],
+) -> tuple[Any, ...]:
+    return bwd(None, *grad_output, *saved_for_backward)
+
+
 @torchsymbol(
     torch.amp.autocast_mode._enter_autocast,
     id="torch.amp.autocast_mode._enter_autocast",

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -5597,46 +5597,6 @@ else:
         utils.check(False, lambda: "torch.distributed is not available")
 
 
-# ref: https://github.com/pytorch/pytorch/blob/b99ef1a/torch/_functorch/autograd_function.py#L715-L752
-@torchsymbol(
-    torch.ops.higher_order.autograd_function_apply,
-    id="torch.ops.higher_order.autograd_function_apply",
-    is_method=False,
-)
-def autograd_function_apply(
-    fwd: Callable[list[TensorProxy], TensorProxy | tuple[TensorProxy, ...]],
-    bwd: Callable[list[TensorProxy], TensorProxy | tuple[TensorProxy, ...]],
-    *args: Any,
-    args_tensor_mask: Sequence[bool] | None,
-    non_differentiable_idx: Sequence[int] | None = None,
-) -> TensorProxy | tuple[TensorProxy, ...]:
-    result, saved_for_backward = fwd(None, *args)
-    return result
-
-
-@register_augmented_forward("torch.ops.higher_order.autograd_function_apply")
-def augmented_forward_autograd_function_apply(
-    fwd: Callable[list[Any | TensorProxy], TensorProxy | tuple[TensorProxy, ...]],
-    bwd: Callable[list[Any | TensorProxy], tuple[TensorProxy, ...]],
-    *args: Any,
-    args_tensor_mask: Sequence[bool],
-    non_differentiable_idx: Sequence[int] | None = None,
-) -> tuple[TensorProxy | tuple[TensorProxy, ...], tuple[Any, ...]]:
-    result, saved_for_backward = fwd(None, *args)
-    return result, (saved_for_backward, bwd, args_tensor_mask, non_differentiable_idx)
-
-
-@register_backward("torch.ops.higher_order.autograd_function_apply")
-def backward_autograd_function_apply(
-    saved_for_backward: tuple[Any, ...],
-    bwd: Callable[list[Any | TensorProxy], tuple[TensorProxy, ...]],
-    args_tensor_mask: Sequence[bool],
-    non_differentiable_idx: Sequence[int] | None = None,
-    *grad_output: Sequence[TensorProxy],
-) -> tuple[Any, ...]:
-    return bwd(None, *grad_output, *saved_for_backward)
-
-
 @torchsymbol(
     torch.amp.autocast_mode._enter_autocast,
     id="torch.amp.autocast_mode._enter_autocast",


### PR DESCRIPTION
## What does this PR do?

As per #1248, the support of `torch.ops.higher_order.autograd_function_apply` would be a bit more flexible by tracing into both `fwd` and `bwd`.

cc @apaz-cli