### PR TITLE
Simplify function implementation returned by thunder.jit for easier instrumentation of different stages

### DIFF
--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -732,7 +732,7 @@ def jit(
         return wrapped
 
 
-    def decorate_computation_functions(get_computation_and_inputs_fn, *decorators):
+    def decorate_computation_function(get_computation_and_inputs_fn, *decorators):
         def wrapped(*args, **kwargs):
             cache_entry, inps, pro_to_epi = get_computation_and_inputs_fn(*args, **kwargs)
             for decorator in decorators:
@@ -742,7 +742,7 @@ def jit(
         return wrapped
 
 
-    get_computation_and_inputs = decorate_computation_functions(get_computation_and_inputs, host_execution_timer)
+    get_computation_and_inputs = decorate_computation_function(get_computation_and_inputs, host_execution_timer)
     cd.get_computation_and_inputs = get_computation_and_inputs
 
 

--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -456,9 +456,6 @@ def jit(
                     except Exception as _:
                         continue
 
-                    cs.last_trace_host_tracing_start = time.perf_counter_ns()
-                    cs.last_trace_host_tracing_stop = time.perf_counter_ns()
-
                     # Updates cache statistics
                     cs.cache_hits += 1
                     cs.last_traces = comp_traces
@@ -490,9 +487,6 @@ def jit(
                 cs.last_prologue_execution_start = time.perf_counter_ns()
                 inps, pro_to_epi = pro(*args, **kwargs)
                 cs.last_prologue_execution_stop = time.perf_counter_ns()
-
-                cs.last_trace_host_tracing_start = time.perf_counter_ns()
-                cs.last_trace_host_tracing_stop = time.perf_counter_ns()
 
                 # Updates cache statistics
                 cs.cache_hits += 1

--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -802,13 +802,11 @@ def jit(
         check_storage_aliases(cache_entry, inps)
 
         result = cache_entry.computation_fn(*inps)
-
         result = maybe_connect_to_autograd(cache_entry, result)
 
         maybe_call_epilogue(cache_entry, result, pro_to_epi)
 
         cs.last_computation = cache_entry.computation_fn
-
         return result
 
     if isinstance(fn, pytorch.nn.Module):

--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -782,7 +782,6 @@ def jit(
         cs.last_computation_execution_stop = cs.last_trace_host_execution_stop
 
         cs.last_executed = cache_entry.computation_fn
-        cs.last_trace_cache_stop = time.perf_counter_ns()
 
         return result
 

--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -768,6 +768,12 @@ def jit(
         return result
 
 
+    def maybe_call_epilogue(cache_entry, result, pro_to_epi):
+        if cache_entry.epilogue_fn:
+            result, comp_to_epi = result
+            cache_entry.epilogue_fn(*pro_to_epi, *comp_to_epi)
+
+
     @wraps(fn)
     @update_call_statistics
     def fn_(*args, **kwargs) -> Any:
@@ -784,9 +790,7 @@ def jit(
 
         result = maybe_connect_to_autograd(cache_entry, result)
 
-        if cache_entry.epilogue_fn:
-            result, comp_to_epi = result
-            cache_entry.epilogue_fn(*pro_to_epi, *comp_to_epi)
+        maybe_call_epilogue(cache_entry, result, pro_to_epi)
 
         cs.last_trace_host_execution_stop = time.perf_counter_ns()
 

--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -781,7 +781,7 @@ def jit(
         cs.last_trace_host_execution_stop = time.perf_counter_ns()
         cs.last_computation_execution_stop = cs.last_trace_host_execution_stop
 
-        cs.last_executed = cache_entry.computation_fn
+        cs.last_computation = cache_entry.computation_fn
 
         return result
 

--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -779,7 +779,6 @@ def jit(
             cache_entry.epilogue_fn(*pro_to_epi, *comp_to_epi)
 
         cs.last_trace_host_execution_stop = time.perf_counter_ns()
-        cs.last_computation_execution_stop = cs.last_trace_host_execution_stop
 
         cs.last_computation = cache_entry.computation_fn
 

--- a/thunder/common.py
+++ b/thunder/common.py
@@ -64,7 +64,6 @@ __all__ = [
 
 
 # Holds statistics and caches for a compiled function
-# TODO RC1 Update last_executed to last_computation
 # TODO RC1 Review how autograd traces are presented
 class CompileStats:
     """A class holding statistics and caches for a compiled function.
@@ -76,7 +75,7 @@ class CompileStats:
         See :mod:`thunder` for more of such utility functions.
 
     Attributes:
-        last_executed:
+        last_computation (Callable):
         last_traces (Sequence[TraceCtx]):
         last_prologue (TraceCtx):
         last_prologue_traces (Sequence[TraceCtx]):
@@ -107,7 +106,7 @@ class CompileStats:
 
     def __init__(self):
         # Callables and traces
-        self.last_executed = None
+        self.last_computation = None
         self.last_traces = None
         self.last_prologue = None
         self.last_prologue_traces = None


### PR DESCRIPTION
This PR changes the `thunder.jit.fn_` implementation to use just a few lines of code making it more readable and amenable to per-function instrumentation like cProfile, pyinstrument, or NVTX decorators.

I removed a few unused timer measurements or if there was just a stop with no start. Other than that all CompileStats time measurements are preserved in this PR.

There was a todo to rename "last_executed" to "last_computation", this change is included here.

Here how the function looks like now:
```py
def fn_(*args, **kwargs) -> Any:
    if is_tracing():
        _recursive_jit_call_warning()
        return fn(*args, **kwargs)

    cache_entry, inps, pro_to_epi = get_computation_and_inputs(*args, **kwargs)
    check_storage_aliases(cache_entry, inps)
    result = cache_entry.computation_fn(*inps)
    result = maybe_connect_to_autograd(cache_entry, result)
    maybe_call_epilogue(cache_entry, result, pro_to_epi)
    return result
```