### PR TITLE
stop start import from clang in thunder namespace

### DIFF
--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -154,13 +154,6 @@ complex64 = dtypes.complex64
 complex128 = dtypes.complex128
 
 #
-# Module aliases
-#
-
-# NOTE this allows clang.foo() to be called directly as thunder.foo()
-from thunder.clang import *
-
-#
 # Promoted executor-related functions and objects
 #
 


### PR DESCRIPTION
## What does this PR do?

At glance, the star import does not seem to have many uses.
