### PR TITLE
Update Thunder installation instructions in README to use the main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,12 +73,18 @@ The easiest way to get started with Thunder, requiring no extra installations or
 
 ## Install Thunder
 
-To use Thunder on your local machine:
-
-- install [nvFuser](https://github.com/NVIDIA/Fuser) and PyTorch stable together as follows:
+Thunder is in alpha and the latest development is happening on the `main` branch. You can install the latest version of Thunder from the `main` branch as follows:
 
 ```bash
-# install nvFuser which installs the matching stable PyTorch
+pip install git+https://github.com/Lightning-AI/lightning-thunder.git@main
+```
+
+To achieve the best performance, you can install Thunder with the following additional dependencies:
+
+- install nightly [nvFuser](https://github.com/NVIDIA/Fuser) built for PyTorch 2.4 as follows:
+
+```bash
+# install nvFuser built for the matching stable PyTorch
 pip install --pre nvfuser-cu121-torch24
 ```
 
@@ -89,32 +95,9 @@ pip install --pre nvfuser-cu121-torch24
 pip install nvidia-cudnn-frontend
 ```
 
-- Finally, install Thunder as follows:
-
-```
-# install thunder
-pip install lightning-thunder
-```
-
 <details>
   <summary>Advanced install options</summary>
     <!-- following section will be skipped from PyPI description -->
-
-&#160;
-
-### Install from main
-
-Alternatively, you can install the latest version of Thunder directly from this GitHub repository as follows:
-
-```
-# 1) Install nvFuser and PyTorch dependencies:
-pip install --pre nvfuser-cu121-torch24
-```
-
-```bash
-# 2) Install Thunder itself
-pip install git+https://github.com/Lightning-AI/lightning-thunder.git
-```
 
 &#160;
 


### PR DESCRIPTION
The PyPI package is outdated and shouldn't be recommended for installation. 

See the feedback at https://github.com/Lightning-AI/lightning-thunder/issues/1312#issuecomment-2418060135.

cc @borda