### PR TITLE
Skip decorators for the prologue function to decrease overheads

### DIFF
--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -601,7 +601,7 @@ def jit(
                 use_del_last_used=False,
             )
             prologue_trc = prologue_traces[-1]
-            pro = prologue_trc.python_callable()
+            pro = prologue_trc.python_callable(include_decorators=False)
 
             if epilogue_trc is not None:
                 epilogue = epilogue_trc.python_callable()


### PR DESCRIPTION
This PR decreases the overhead of prologue functions. We use torch.autocast and torch.no_grad decorators by default for every TraceCtx, however, they are not needed for the prologue traces and can be skipped.

```py
import thunder
import timeit

def f():
    pass

tf = thunder.jit(f)
tf()

iterations, timing = timeit.Timer("tf()", globals=globals()).autorange()
print(f"Average time thunder.jit(f): {(timing / iterations * 1e6):.3f} µs")
```
Before this change:
```py
Average time thunder.jit(f): 27.226 µs
```
With this change:
```py
Average time thunder.jit(f): 20.935 µs
```