### PR TITLE
fix leak when view of output is saved for backward in autograd.Function

### DIFF
--- a/thunder/executors/torch_autograd.py
+++ b/thunder/executors/torch_autograd.py
@@ -78,6 +78,8 @@ class ThunderFunction(torch.autograd.Function):
         # NOTE - Detaching here would lead to problem with higher order differentiation but
         #        this is ok for now because ThunderFunction is only `once_differentiable`.
         def detach_if_tensor(t):
+            # Some operations may claim to return Tensor (as per their meta function)
+            # but may return None at Runtime (eg. noticed this for sdpa)
             if isinstance(t, torch.Tensor):
                 return t.detach()
             return t

--- a/thunder/executors/torch_autograd.py
+++ b/thunder/executors/torch_autograd.py
@@ -70,10 +70,27 @@ class ThunderFunction(torch.autograd.Function):
         ctx.saved_other = saved_other
         ctx.compiled_backward = compiled_backward
 
+        # NOTE [Saved view of output of torch.autograd.Function leaks]
+        # We detach here to avoid a bug in PyTorch where
+        # it leaks memory if view of the output of torch.autograd.Function
+        # is saved for backward.
+        # See - https://github.com/pytorch/pytorch/issues/94990#issuecomment-1435181804
+        # NOTE - Detaching here would lead to problem with higher order differentiation but
+        #        this is ok for now because ThunderFunction is only `once_differentiable`.
+        def detach_if_tensor(t):
+            if isinstance(t, torch.Tensor):
+                return t.detach()
+            return t
+
+        saved_tensors = tuple(map(detach_if_tensor, saved_tensors))
+
         # We must save tensors using ctx.save_for_backward
         ctx.save_for_backward(*saved_tensors)
         return flat_output
 
+    # NOTE: If `torch.autograd.function.once_differentiable` is to be removed,
+    # one must take care of correctly removing the `detach_if_tensor` above.
+    # For more context, see NOTE [Saved view of output of torch.autograd.Function leaks] above.
     @staticmethod
     @torch.autograd.function.once_differentiable
     def backward(ctx, *args):

--- a/thunder/tests/test_core.py
+++ b/thunder/tests/test_core.py
@@ -2978,8 +2978,8 @@ def test_saved_view_of_output_of_autograd_function_does_not_leak():
         matmul = emb @ emb.T
         return tok_emb, matmul
 
-    weight = make_tensor((16, 32), dtype=torch.float, device="cuda", requires_grad=True)
-    x = make_tensor((1, 2), dtype=torch.int64, low=0, high=10, device="cuda")
+    weight = make_tensor((16, 32), dtype=torch.float, device="cpu", requires_grad=True)
+    x = make_tensor((1, 2), dtype=torch.int64, low=0, high=10, device="cpu")
 
     jfn = thunder.jit(fn)
 

--- a/thunder/tests/test_core.py
+++ b/thunder/tests/test_core.py
@@ -2966,3 +2966,42 @@ def test_indexing_with_hashable_object():
     assert jfn() == 2  # Verify that jfn now returns 2
     assert thunder.cache_hits(jfn) == 1
     assert thunder.cache_misses(jfn) == 2
+
+
+def test_saved_view_of_output_of_autograd_function_does_not_leak():
+    # Verify that we have side-stepped the bug in torch.autograd.Function
+    # where saving a view of the output for backward leads to leak.
+    # See NOTE [Saved view of output of torch.autograd.Function leaks]
+    def fn(idx, weight):
+        tok_emb = torch.nn.functional.embedding(idx, weight)
+        emb = torch.reshape(tok_emb, (2, 32))
+        matmul = emb @ emb.T
+        return tok_emb, matmul
+
+    weight = make_tensor((16, 32), dtype=torch.float, device="cuda", requires_grad=True)
+    x = make_tensor((1, 2), dtype=torch.int64, low=0, high=10, device="cuda")
+
+    jfn = thunder.jit(fn)
+
+    # Computation Trace for jfn
+    # We save view of the output `tok_emb` for backward.
+    # @torch.no_grad()
+    # @no_autocast
+    # def computation(idx, t_wte_weight):
+    #   # idx: "cuda:0 i64[1, 2]"
+    #   # t_wte_weight: "cuda:0 f32[16, 32]"
+    #   tok_emb = torch.nn.functional.embedding(idx, t_wte_weight, None, None, 2.0, False, False)  # tok_emb: "cuda:0 f32[1, 2, 32]"
+    #   [emb, t4] = nvFusion0(tok_emb)
+    #       # emb = prims.reshape(tok_emb, (2, 32))  # emb: "cuda:0 f32[2, 32]"
+    #       # t4 = prims.transpose(emb, (1, 0))  # t4: "cuda:0 f32[32, 2]"
+    #   matmul = torch.matmul(emb, t4)  # matmul: "cuda:0 f32[2, 2]"
+    #   return {'output': (tok_emb, matmul), 'flat_args': [idx, t_wte_weight], 'flat_output': (tok_emb, matmul)}, ((emb, idx, t4), ())
+
+    prev_iter_refs = []
+    for iter_n in range(4):
+        tok_emb, _ = jfn(x, weight)
+        if iter_n < 3:
+            prev_iter_refs.append(weakref.ref(tok_emb))
+
+    for ref in prev_iter_refs:
+        assert ref() is None

--- a/thunder/tests/test_grad.py
+++ b/thunder/tests/test_grad.py
@@ -1725,7 +1725,8 @@ def test_torch_checkpoint():
         # With activation checkpointing, we are saving only the original input.
         # The intermediate values are recomputed during backward pass.
         assert len(out.grad_fn.saved_tensors) == 1
-        assert out.grad_fn.saved_tensors[0] is x
+        # We detach the saved tensors (which returns a new Python tensor backed by same storage)
+        assert out.grad_fn.saved_tensors[0].data_ptr() == x.data_ptr()
 
         g = torch.ones_like(out)
         out.backward(g)


### PR DESCRIPTION
Fixes https://github.com/Lightning-AI/lightning-thunder/issues/1314

PyTorch has a bug where saving a view of the output in `torch.autograd.Function` leads to memory leak. See https://github.com/pytorch/pytorch/issues/94990 and [comment](https://github.com/pytorch/pytorch/issues/94990#issuecomment-1435181804).

We side-step this issue by detaching the saved tensors before saving for backward (as mentioned as an option in [comment](https://github.com/pytorch/pytorch/issues/94990#issuecomment-1435181804)). This can lead to problem with higher order gradients but for now thunder explicitly disables it, so it should be fine.

Have added a small repro test for the same.