### PR TITLE
bump gpu timeout

### DIFF
--- a/.azure/gpu-tests.yml
+++ b/.azure/gpu-tests.yml
@@ -84,7 +84,6 @@ jobs:
             pytest thunder/tests/ \
               -m "not standalone" \
               -v --datefmt="%Y%m%d-%H:%M:%S.%f" \
-              --timeout=240 \
               --random-order-seed=42 \
               --durations=250 \
               --timeout=240 \
@@ -97,7 +96,7 @@ jobs:
           ./codecov --token=$(CODECOV_TOKEN) --commit=$(Build.SourceVersion) \
             --flags=gpu,pytest,regular --name="GPU-coverage" --env=linux,azure
         condition: ne(variables['testing'], 'distributed')
-        timeoutInMinutes: "30"
+        timeoutInMinutes: "35"
         displayName: "Testing: regular"
 
       - bash: |


### PR DESCRIPTION
Even better would be to have more runners and smaller jobs, but it is what it is.