### PR TITLE
Make graph visualization from a trace

### DIFF
--- a/docs/source/reference/examine/index.rst
+++ b/docs/source/reference/examine/index.rst
@@ -7,4 +7,4 @@ thunder.examine
     :toctree: generated/
 
     examine
-    make_trace_dot
+

--- a/docs/source/reference/examine/index.rst
+++ b/docs/source/reference/examine/index.rst
@@ -7,4 +7,3 @@ thunder.examine
     :toctree: generated/
 
     examine
-

--- a/docs/source/reference/examine/index.rst
+++ b/docs/source/reference/examine/index.rst
@@ -7,3 +7,4 @@ thunder.examine
     :toctree: generated/
 
     examine
+    make_trace_dot

--- a/thunder/examine/__init__.py
+++ b/thunder/examine/__init__.py
@@ -2,10 +2,10 @@ from typing import Any
 from collections.abc import Callable
 import collections
 import traceback
-import warnings
 
 import thunder
 from thunder.core.trace import TraceCtx
+from thunder.core.transforms import bsym_list_to_dag, Node
 from thunder.core.proxies import TensorProxy
 from thunder.core.symbol import BoundSymbol
 from thunder.torch import _torch_to_thunder_function_map
@@ -14,13 +14,7 @@ from thunder.core.langctxs import resolve_language, LanguageContext, Languages
 import torch
 from warnings import warn
 from itertools import chain
-
-try:
-    import graphviz
-
-    HAS_GRAPHVIZ = True
-except ImportError:
-    HAS_GRAPHVIZ = False
+import importlib
 
 
 # TODO Maybe make collect_into a set?
@@ -282,7 +276,7 @@ def get_nvfuser_repro(trace: TraceCtx, fusion_name: str, /) -> str:
     return get_repro(fusion.last_inputs)
 
 
-def make_trace_dot(trace: TraceCtx) -> graphviz.Digraph:
+def make_trace_dot(trace: TraceCtx):
     """
     Creates a directed graph of the given trace.
 
@@ -297,12 +291,11 @@ def make_trace_dot(trace: TraceCtx) -> graphviz.Digraph:
     Returns:
         graphviz.Digraph: A graphviz directed graph.
     """
-    if not HAS_GRAPHVIZ:
-        warnings.warn("graphviz is not available. Graph cannot be created.")
+    if not importlib.util.find_spec("graphviz"):
+        warn("graphviz is not available. Graph cannot be created.")
         return
 
-    from thunder.core.transforms import bsym_list_to_dag, Node
-    from thunder.core.proxies import TensorProxy
+    import graphviz
 
     node_attr = dict(
         style="filled", shape="box", align="left", fontsize="10", ranksep="0.1", height="0.2", fontname="monospace"

--- a/thunder/examine/__init__.py
+++ b/thunder/examine/__init__.py
@@ -2,6 +2,7 @@ from typing import Any
 from collections.abc import Callable
 import collections
 import traceback
+import warnings
 
 import thunder
 from thunder.core.trace import TraceCtx
@@ -14,7 +15,12 @@ import torch
 from warnings import warn
 from itertools import chain
 
-import graphviz
+try:
+    import graphviz
+
+    HAS_GRAPHVIZ = True
+except ImportError:
+    HAS_GRAPHVIZ = False
 
 
 # TODO Maybe make collect_into a set?
@@ -291,6 +297,9 @@ def make_trace_dot(trace: TraceCtx) -> graphviz.Digraph:
     Returns:
         graphviz.Digraph: A graphviz directed graph.
     """
+    if not HAS_GRAPHVIZ:
+        warnings.warn("graphviz is not available. Graph cannot be created.")
+        return
 
     from thunder.core.transforms import bsym_list_to_dag, Node
     from thunder.core.proxies import TensorProxy

--- a/thunder/examine/__init__.py
+++ b/thunder/examine/__init__.py
@@ -300,7 +300,7 @@ def make_trace_dot(trace: TraceCtx) -> graphviz.Digraph:
     )
     dot = graphviz.Digraph(
         node_attr=node_attr,
-        graph_attr=dict(size="10,10", nslimit="1.0"),
+        graph_attr=dict(size="10,10"),
     )
     dot.strict = True
 


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

In the quest of finding the OOMs I wrote this utility that takes a trace and returns a graph that can be rendered out to visualize the flow of computation.

This requires installing graphviz to work, I haven't added it to the dependencies as it is only needed in this function, however it might be added if you think its better to.

## Usage

Here is an example, from the following code:

```python
import torch
import torch.nn as nn

import thunder
from thunder.examine import make_trace_dot

class MyModel(nn.Module):
    def __init__(self) -> None:
        super().__init__()
        self.layers = nn.Sequential(nn.Linear(10, 10), nn.ReLU(), nn.Linear(10, 10))

    def forward(self, x):
        return self.layers(x)

a = torch.randn((10, 10), requires_grad=True, device="cuda")
m = MyModel().to("cuda")

jm = thunder.jit(m)
jm(a)

bwd_trace = thunder.last_backward_traces(jm)[0]

dot = make_trace_dot(bwd_trace)

dot.render(filename="backward_trace", format="svg")
```

will output something like this:

![backward_trace](https://github.com/user-attachments/assets/7319e5ab-fe9b-4587-a326-339c7cfc7bc0)




cc @borda @apaz-cli @carmocca