### PR TITLE
Disallow traceable tensor subclasses

### DIFF
--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -724,6 +724,23 @@ def jit(
             if cd.cache_option is not CACHE_OPTIONS.NO_CACHING:
                 cs.interpreter_cache.append(cache_entry)
 
+            # TODO(crcrpar): Ideally we should disable `__torch_dispatch__`s.
+            # But it feels like a temporary necessary evil to let them working if all of the
+            # executors are capable of obeying `__torch_dispatch__`s.
+            non_compat_executors: set[extend.Executor] = {
+                ex for ex in (cudnn_executor, sdpa_executor, apex_executor, nvfuser_executor) if ex is not None
+            }
+            if (set(cd.executors_list) & non_compat_executors) or ad_hoc_executor.opmap:
+                from thunder.core.pytree import tree_flatten
+
+                check(
+                    not any(
+                        pytorch.utils._python_dispatch.is_traceable_wrapper_subclass(a)
+                        for a in tree_flatten((args, kwargs))[0]
+                    ),
+                    lambda: f"Traceable tensor subclasses are not supported",
+                )
+
         return cache_entry, inps, pro_to_epi
 
     cd.get_computation_and_inputs = get_computation_and_inputs

--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -66,6 +66,7 @@ from thunder.core.proxies import (
     ListProxy,
     DictProxy,
     AnyProxy,
+    SubclassTensorProxy,
 )
 from thunder.core.interpreter import print_interpreter_log, print_to_log
 from thunder.core.jit_ext import thunder_general_jit
@@ -581,6 +582,17 @@ def jit(
                         vanilla_tensor_args = set(tensor_indices)
 
             # TODO(crcrpar): Transform computation_trc if it has any tensor subclasses inside of it.
+            from thunder.core.symbol import BoundSymbol
+
+            bsym: BoundSymbol
+            for bsym in computation_trc.bound_symbols:
+                for a in bsym.flat_proxy_args + bsym.flat_proxy_outs:
+                    if isinstance(a, SubclassTensorProxy):
+                        check(
+                            False,
+                            lambda: f"{bsym} has Tensor Subclasses of {a}",
+                            exception_type=NotImplementedError,
+                        )
 
             if epilogue_trc is not None:
                 epilogue_traces = [epilogue_trc]

--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -580,6 +580,8 @@ def jit(
                     if len(tensor_args_consumed_by_inplace_grouped_by_numel) > 1:
                         vanilla_tensor_args = set(tensor_indices)
 
+            # TODO(crcrpar): Transform computation_trc if it has any tensor subclasses inside of it.
+
             if epilogue_trc is not None:
                 epilogue_traces = [epilogue_trc]
             else:

--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -730,20 +730,20 @@ def jit(
             non_compat_executors: set[extend.Executor] = {
                 ex for ex in (cudnn_executor, sdpa_executor, apex_executor, nvfuser_executor) if ex is not None
             }
-            if (enabled_fusion_exs := set(cd.executors_list) & non_compat_executors) or ad_hoc_executor.opmap:
-                from thunder.core.pytree import tree_flatten
-
-                check(
-                    not any(
-                        pytorch.utils._python_dispatch.is_traceable_wrapper_subclass(a)
-                        for a in tree_flatten((args, kwargs))[0]
-                    ),
-                    lambda: (
-                        f"Traceable tensor subclasses are not supported because of "
-                        f"executors of {[e.name for e in enabled_fusion_exs]} and "
-                        f"ad hoc ops of {list(ad_hoc_executor.opmap.keys())}"
-                    ),
-                )
+            # if (enabled_fusion_exs := set(cd.executors_list) & non_compat_executors) or ad_hoc_executor.opmap:
+            #     from thunder.core.pytree import tree_flatten
+            #
+            #     check(
+            #         not any(
+            #             pytorch.utils._python_dispatch.is_traceable_wrapper_subclass(a)
+            #             for a in tree_flatten((args, kwargs))[0]
+            #         ),
+            #         lambda: (
+            #             f"Traceable tensor subclasses are not supported because of "
+            #             f"executors of {[e.name for e in enabled_fusion_exs]} and "
+            #             f"ad hoc ops of {list(ad_hoc_executor.opmap.keys())}"
+            #         ),
+            #     )
 
         return cache_entry, inps, pro_to_epi
 

--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -582,7 +582,9 @@ def jit(
                         vanilla_tensor_args = set(tensor_indices)
 
             # TODO(crcrpar): Transform computation_trc if it has any tensor subclasses inside of it.
-            from thunder.core.symbol import BoundSymbol
+            from thunder.transforms.flatten_tensor_subclasses import flatten_tensor_subclasses
+
+            computation_trc = flatten_tensor_subclasses(computation_trc)
 
             bsym: BoundSymbol
             for bsym in computation_trc.bound_symbols:

--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -361,7 +361,11 @@ def jit(
         data_ptr_to_tensor_group_index = {}
         tensor_group_index_to_tensor_indices = defaultdict(list)
         for idx, t in enumerate(flat_args):
-            if pytorch.is_tensor(t) and t.layout == pytorch.strided:
+            if (
+                pytorch.is_tensor(t)
+                and not issubclass(type(t), (pytorch.Tensor, pytorch.nn.Parameter))
+                and t.layout == pytorch.strided
+            ):
                 data_ptr = t.untyped_storage().data_ptr()
                 if data_ptr not in data_ptr_to_tensor_group_index:
                     data_ptr_to_tensor_group_index[data_ptr] = len(data_ptr_to_tensor_group_index)

--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -1,25 +1,16 @@
-import thunder
 import math
-from typing import Any, Optional, Dict, Tuple, Literal
-import builtins
+from typing import Any, Optional, Literal
 import collections
-from collections.abc import ValuesView, Iterable, Iterator
-from collections.abc import Callable, Sequence
-import weakref
-import random
-from functools import partial, wraps, reduce
-import linecache
-import operator
-import copy
+from collections.abc import ValuesView, Iterable, Callable, Sequence
+from functools import partial, wraps
 import contextvars
 from contextlib import contextmanager
 import dis
 import warnings
-from enum import Enum, auto
-from io import StringIO
-import inspect
-import time
+from enum import Enum
+import itertools
 
+import thunder
 from thunder.core.compile_data import compile_data_and_stats, get_cache_option, get_compile_data
 import thunder.clang as clang
 import thunder.core.transforms
@@ -1644,6 +1635,13 @@ def update_tags(proxy_swapmap: dict[Variable, Proxy]) -> None:
         new.tags.update(unvariableify(old).tags)
 
 
+def _flatten_traceable_tensor_subclass(t: Any) -> Any | tuple[torch.Tensor, dict[str, Any]]:
+    if torch.utils._python_dispatch.is_traceable_wrapper_subclass(t):
+        tensor_attrs, metadata = t.__tensor_flatten__()
+        return *[getattr(t, name) for name in tensor_attrs], metadata
+    return t
+
+
 def thunder_general_jit(
     fn: Callable,
     args: tuple[Any, ...],
@@ -1694,9 +1692,22 @@ def thunder_general_jit(
         record_history=record_history,
     )
 
+    args_with_subclass_flattened, kwargs_with_subclass_flattened = tree_map(
+        _flatten_traceable_tensor_subclass,
+        (args, kwargs),
+    )
+    args_with_subclass_flattened = []
+    for a in args:
+        new_a = _flatten_traceable_tensor_subclass(a)
+        if new_a is a:
+            args_with_subclass_flattened.append(new_a)
+        else:
+            args_with_subclass_flattened.extend(list(new_a))
+    args_with_subclass_flattened = tuple(args_with_subclass_flattened)
     with jit_ctx(ctx):
         with tracectx(computation_trace):
-            result = jfn(*args, **kwargs)
+            print(f"$$$ {args=}\n$$$ {args_with_subclass_flattened=}\n$$$ {kwargs_with_subclass_flattened=}")
+            result = jfn(*args_with_subclass_flattened, **kwargs_with_subclass_flattened)
             prims.python_return(result)
             computation_trace.set_current_source_location(None, None)
             process_recorded_modifications(ctx, epilogue_trace)

--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -746,6 +746,47 @@ def _general_jit_torch_autograd_function_apply_lookaside(obj: Any, *args, **kwar
     return forward_result
 
 
+# NOTE(crcrpar): This isn't needed as of now due to the ban of subclass instantiation inside of callable
+# ref for args: https://github.com/pytorch/pytorch/blob/deaf041/torch/csrc/autograd/python_variable.cpp#L748-L778
+@register_general_jit_lookaside(torch.Tensor._make_wrapper_subclass)
+def _general_jit__make_wrapper_subclass_lookaside(
+    cls,
+    size,
+    strides: Sequence[int] | None = None,
+    storage_offset: int | None = None,
+    memory_format: torch.memory_format | None = None,
+    dtype: torch.dtype | None = None,
+    layout: torch.layout = torch.strided,
+    device: torch.device | None = None,
+    pin_memory: bool = False,
+    requires_grad: bool = False,
+    dispatch_sizes_strides_policy: str = None,
+    dispatch_device: bool = False,
+    dispatch_layout: bool = False,
+    _extra_dispatch_keys: Any | None = None,
+    storage_size: int | None = None,
+):
+    from thunder.core.proxies import SubclassTensorProxy
+
+    u_size = unwrap(size)
+    u_strides = unwrap(strides)
+    u_dtype = unwrap(dtype)
+    u_device = unwrap(device)
+    u_pin_memory = unwrap(pin_memory)
+    u_requires_grad = unwrap(requires_grad)
+    if not (u_strides is None or not u_strides):
+        warnings.warn(f"Thunder is not capable of utilizing strides of {u_strides}")
+    placeholder_tensor = SubclassTensorProxy(
+        name=None,
+        shape=tuple(u_size),
+        device=u_device,
+        dtype=u_dtype,
+        requires_grad=u_requires_grad,
+    )
+    wrapped = WrappedValue(placeholder_tensor, provenance=size.provenance)
+    return wrapped
+
+
 @register_general_jit_lookaside(torch.finfo)
 @interpreter_needs_wrap
 def _general_jit_torch_finfo_lookaside(dtype: thunder.dtypes.dtype):
@@ -1263,7 +1304,6 @@ def unpack_inputs(ctx, prologue_trace, pro_to_comp_inps, pro_to_epi_inps, args, 
 
     # Unpacks the inputs in the prologue trace
     # TODO Generate unpacking constraints
-    # TODO(crcrpar): "flatten" tensor subclasses
     def unpack(v: Variable | Proxy) -> Proxy:
         p: Proxy
         if isinstance(v, Proxy):

--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -1272,6 +1272,7 @@ def unpack_inputs(ctx, prologue_trace, pro_to_comp_inps, pro_to_epi_inps, args, 
 
     # Unpacks the inputs in the prologue trace
     # TODO Generate unpacking constraints
+    # TODO(crcrpar): "flatten" tensor subclasses
     def unpack(v: Variable | Proxy) -> Proxy:
         p: Proxy
         if isinstance(v, Proxy):

--- a/thunder/core/proxies.py
+++ b/thunder/core/proxies.py
@@ -27,8 +27,7 @@ import thunder.core.devices as devices
 import thunder.core.dtypes as dtypes
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
-    from typing import Any, Type
+    from typing import Any
 
 ShapeLike = Sequence[int]
 
@@ -1886,32 +1885,77 @@ class TensorProxy(Proxy, TensorProxyInterface):
 
 class SubclassTensorProxy(TensorProxy):
     _tensors: list[TensorProxy]
+    _tensor_attr_names: list[str]
     _metadata: dict[str, Any]
-    # `__torch_dispatch__(cls, aten_op, types, args, **kwargs=None) -> Tensor`
+    # Signature of `__torch_dispatch__` is `(cls, aten_op, types, args, **kwargs=None) -> Tensor`
     _torch_dispatch_impl: Callable[[Any, Callable[[Any], Any], Any, Any, Any], Any]
 
+    @staticmethod
+    def filter_args_and_kwargs(*args, **kwargs):
+        tensor_subclass_args = []
+        filtered_args = []
+        for a in args:
+            if isinstance(a, (TensorProxy, torch.Tensor, dict)):
+                tensor_subclass_args.append(a)
+            else:
+                tensor_subclass_args.append(a)
+        filtered_args = tuple(filtered_args)
+
+        tensor_subclass_kwargs = {}
+        filtered_kwargs = {}
+        for k, v in kwargs.items():
+            if isinstance(v, (TensorProxy, torch.Tensor, dict)):
+                tensor_subclass_kwargs[k] = v
+            else:
+                filtered_kwargs[k] = v
+        return filtered_args, filtered_kwargs, tensor_subclass_args, tensor_subclass_kwargs
+
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        from thunder.core.interpreter import WrappedValue
+
+        baseutils.check(not isinstance(self, WrappedValue), lambda: f"{type(self)=}, {type(self.value)=}")
+
+        filtered_args, filtered_kwargs, tensor_subclass_args, tensor_subclass_kwargs = (
+            SubclassTensorProxy.filter_args_and_kwargs(*args, **kwargs)
+        )
+        flat_tensor_subclass_args: list[TensorProxy | dict[str, Any]] = tensor_subclass_args + list(
+            tensor_subclass_kwargs.values()
+        )
+        baseutils.check(
+            not flat_tensor_subclass_args,
+            lambda: (
+                f"args/kwargs for tensor subclasses are found: {flat_tensor_subclass_args}. "
+                "Subclass tensor instantiation inside of a callable is not supported yet."
+            ),
+            exception_type=NotImplementedError,
+        )
+
+        super().__init__(*filtered_args, **filtered_kwargs)
+
         self._tensors = []
-        self._metadata = {}
+        self._tensor_attr_names = []
+        self._non_tensor_attr_names = []
         self._torch_dispatch_impl = None
 
-    def tensor_flatten(self) -> tuple[list[TensorProxy], dict[str, Any]]:
-        return self._tensors, self._metadata
-
-    @staticmethod
-    def tensor_unflatten(inner_tensors: dict[str, TensorProxy], metadata: dict[str, Any], outer_size, outer_stride):
-        s = SubclassTensorProxy()
-        s._tensors = inner_tensors
-        s._metadata = metadata
-        return s
+    # TODO(crcrpar): Audit the necessity of the following two methods.
+    # I initially added them just for the signature-wise compatibility with PT2-traceable torch.Tensor subclasses
+    # def tensor_flatten(self) -> tuple[list[TensorProxy], dict[str, Any]]:
+    #     return self._tensor_attr_names, self._metadata
+    #
+    # @staticmethod
+    # def tensor_unflatten(inner_tensors: dict[str, TensorProxy], metadata: dict[str, Any], outer_size, outer_stride):
+    #     s = SubclassTensorProxy()
+    #     s._set_tensor_attrs(list(inner_tensors.keys()), list(inner_tensors.values()))
+    #     s._metadata = metadata
+    #     return s
 
     @classmethod
     def torch_dispatch(cls, func, types, args, kwargs=None):
         pass
 
     def __repr__(self):
-        return f'<{type(self).__name__}(name="{self.name}", dtype={self.dtype}, tensors={self._tensors}, metadata={self._metadata}, __torch_dispatch__={self._torch_dispatch_impl})>'
+        metadata = {a: getattr(self, a) for a in self._non_tensor_attr_names}
+        return f'<{type(self).__name__}(name="{self.name}", dtype={self.dtype}, tensors={self._tensors}, metadata={metadata}, __torch_dispatch__={self._torch_dispatch_impl})>'
 
     def type_string(self):
         return f"{self.device.device_str()} {self.dtype.shortname()}{list(self.shape)}"
@@ -1959,10 +2003,22 @@ class SubclassTensorProxy(TensorProxy):
             thunder_fsdp_padding_size=thunder_fsdp_padding_size,
             history=history,
         )
-        t._tensors = self._tensors
-        t._metadata = self._metadata
+        # TODO(crcrpar): Fix copying of `__tensor_flatten__` info.
+        t._set_tensor_attrs(self._tensor_attr_names, self._tensors)
+        t._set_non_tensor_attrs({a: getattr(self, a) for a in self._non_tensor_attr_names})
         t._torch_dispatch_impl = self._torch_dispatch_impl
         return t
+
+    def _set_tensor_attrs(self, attr_names: list[str], tensors: list[TensorProxy]):
+        self._tensors = tensors
+        self._tensor_attr_names = attr_names
+        for n, t in zip(attr_names, tensors):
+            setattr(self, n, t)
+
+    def _set_non_tensor_attrs(self, metadata: dict[str, Any]):
+        self._non_tensor_attr_names = list(metadata.keys())
+        for k, v in metadata.items():
+            setattr(self, k, v)
 
 
 class TorchAutogradFunctionCtxProxy(Proxy, TorchAutogradFunctionCtxProxyInterface):
@@ -2085,12 +2141,17 @@ def tensorproxy(t: torch.Tensor, /, *, name: None | str, history: None | tuple =
     )
 
     tensor_type = type(t)
-    if is_traceable_wrapper_subclass_type(tensor_type):
+    if tensor_type != torch.Tensor and tensor_type != torch.nn.Parameter:
+        baseutils.check(
+            is_traceable_wrapper_subclass_type(tensor_type),
+            lambda: f"Untraceable tensor subclass of {tensor_type} found",
+            exception_type=NotImplementedError,
+        )
         subclass_tensor = SubclassTensorProxy(**ctor_args_kwargs)
-        tensor_attr_names, subclass_tensor._metadata = t.__tensor_flatten__()
-        subclass_tensor._tensors = [
-            tensorproxy(getattr(t, name), name=None, history=history) for name in tensor_attr_names
-        ]
+        tensor_attr_names, metadata = t.__tensor_flatten__()
+        tensors = [tensorproxy(getattr(t, name), name=None, history=history) for name in tensor_attr_names]
+        subclass_tensor._set_tensor_attrs(tensor_attr_names, tensors)
+        subclass_tensor._set_non_tensor_attrs(metadata)
         subclass_tensor._torch_dispatch_impl = tensor_type.__torch_dispatch__
         return subclass_tensor
     else:

--- a/thunder/core/proxies.py
+++ b/thunder/core/proxies.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
-
 import copy
+from collections.abc import Sequence
 from enum import auto, Enum
 from numbers import Number
-from typing import Any
-from collections.abc import Callable
-from collections.abc import Sequence
-
+from typing import TYPE_CHECKING
 from functools import reduce, partial
 import operator
 import builtins
@@ -28,6 +25,10 @@ import thunder.core.baseutils as baseutils
 from thunder.core.langctxs import resolve_method, get_langctx
 import thunder.core.devices as devices
 import thunder.core.dtypes as dtypes
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from typing import Any, Type
 
 ShapeLike = Sequence[int]
 
@@ -128,6 +129,8 @@ class Proxy(VariableInterface, ProxyInterface):
                 prefix = "s"
             elif isinstance(self, TensorProxy):
                 prefix = "t"
+            elif isinstance(self, SubclassTensorProxy):
+                prefix = "subclass_t"
             elif isinstance(self, CollectionProxy):
                 prefix = "C"
             elif isinstance(self, TupleProxy):
@@ -1493,6 +1496,16 @@ class TensorProxy(Proxy, TensorProxyInterface):
     def thunder_fsdp_padding_size(self):
         return self._thunder_fsdp_padding_size
 
+    def stride(self) -> tuple[...]:
+        return ()
+
+    def storage_offset(self) -> int:
+        return -1
+
+    @property
+    def layout(self) -> torch.layout:
+        return torch.strided
+
     # We need to implement `__len__` as
     # > In addition to bypassing any instance attributes in the
     # > interest of correctness, implicit special method lookup
@@ -1871,6 +1884,86 @@ class TensorProxy(Proxy, TensorProxyInterface):
         return method(self)
 
 
+class SubclassTensorProxy(TensorProxy):
+    _tensors: list[TensorProxy]
+    _metadata: dict[str, Any]
+    _type: Any
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._tensors = []
+        self._metadata = {}
+        self._type = None
+
+    def tensor_flatten(self) -> tuple[list[TensorProxy], dict[str, Any]]:
+        return self._tensors, self._metadata
+
+    @staticmethod
+    def tensor_unflatten(inner_tensors: dict[str, TensorProxy], metadata: dict[str, Any], outer_size, outer_stride):
+        s = SubclassTensorProxy()
+        s._tensors = inner_tensors
+        s._metadata = metadata
+        return s
+
+    @classmethod
+    def torch_dispatch(cls, func, types, args, kwargs=None):
+        pass
+
+    def __repr__(self):
+        return f'<{type(self).__name__}(name="{self.name}", dtype={self.dtype}, tensors={self._tensors}, metadata={self._metadata})>'
+
+    def type_string(self):
+        return f"{self.device.device_str()} {self.dtype.shortname()}{list(self.shape)}"
+
+    def replace(self, **changes):
+        r"""Return a copy of the TensorProxy object with new values for the specified fields as given to the constructor as arguments.
+        Valid kewword arguments are ``name``, ``history``, ``shape``, ``dtype``, ``device``, ``requires_grad``, ``distparallel_type``,  ``thunder_fsdp_padding_size``.
+        ``like`` is also a valid keyword and will take metadata from the tensor proxy argument
+        in preference to the old values but overridable by keyword arguments.
+        Note that the copy will use the current (environment) tracectx."""
+
+        like = changes.get("like")
+        (
+            shape,
+            device,
+            dtype,
+            true_dtype,
+            numel,
+            ndim,
+            requires_grad,
+            grad,
+            distparallel_type,
+            thunder_fsdp_padding_size,
+        ) = _infer_tensor_properties(
+            like,
+            changes.get("shape", self._shape if like is None else None),
+            changes.get("device", self._device if like is None else None),
+            changes.get("dtype", self._dtype if like is None else None),
+            changes.get("requires_grad", self._requires_grad if like is None else None),
+            changes.get("grad", self._grad if like is None else None),
+            changes.get("distparallel_type", self._distparallel_type if like is None else None),
+            changes.get("thunder_fsdp_padding_size", self._thunder_fsdp_padding_size if like is None else None),
+        )
+        name = changes.get("name", self.name)
+        history = changes.get("history", self.history)
+        tags = changes.get("tags", self.tags)
+        t = SubclassTensorProxy(
+            name=name,
+            tags=tags,
+            shape=shape,
+            device=device,
+            dtype=dtype,
+            requires_grad=requires_grad,
+            distparallel_type=distparallel_type,
+            thunder_fsdp_padding_size=thunder_fsdp_padding_size,
+            history=history,
+        )
+        t._tensors = self._tensors
+        t._metadata = self._metadata
+        t._type = self._type
+        return t
+
+
 class TorchAutogradFunctionCtxProxy(Proxy, TorchAutogradFunctionCtxProxyInterface):
     def __init__(
         self,
@@ -1942,6 +2035,7 @@ _cls_to_number_proxy_map = {
 
 # TODO: move this function to jit_ext.py
 def tensorproxy(t: torch.Tensor, /, *, name: None | str, history: None | tuple = None) -> TensorProxy:
+    from torch.utils._python_dispatch import is_traceable_wrapper_subclass_type
     from thunder.core.interpreter import ProvenanceRecord, PseudoInst, wrap_const
 
     if hasattr(t, "_thunder_device"):
@@ -1976,8 +2070,9 @@ def tensorproxy(t: torch.Tensor, /, *, name: None | str, history: None | tuple =
     else:
         # NOTE Without tuple(t.shape) then the shape would be a torch.Size object
         shape = tuple(t.shape)
-    return TensorProxy(
-        name,
+
+    ctor_args_kwargs = dict(
+        name=name,
         shape=tuple(shape),
         device=device,
         dtype=dtype,
@@ -1987,6 +2082,18 @@ def tensorproxy(t: torch.Tensor, /, *, name: None | str, history: None | tuple =
         history=history,
         thunder_fsdp_padding_size=_thunder_fsdp_padding_size,
     )
+
+    tensor_type = type(t)
+    if is_traceable_wrapper_subclass_type(tensor_type):
+        subclass_tensor = SubclassTensorProxy(**ctor_args_kwargs)
+        tensor_attr_names, subclass_tensor._metadata = t.__tensor_flatten__()
+        subclass_tensor._tensors = [
+            tensorproxy(getattr(t, name), name=None, history=history) for name in tensor_attr_names
+        ]
+        subclass_tensor._type = tensor_type
+        return subclass_tensor
+    else:
+        return TensorProxy(**ctor_args_kwargs)
 
 
 def futuretensorproxy(

--- a/thunder/core/proxies.py
+++ b/thunder/core/proxies.py
@@ -1887,13 +1887,14 @@ class TensorProxy(Proxy, TensorProxyInterface):
 class SubclassTensorProxy(TensorProxy):
     _tensors: list[TensorProxy]
     _metadata: dict[str, Any]
-    _type: Any
+    # `__torch_dispatch__(cls, aten_op, types, args, **kwargs=None) -> Tensor`
+    _torch_dispatch_impl: Callable[[Any, Callable[[Any], Any], Any, Any, Any], Any]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._tensors = []
         self._metadata = {}
-        self._type = None
+        self._torch_dispatch_impl = None
 
     def tensor_flatten(self) -> tuple[list[TensorProxy], dict[str, Any]]:
         return self._tensors, self._metadata
@@ -1910,7 +1911,7 @@ class SubclassTensorProxy(TensorProxy):
         pass
 
     def __repr__(self):
-        return f'<{type(self).__name__}(name="{self.name}", dtype={self.dtype}, tensors={self._tensors}, metadata={self._metadata})>'
+        return f'<{type(self).__name__}(name="{self.name}", dtype={self.dtype}, tensors={self._tensors}, metadata={self._metadata}, __torch_dispatch__={self._torch_dispatch_impl})>'
 
     def type_string(self):
         return f"{self.device.device_str()} {self.dtype.shortname()}{list(self.shape)}"
@@ -1960,7 +1961,7 @@ class SubclassTensorProxy(TensorProxy):
         )
         t._tensors = self._tensors
         t._metadata = self._metadata
-        t._type = self._type
+        t._torch_dispatch_impl = self._torch_dispatch_impl
         return t
 
 
@@ -2090,7 +2091,7 @@ def tensorproxy(t: torch.Tensor, /, *, name: None | str, history: None | tuple =
         subclass_tensor._tensors = [
             tensorproxy(getattr(t, name), name=None, history=history) for name in tensor_attr_names
         ]
-        subclass_tensor._type = tensor_type
+        subclass_tensor._torch_dispatch_impl = tensor_type.__torch_dispatch__
         return subclass_tensor
     else:
         return TensorProxy(**ctor_args_kwargs)

--- a/thunder/tests/test_tensor_subclass.py
+++ b/thunder/tests/test_tensor_subclass.py
@@ -89,7 +89,7 @@ class ScaleTensorSubclass(torch.Tensor):
                 or issubclass(torch._subclasses.functional_tensor.FunctionalTensor, typ)
             )
 
-        def maybe_unwrap(t: ScaleTensorSubclass | Any):
+        def maybe_unwrap_and_scale(t: ScaleTensorSubclass | Any):
             if isinstance(t, ScaleTensorSubclass):
                 if t.is_floating_point():
                     return t._x * t._scale
@@ -101,8 +101,7 @@ class ScaleTensorSubclass(torch.Tensor):
             return NotImplementedError(f"Unsupported types are included: {types}")
 
         scales = tuple(t._scale for t in pytree.tree_flatten((args, kwargs))[0] if isinstance(t, ScaleTensorSubclass))
-
-        unwrapped_args, unwrapped_kwargs = pytree.tree_map(maybe_unwrap, (args, kwargs))
+        unwrapped_args, unwrapped_kwargs = pytree.tree_map(maybe_unwrap_and_scale, (args, kwargs))
         out = func(*unwrapped_args, **unwrapped_kwargs)
         if not isinstance(out, torch.Tensor):
             return out

--- a/thunder/tests/test_tensor_subclass.py
+++ b/thunder/tests/test_tensor_subclass.py
@@ -1,0 +1,50 @@
+import pytest
+
+import torch
+import torch.nn as nn
+
+from thunder.core import devices
+from thunder.core import dtypes
+from thunder.tests.framework import DynamoThunderExecutor, instantiate, nvFuserExecutor
+from thunder.tests.make_tensor import make_tensor
+
+
+@instantiate(
+    executors=(
+        DynamoThunderExecutor,
+        nvFuserExecutor,
+    ),
+    devicetypes=(devices.DeviceType.CUDA,),
+    dtypes=(dtypes.bfloat16,),
+)
+def test_torchao_float8_linear(executor, device, dtype):
+    pytest.importorskip("torchao")
+    from torchao.float8 import convert_to_float8_training
+
+    torch_device = devices.to_torch_device(device)
+    torch_dtype = dtypes.to_torch_dtype(dtype)
+
+    if (capability := torch.cuda.get_device_capability(torch_device)) < (8, 9):
+        pytest.skip(f"Requires capability>=(8, 9) but  {capability=}")
+
+    model = nn.Sequential(
+        nn.Linear(64, 32),
+        nn.GELU(approximate="tanh"),
+        nn.Linear(32, 16),
+    ).to(device=torch_device, dtype=torch_dtype)
+    model = convert_to_float8_training(model)
+    jitted = executor.make_callable(model)
+    optimizer = torch.optim.AdamW(jitted.parameters())
+
+    if executor == DynamoThunderExecutor:
+        for _ in range(2):
+            optimizer.zero_grad()
+            x = make_tensor((16, 64), device=torch_device, dtype=torch_dtype, requires_grad=True)
+            out = jitted(x)
+            out.backward(torch.rand_like(out))
+
+            optimizer.step()
+    else:
+        x = make_tensor((16, 64), device=torch_device, dtype=torch_dtype, requires_grad=True)
+        with pytest.raises(AttributeError, match="Unknown attribute stride"):
+            _ = jitted(x)

--- a/thunder/tests/test_tensor_subclass.py
+++ b/thunder/tests/test_tensor_subclass.py
@@ -125,13 +125,9 @@ def test_subclass_inputs(executor, device, _):
     expected = f(x, y)
 
     jitted = executor.make_callable(f)
-    if executor in {nvFuserExecutor, DynamoThunderExecutor}:
-        with pytest.raises(RuntimeError, match="Traceable tensor subclasses are not supported because of executors of"):
+    if executor != DynamoThunderExecutor:
+        with pytest.raises(NotImplementedError, match="has Tensor Subclasses of"):
             jitted(x, y)
-            torch.cuda.synchronize()
-    else:
-        actual = jitted(x, y)
-        torch.testing.assert_close(actual, expected)
 
 
 @instantiate(
@@ -151,9 +147,6 @@ def test_conversion_to_subclass(executor, device, _):
     z = ScaleTensorSubclass.from_tensor(make_tensor((2, 2), device=device, dtype=torch.float32))
 
     jitted = executor.make_callable(f)
-    if executor == DynamoThunderExecutor:
-        with pytest.raises(RuntimeError, match="Traceable tensor subclasses are not supported because of executors of"):
-            jitted(x, y, z)
-    else:
-        with pytest.raises(AttributeError, match="Unknown attribute stride"):
+    if executor != DynamoThunderExecutor:
+        with pytest.raises(NotImplementedError, match="tensor subclasses are found"):
             jitted(x, y, z)

--- a/thunder/tests/test_tensor_subclass.py
+++ b/thunder/tests/test_tensor_subclass.py
@@ -1,12 +1,126 @@
+from __future__ import annotations
 import pytest
+from typing import TYPE_CHECKING, cast
 
 import torch
 import torch.nn as nn
+from torch.utils import _pytree as pytree
 
 from thunder.core import devices
 from thunder.core import dtypes
-from thunder.tests.framework import DynamoThunderExecutor, instantiate, nvFuserExecutor
+from thunder.tests.framework import DynamoThunderExecutor
+from thunder.tests.framework import instantiate
+from thunder.tests.framework import nvFuserExecutor
+from thunder.tests.framework import TorchExecutor
+from thunder.tests.framework import TorchCompileExecutor
+from thunder.tests.framework import TorchCompileCatExecutor
 from thunder.tests.make_tensor import make_tensor
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+class TensorSubclassForTest(torch.Tensor):
+    _x: torch.Tensor
+    _scale: torch.Tensor
+    __slots__ = ["_x", "_scale"]
+
+    def __new__(cls, x: torch.Tensor, scale: torch.Tensor):
+        if scale.numel() != 1:
+            raise ValueError(f"Invalid `scale`: {scale}")
+        self = torch.Tensor._make_wrapper_subclass(
+            cls,
+            x.size(),
+            strides=x.stride(),
+            storage_offset=x.storage_offset(),
+            dtype=x.dtype,
+            layout=x.layout,
+            requires_grad=x.requires_grad,
+            device=x.device,
+        )
+        self._x = x
+        self._scale = scale
+
+        return self
+
+    # ref: https://github.com/albanD/subclass_zoo/blob/ec47458/base_tensor.py#L22
+    __torch_function__ = torch._C._disabled_torch_function_impl
+
+    def __repr__(self):
+        return f"TensorSubclassForTest(dtype={self._x.dtype}, scale={self._scale})"
+
+    def __tensor_flatten__(self):
+        return ["_x", "_scale"], {}
+
+    @staticmethod
+    def __tensor_unflatten__(
+        inner_tensors: dict[str, torch.Tensor], metadata: dict[str, Any], outer_size, outer_stride
+    ):
+        return TensorSubclassForTest(inner_tensors["_x"], inner_tensors["_scale"])
+
+    @staticmethod
+    def from_tensor(x: torch.Tensor):
+        scale = x.abs().max()
+        return TensorSubclassForTest(x, scale)
+
+    @classmethod
+    def __torch_dispatch__(cls, func, types, args=(), kwargs=None):
+
+        def allowed_subclass(typ):
+            return (
+                issubclass(cls, typ)
+                or issubclass(torch._subclasses.FakeTensor, typ)
+                or issubclass(torch._subclasses.functional_tensor.FunctionalTensor, typ)
+            )
+
+        def maybe_unwrap(t: TensorSubclassForTest | Any):
+            if isinstance(t, TensorSubclassForTest):
+                if t.is_floating_point():
+                    return t._x * t._scale
+                else:
+                    return t._x
+            return t
+
+        if not all(allowed_subclass(t) for t in types):
+            return NotImplementedError(f"Unsupported types are included: {types}")
+
+        scales = tuple(t._scale for t in pytree.tree_flatten((args, kwargs))[0] if isinstance(t, TensorSubclassForTest))
+
+        unwrapped_args, unwrapped_kwargs = pytree.tree_map(maybe_unwrap, (args, kwargs))
+        out = func(*unwrapped_args, **unwrapped_kwargs)
+        if not isinstance(out, torch.Tensor):
+            return out
+        else:
+            out = cast(torch.Tensor, out)
+            return TensorSubclassForTest(out, scales[0])
+
+
+@instantiate(
+    executors=(nvFuserExecutor, TorchExecutor, TorchCompileCatExecutor, TorchCompileExecutor),
+    dtypes=(dtypes.float32,),
+    devicetypes=(devices.DeviceType.CUDA,),
+)
+def test_subclass(executor, device, _):
+
+    def f(a, b):
+        return a + b
+
+    x = TensorSubclassForTest.from_tensor(make_tensor((2, 2), device=device, dtype=torch.float32))
+    y = TensorSubclassForTest.from_tensor(make_tensor((2, 2), device=device, dtype=torch.float32))
+
+    out = f(x, y)
+
+    torch_compiled = torch.compile(f)
+    expected = torch_compiled(x, y)
+
+    jitted = executor.make_callable(f)
+    if executor == nvFuserExecutor:
+        with pytest.raises(RuntimeError, match="Traceable tensor subclasses are not supported"):
+            jitted(x, y)
+            torch.cuda.synchronize()
+    else:
+        actual = jitted(x, y)
+        torch.testing.assert_close(actual, expected)
 
 
 @instantiate(

--- a/thunder/tests/test_tensor_subclass.py
+++ b/thunder/tests/test_tensor_subclass.py
@@ -3,13 +3,12 @@ import pytest
 from typing import TYPE_CHECKING, cast
 
 import torch
-import torch.nn as nn
 from torch.utils import _pytree as pytree
 
 from thunder.core import devices
 from thunder.core import dtypes
-from thunder.tests.framework import DynamoThunderExecutor
 from thunder.tests.framework import instantiate
+from thunder.tests.framework import DynamoThunderExecutor
 from thunder.tests.framework import nvFuserExecutor
 from thunder.tests.framework import TorchExecutor
 from thunder.tests.framework import TorchCompileExecutor
@@ -117,44 +116,3 @@ def test_subclass(executor, device, _):
     else:
         actual = jitted(x, y)
         torch.testing.assert_close(actual, expected)
-
-
-@instantiate(
-    executors=(
-        DynamoThunderExecutor,
-        nvFuserExecutor,
-    ),
-    devicetypes=(devices.DeviceType.CUDA,),
-    dtypes=(dtypes.bfloat16,),
-)
-def test_torchao_float8_linear(executor, device, dtype):
-    pytest.importorskip("torchao")
-    from torchao.float8 import convert_to_float8_training
-
-    torch_device = devices.to_torch_device(device)
-    torch_dtype = dtypes.to_torch_dtype(dtype)
-
-    if (capability := torch.cuda.get_device_capability(torch_device)) < (8, 9):
-        pytest.skip(f"Requires capability>=(8, 9) but  {capability=}")
-
-    model = nn.Sequential(
-        nn.Linear(64, 32),
-        nn.GELU(approximate="tanh"),
-        nn.Linear(32, 16),
-    ).to(device=torch_device, dtype=torch_dtype)
-    model = convert_to_float8_training(model)
-    jitted = executor.make_callable(model)
-    optimizer = torch.optim.AdamW(jitted.parameters())
-
-    if executor == DynamoThunderExecutor:
-        for _ in range(2):
-            optimizer.zero_grad()
-            x = make_tensor((16, 64), device=torch_device, dtype=torch_dtype, requires_grad=True)
-            out = jitted(x)
-            out.backward(torch.rand_like(out))
-
-            optimizer.step()
-    else:
-        x = make_tensor((16, 64), device=torch_device, dtype=torch_dtype, requires_grad=True)
-        with pytest.raises(AttributeError, match="Unknown attribute stride"):
-            _ = jitted(x)

--- a/thunder/transforms/flatten_tensor_subclasses.py
+++ b/thunder/transforms/flatten_tensor_subclasses.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+from thunder.core.proxies import SubclassTensorProxy
+from thunder.core import utils
+
+if TYPE_CHECKING:
+    from thunder.core.trace import TraceCtx
+    from thunder.core.symbol import BoundSymbol
+
+
+__all__ = [
+    "flatten_tensor_subclasses",
+]
+
+
+def flatten_tensor_subclasses(computation_trace: TraceCtx) -> TraceCtx:
+    bsym: BoundSymbol
+    for bsym in computation_trace.bound_symbols:
+        for a in bsym.flat_proxy_args + bsym.flat_proxy_outs:
+            utils.check(
+                not isinstance(a, SubclassTensorProxy),
+                lambda: f"{bsym} has Tensor Subclasses of {a}",
+                exception_type=NotImplementedError,
+            )
+    return computation_trace


### PR DESCRIPTION
## What does this PR do?

Conservatively errors out when any of tensor inputs are a traceable tensor subclass and any non-pytorch executor is enabled.
Ideally we should interpret, translate, and disable `__torch_dispatch__` eventually.