### PR TITLE
[transforms] Add ConstantFolding as transform

### DIFF
--- a/thunder/dev_utils/debug_transform.py
+++ b/thunder/dev_utils/debug_transform.py
@@ -12,7 +12,7 @@ def create_debug_boundsymbol(name: str, bsym: BoundSymbol, call_ctx: Callable):
     def bind_postprocess(debug_bsym):
         debug_bsym._call_ctx = {name: partial(call_ctx, debug_bsym, bsym)}
 
-    debug_sym = Symbol(name, lambda *_: None, is_prim=True, _bind_postprocess=bind_postprocess)
+    debug_sym = Symbol(name, lambda *_, **__: None, is_prim=True, _bind_postprocess=bind_postprocess)
     debug_bsym = debug_sym.bind(*bsym.args, output=None, **bsym.kwargs)
     return debug_bsym
 

--- a/thunder/tests/test_transforms.py
+++ b/thunder/tests/test_transforms.py
@@ -589,5 +589,6 @@ def test_constant_folding():
     for bsym in exec_trace.bound_symbols:
         if bsym.sym.id == "add":
             assert bsym.args[1] == 5.0
+            break
     else:
         raise RuntimeError("Failed to find `add` symbol in trace")

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -1854,7 +1854,7 @@ _inplace_to_out_of_place[silu] = silu, 1
 def add(
     a: NumberLike | TensorLike, b: NumberLike | TensorLike, /, *, alpha: Number | TensorLike = 1
 ) -> Number | TensorLike:
-    if alpha != 1:
+    if isinstance(alpha, torch.Tensor) or alpha != 1:
         b = b * alpha
 
     return clang.add(a, b)

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -1854,7 +1854,7 @@ _inplace_to_out_of_place[silu] = silu, 1
 def add(
     a: NumberLike | TensorLike, b: NumberLike | TensorLike, /, *, alpha: Number | TensorLike = 1
 ) -> Number | TensorLike:
-    if isinstance(alpha, torch.Tensor) or alpha != 1:
+    if isinstance(alpha, TensorProxy) or alpha != 1:
         b = b * alpha
 
     return clang.add(a, b)
@@ -1866,7 +1866,7 @@ def add_(
     b: NumberLike | TensorLike,
     /,
     *,
-    alpha: None | Number | TensorLike = None,
+    alpha: Number | TensorLike = 1,
 ) -> TensorLike:
     return prims.copy_(add(a, b, alpha=alpha), a)
 
@@ -2144,15 +2144,15 @@ def remainder_(a, b, /):
 
 
 @torchsymbol(torch.sub, is_method=True)
-def sub(a, b, /, *, alpha=None):
-    if alpha is not None:
+def sub(a, b, /, *, alpha: NumberLike | TensorLike = 1):
+    if isinstance(alpha, TensorProxy) or alpha != 1:
         b = b * alpha
 
     return clang.sub(a, b)
 
 
 @torchsymbol(torch.Tensor.sub_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
-def sub_(a, b, /, *, alpha=None):
+def sub_(a, b, /, *, alpha: NumberLike | TensorLike = 1):
     return prims.copy_(sub(a, b, alpha=alpha), a)
 
 

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -1852,9 +1852,9 @@ _inplace_to_out_of_place[silu] = silu, 1
 
 @torchsymbol(torch.add, is_method=True)
 def add(
-    a: NumberLike | TensorLike, b: NumberLike | TensorLike, /, *, alpha: None | Number | TensorLike = None
+    a: NumberLike | TensorLike, b: NumberLike | TensorLike, /, *, alpha: Number | TensorLike = 1
 ) -> Number | TensorLike:
-    if alpha is not None:
+    if alpha != 1:
         b = b * alpha
 
     return clang.add(a, b)

--- a/thunder/transforms/constant_folding.py
+++ b/thunder/transforms/constant_folding.py
@@ -1,0 +1,118 @@
+import thunder
+from thunder.core.trace import from_trace
+from thunder.core.proxies import variableify, Variable, TensorProxy, NumberProxy
+from thunder.core.symbol import BoundSymbol
+from thunder.core.dtypes import to_dtype
+from thunder.core.devices import to_device
+from thunder.torch import _torch_to_thunder_function_map
+from thunder.core.utils import get_symbols_to_last_used_variables
+
+_thunder_to_torch_function_map = {v: k for k, v in _torch_to_thunder_function_map.items()}
+
+# Factory functions whose value we know.
+TENSOR_FACTORY = (
+    thunder.torch.tensor.id,
+    thunder.torch.ones.id,
+    thunder.torch.zeros.id,
+)
+
+
+def compute_with_concrete_tensor_and_pytorch_eager(bsym, const_values):
+
+    def materialize_args(a):
+        if isinstance(a, TensorProxy):
+            return const_values[variableify(a)]
+        elif isinstance(a, NumberProxy):
+            return a.value
+        return a
+
+    new_args = tuple(map(materialize_args, bsym.args))
+    new_kwargs = {k: materialize_args(v) for k, v in bsym.kwargs.items()}
+    torch_fn = _thunder_to_torch_function_map.get(bsym.sym, None)
+    if torch_fn is None:
+        return
+    return torch_fn(*new_args, **new_kwargs)
+
+
+class ConstantFolding(thunder.Transform):
+    def transform_traces_pre_prologue(self, prologue_trc, computation_trc, epilogue_trc, **kwargs):
+        # Create a new trace
+        const_folded_trace = from_trace(computation_trc)
+        const_folded_trace.bound_symbols = computation_trc.bound_symbols
+
+        const_tensors: dict[Variable, BoundSymbol] = {}
+
+        # Tag output from factory functions as constant value.
+        for bsym in const_folded_trace.bound_symbols:
+            if bsym.sym.id in TENSOR_FACTORY:
+                torch_fn = _thunder_to_torch_function_map[bsym.sym]
+                t = torch_fn(*bsym.args, **bsym.kwargs)
+                const_tensors[variableify(bsym.output)] = t
+
+        new_bsyms = []
+        symbol_to_last_used_variables = get_symbols_to_last_used_variables(const_folded_trace.bound_symbols, ignore=())
+
+        def is_constant(proxy):
+            if isinstance(proxy, TensorProxy) and variableify(proxy) in const_tensors:
+                return True
+            elif isinstance(proxy, NumberProxy) and proxy.is_static_constrained():
+                return True
+            return False
+
+        for bsym in const_folded_trace.bound_symbols:
+            # If bsym has constant inputs, try to compute the output.
+            if all(map(is_constant, bsym.flat_proxy_args)) and bsym.sym.id not in TENSOR_FACTORY:
+                if bsym.flat_args == []:  # eg, unpack_trivial
+                    continue
+                new_concrete_output = compute_with_concrete_tensor_and_pytorch_eager(bsym, const_tensors)
+                if (
+                    new_concrete_output is not None
+                ):  # Might happen for `python_return` as it won't have mapping in `_thunder_to_torch_map`.
+
+                    # Create a new symbol with same output proxy but which will now represent the computed constant value.
+                    # eg.
+                    # known_tensor = torch.tensor(2)
+                    # t = known_tensor + 1 --> t = torch.tensor(3)
+                    if new_concrete_output.ndim == 0:
+                        new_bsym = BoundSymbol(
+                            thunder.prims.full,
+                            args=(
+                                new_concrete_output.shape,
+                                new_concrete_output.tolist(),
+                            ),
+                            kwargs={
+                                "dtype": to_dtype(new_concrete_output.dtype),
+                                "device": to_device(new_concrete_output.device),
+                            },
+                            output=bsym.output,
+                        )
+                    else:
+                        new_bsym = BoundSymbol(
+                            thunder.prims.tensor_from_sequence,
+                            args=(new_concrete_output.tolist(),),
+                            kwargs={
+                                "dtype": to_dtype(new_concrete_output.dtype),
+                                "device": to_device(new_concrete_output.device),
+                            },
+                            output=bsym.output,
+                        )
+                    new_bsyms.append(new_bsym)
+
+                    # Update const_tensors (so that usage of the output of this symbol will also be used for further computation.)
+                    const_tensors[variableify(bsym.output)] = new_concrete_output
+
+                    # Clear tensors which won't be used further.
+                    for proxy_v in symbol_to_last_used_variables[bsym]:
+                        const_tensors.pop(proxy_v, None)
+
+                    continue
+
+            # BoundSymbol with non-constant inputs, keep it as-is
+            new_bsyms.append(bsym)
+
+        del const_tensors
+
+        const_folded_trace.bound_symbols = new_bsyms
+
+        const_folded_trace.set_provenance("Constant Folding pass")
+        return prologue_trc, const_folded_trace, epilogue_trc

--- a/thunder/transforms/constant_folding.py
+++ b/thunder/transforms/constant_folding.py
@@ -73,6 +73,9 @@ class ConstantFolding(thunder.Transform):
                     # eg.
                     # known_tensor = torch.tensor(2)
                     # t = known_tensor + 1 --> t = torch.tensor(3)
+
+                    # For `ndim==0`, we need to use full as `tensor_from_sequence` expects
+                    # a sequence (and not plain numbers).
                     if new_concrete_output.ndim == 0:
                         new_bsym = BoundSymbol(
                             thunder.prims.full,


### PR DESCRIPTION
Related #1250 

Add ConstantFolding as a transform. It is added as `transform_traces_pre_prologue` so that successive passes can use the simplified compute. We use PyTorch eager to evaluate on constant values see `compute_with_concrete_tensor_and_pytorch_eager`.

NOTE - This is currently opt-in. I think we should figure out if this should be in default and how that would look in a seperate PR.

Misc Changes
* Few fixes to `get_symbols_to_last_used_variables` from utils.py
* Update signature of `thunder.torch.add` to match the PyTorch [torch.add](https://pytorch.org/docs/stable/generated/torch.add.html) and torch.sub signature (alpha should be a number and not None).

Example Traces

Function
```python
def forward(x):
    scale_t = torch.tensor([2.])
    getitem = scale_t[0]
    getitem_2 = torch.tensor([2., 3.])[0]
    return x + getitem + getitem_2

```

Original Computation Trace
```python
def computation(x):
  # x: "cpu f32[3, 3]"
  scale_t = torch.tensor([2.0], device=torch.device("cpu"), dtype=None)  # scale_t: "cpu f32[1]"
    # scale_t = ltorch.tensor([2.0], device=torch.device("cpu"), dtype=None, requires_grad=False, pin_memory=False)  # scale_t: "cpu f32[1]"
      # scale_t = prims.tensor_from_sequence([2.0], dtype=None, device=devices.Device("cpu"))  # scale_t: "cpu f32[1]"
  t3 = torch.tensor([2.0, 3.0], device=torch.device("cpu"), dtype=None)  # t3: "cpu f32[2]"
    # t3 = ltorch.tensor([2.0, 3.0], device=torch.device("cpu"), dtype=None, requires_grad=False, pin_memory=False)  # t3: "cpu f32[2]"
      # t3 = prims.tensor_from_sequence([2.0, 3.0], dtype=None, device=devices.Device("cpu"))  # t3: "cpu f32[2]"
  getitem = Tensor.__getitem__(scale_t, 0)  # getitem: "cpu f32[]"
    # getitem = ltorch.getitem(scale_t, 0)  # getitem: "cpu f32[]"
      # (_,) = prims.shape(scale_t)
      # t17 = prims.slice_prim(scale_t, [0], [1], [1])  # t17: "cpu f32[1]"
      # getitem = prims.squeeze(t17, (0,))  # getitem: "cpu f32[]"
  del scale_t
  getitem_2 = Tensor.__getitem__(t3, 0)  # getitem_2: "cpu f32[]"
    # getitem_2 = ltorch.getitem(t3, 0)  # getitem_2: "cpu f32[]"
      # (_,) = prims.shape(t3)
      # t20 = prims.slice_prim(t3, [0], [1], [1])  # t20: "cpu f32[1]"
      # getitem_2 = prims.squeeze(t20, (0,))  # getitem_2: "cpu f32[]"
  del t3
  t6 = torch.add(x, getitem, alpha=1)  # t6: "cpu f32[3, 3]"
    # t6 = ltorch.add(x, getitem, alpha=1)  # t6: "cpu f32[3, 3]"
      # t6 = prims.add(x, getitem)  # t6: "cpu f32[3, 3]"
  del getitem
  t7 = torch.add(t6, getitem_2, alpha=1)  # t7: "cpu f32[3, 3]"
    # t7 = ltorch.add(t6, getitem_2, alpha=1)  # t7: "cpu f32[3, 3]"
      # t7 = prims.add(t6, getitem_2)  # t7: "cpu f32[3, 3]"
  del t6, getitem_2
  return t7
```

Constant Folded Trace
```python
def computation(x):
  # x: "cpu f32[3, 3]"
  getitem = torch.full((), 2.0, device=torch.device("cpu"), dtype=torch.float32)  # getitem: "cpu f32[]"
    # getitem = ltorch.full((), 2.0, device=torch.device("cpu"), dtype=torch.float32)  # getitem: "cpu f32[]"
      # getitem = prims.full((), 2.0, device=devices.Device("cpu"), dtype=dtypes.float32)  # getitem: "cpu f32[]"
  t6 = torch.add(x, getitem, alpha=1)  # t6: "cpu f32[3, 3]"
    # t6 = ltorch.add(x, getitem, alpha=1)  # t6: "cpu f32[3, 3]"
      # t6 = prims.add(x, getitem)  # t6: "cpu f32[3, 3]"
  t7 = torch.add(t6, getitem, alpha=1)  # t7: "cpu f32[3, 3]"
    # t7 = ltorch.add(t6, getitem, alpha=1)  # t7: "cpu f32[3, 3]"
      # t7 = prims.add(t6, getitem)  # t7: "cpu f32[3, 3]"
  del t6, getitem
  return t7
```