### PR TITLE
[thunderFX] splitter - handle no_grad correctly

### DIFF
--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -455,7 +455,7 @@ def test_no_grad_ctx_manager(executor, device: str, dtype: dtypes.dtype):
     assert len(backend.subgraph_infos) == 1
 
     for subgraph_info in backend.subgraph_infos:
-        assert len(subgraph_info.split_reasons) > 1  # Verify there were no splits in the subgraph.
+        assert len(subgraph_info.split_reasons) > 1  # Verify there were splits in the subgraph.
         assert isinstance(subgraph_info.original_graph_module, torch.fx.GraphModule)
         assert any("has been manually disabled" in split_reason.info for split_reason in subgraph_info.split_reasons)
 

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -435,3 +435,33 @@ def test_thundercompiler_optim_step(executor, device, dtype, optim):
             tuple(ref_model.parameters()),
             msg=lambda s: f"{i+1}-iter {s}",
         )
+
+
+@instantiate(dtypes=NOTHING, executors=[DynamoThunderExecutor])
+def test_no_grad_ctx_manager(executor, device: str, dtype: dtypes.dtype):
+    backend = ThunderCompiler()
+
+    def func(x):
+        with torch.no_grad():
+            with torch.autocast("cuda", dtype=torch.bfloat16):
+                y = x @ x
+        return y + x
+
+    x = torch.randn(3, 3, device=device, dtype=dtype, requires_grad=True)
+    actual = torch.compile(func, backend=backend)(x)
+    expected = torch.compile(func, backend="eager")(x)
+
+    # We record the GraphModules that was compiled by ThunderCompiler
+    assert len(backend.subgraph_infos) == 1
+
+    for subgraph_info in backend.subgraph_infos:
+        assert len(subgraph_info.split_reasons) > 1  # Verify there were no splits in the subgraph.
+        assert isinstance(subgraph_info.original_graph_module, torch.fx.GraphModule)
+        assert any("has been manually disabled" in split_reason.info for split_reason in subgraph_info.split_reasons)
+
+    torch.testing.assert_close(actual, expected)
+
+    g = torch.randn_like(actual)
+    actual_grad = torch.autograd.grad(actual, x, g)
+    expected_grad = torch.autograd.grad(expected, x, g)
+    torch.testing.assert_close(actual_grad, expected_grad)


### PR DESCRIPTION
Fixes #1219

`no_grad` ctx manager maps to `_set_grad_enabled(False)` and `_set_grad_enabled(True)`.

Currently, we have the following implementation of `_set_grad_enabled` which just throws a warning (`register_function` adds this mapping to `_torch_to_thunder_function_map`).

https://github.com/Lightning-AI/lightning-thunder/blob/dafc79d21c04769c5e9d1fb737b8cd21d0841e69/thunder/torch/__init__.py#L5179-L5183

Now, if depending on the split, if inductor receives `_set_grad_enabled(False)` it actually disables the grad but if the corresponding `_set_grad_enabled(True)` ends up with thunder, it doesn't re-enable it and we end up with detached grad.

For this PR, we mark the region between `_set_grad_enabled(False)` and `_set_grad_enabled(True)` to thunder unsupported region and pass it to inductor. We pass it to inductor as it understand this correctly (as thunder would create a graph with intermediates saved for backward pass thus increasing memory usage).

In future, we should revisit and support no_grad regions correctly in thunder.

NOTE - split_module tries to correctly setup and unwind autocast and no_grad regions if they are split over different sub_modules. So, it is best to pass these regions from start to end to a supported backend. See https://github.com/pytorch/pytorch/pull/112231#issuecomment-1804274605