### PR TITLE
Temporarily disable some inductor tests on windows

### DIFF
--- a/thunder/tests/test_autocast.py
+++ b/thunder/tests/test_autocast.py
@@ -1,4 +1,5 @@
 import itertools
+import platform
 
 import pytest
 import torch
@@ -140,7 +141,9 @@ def test_compile_autocast(executor, device, dtype):
     assert output.dtype == (torch.float16 if torch_device.type == "cuda" else torch.bfloat16)
 
 
-@pytest.mark.skipif(not is_inductor_supported(), reason="inductor unsupported")
+# Disabling on windows temporarily, until our windows runners source the
+# appropriate visual studio config.
+@pytest.mark.skipif(not is_inductor_supported() or platform.system() == "Windows", reason="inductor unsupported")
 def test_torch_compile_autocast():
     """Checks if our autocast decorator plays well with ``torch.compile``"""
 

--- a/thunder/tests/test_torch_compile_executor.py
+++ b/thunder/tests/test_torch_compile_executor.py
@@ -1,3 +1,4 @@
+import platform
 import pytest
 import torch
 from torch._dynamo import is_inductor_supported
@@ -15,7 +16,9 @@ def test_supported_ops_are_in_pytorch_executor():
     assert supported_ops - pytorch_ex.implmap.keys() == set()
 
 
-@pytest.mark.skipif(not is_inductor_supported(), reason="inductor unsupported")
+# Disabling on windows temporarily, until our windows runners source the
+# appropriate visual studio config.
+@pytest.mark.skipif(not is_inductor_supported() or platform.system() == "Windows", reason="inductor unsupported")
 def test_torch_compile_litgpt():
     from litgpt.model import GPT
 


### PR DESCRIPTION
These tests require that the `cl` compiler is available and this may take some setup.

## What does this PR do?

Disables some tests since they require some setup on the runners.