### PR TITLE
Add recipes and high level entrypoint

### DIFF
--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -39,6 +39,7 @@ from thunder.core.functionalization import (
     check_inplace_to_views,
     functionalize_inplace_ops,
 )
+from thunder.core.recipe import Recipe, Lookaside
 from thunder.common import (
     CompileData,
     CompileStats,
@@ -263,6 +264,13 @@ CacheEntry = namedtuple(
         "vanilla_tensor_args",
     ],
 )
+
+
+def compile(fn: Callable, recipe: Recipe | None):
+    if recipe is None:
+        return thunder.jit(fn)
+
+    return recipe.apply(fn)
 
 
 # This function will replace compile() (below) before RC1

--- a/thunder/core/recipe.py
+++ b/thunder/core/recipe.py
@@ -71,3 +71,7 @@ class Recipe:
             raise AttributeError(f"Compiler must be one of 'thunder.jit', 'torch.compile'. Found: {self.compiler}.")
 
         return thunder_model
+
+
+class DynamoRecipe(Recipe):
+    compiler = "torch.compile"

--- a/thunder/core/recipe.py
+++ b/thunder/core/recipe.py
@@ -27,16 +27,16 @@ class Recipe:
     #     # this is for registering custom kernels on the fly
     #     return None
 
-    def setup_lookasides(self) -> List[Lookaside] | None:
+    def setup_lookasides(self) -> list[Lookaside] | None:
         return None
 
-    def setup_transforms(self) -> List[Transform] | None:
+    def setup_transforms(self) -> list[Transform] | None:
         return None
 
-    def setup_executors(self) -> List[Executor] | None:
+    def setup_executors(self) -> list[Executor] | None:
         return None
 
-    def setup_config(self) -> Dict:
+    def setup_config(self) -> dict:
         return {}
 
     def apply(self, model):
@@ -58,20 +58,15 @@ class Recipe:
 
         if self.compiler == "thunder.jit":
             from thunder import jit
-            thunder_model = jit(model,
-                         transforms=self.transforms,
-                         executors=self.executors,
-                         **self.config)
+
+            thunder_model = jit(model, transforms=self.transforms, executors=self.executors, **self.config)
 
         elif self.compiler == "torch.compile":
             from thunder.dynamo import ThunderCompiler
-            thunder_backend = ThunderCompiler(
-                transforms=self.transforms,
-                executors=self.executors,
-                **self.config
-            )
+
+            thunder_backend = ThunderCompiler(transforms=self.transforms, executors=self.executors, **self.config)
             thunder_model = torch.compile(model, backend=thunder_backend)
-        
+
         else:
             raise AttributeError(f"Compiler must be one of 'thunder.jit', 'torch.compile'. Found: {self.compiler}.")
 

--- a/thunder/core/recipe.py
+++ b/thunder/core/recipe.py
@@ -1,0 +1,78 @@
+from typing import List, Dict
+
+from thunder.core.transform_common import Transform
+from thunder.extend import Executor
+
+import torch
+
+
+class Lookaside:
+    def __init__(self, fn, replace_with):
+        self._fn = fn
+        self._replace_with = replace_with
+
+
+class Recipe:
+    # thunder.jit | torch.compile
+    compiler = "thunder.jit"
+
+    def __init__(self):
+        pass
+
+    def validate(self, model):
+        # this is supposed to raise
+        pass
+
+    # def setup_operators(self) -> List[Operator]:
+    #     # this is for registering custom kernels on the fly
+    #     return None
+
+    def setup_lookasides(self) -> List[Lookaside] | None:
+        return None
+
+    def setup_transforms(self) -> List[Transform] | None:
+        return None
+
+    def setup_executors(self) -> List[Executor] | None:
+        return None
+
+    def setup_config(self) -> Dict:
+        return {}
+
+    def apply(self, model):
+        self.validate(model)
+
+        self.config = self.setup_config()
+        lookasides = self.setup_lookasides()
+
+        from thunder.core import jit_ext, interpreter
+
+        if lookasides is not None:
+            for lookaside in lookasides:
+                wrapped_replacement_fn = interpreter.interpreter_needs_wrap(lookaside._replace_with)
+                jit_ext._general_jit_lookaside_map[lookaside._fn] = wrapped_replacement_fn
+
+        self.lookasides = lookasides
+        self.executors = self.setup_executors()
+        self.transforms = self.setup_transforms()
+
+        if self.compiler == "thunder.jit":
+            from thunder import jit
+            thunder_model = jit(model,
+                         transforms=self.transforms,
+                         executors=self.executors,
+                         **self.config)
+
+        elif self.compiler == "torch.compile":
+            from thunder.dynamo import ThunderCompiler
+            thunder_backend = ThunderCompiler(
+                transforms=self.transforms,
+                executors=self.executors,
+                **self.config
+            )
+            thunder_model = torch.compile(model, backend=thunder_backend)
+        
+        else:
+            raise AttributeError(f"Compiler must be one of 'thunder.jit', 'torch.compile'. Found: {self.compiler}.")
+
+        return thunder_model

--- a/thunder/core/recipe.py
+++ b/thunder/core/recipe.py
@@ -1,7 +1,7 @@
 from typing import List, Dict
 
 from thunder.core.transform_common import Transform
-from thunder.extend import Executor
+from thunder.extend import Executor, get_default_executors
 
 import torch
 
@@ -33,8 +33,8 @@ class Recipe:
     def setup_transforms(self) -> list[Transform] | None:
         return None
 
-    def setup_executors(self) -> list[Executor] | None:
-        return None
+    def setup_executors(self):
+        return get_default_executors()
 
     def setup_config(self) -> dict:
         return {}

--- a/thunder/recipes/hf_bert.py
+++ b/thunder/recipes/hf_bert.py
@@ -11,7 +11,7 @@ class HFBertBasic(thunder.Recipe):
     def setup_lookasides(self):
         warn_lookaside = thunder.Lookaside(
             fn=transformers.modeling_utils.PreTrainedModel.warn_if_padding_and_no_attention_mask,
-            replace_with=lambda *args: None
+            replace_with=lambda *args: None,
         )
 
         if hasattr(torch, "compiler") and hasattr(torch.compiler, "is_compiling"):
@@ -19,10 +19,7 @@ class HFBertBasic(thunder.Recipe):
         else:
             is_compiling = torch._dynamo.is_compiling
 
-        is_compiling_lookaside = thunder.Lookaside(
-            fn=is_compiling,
-            replace_with=lambda *_: True
-        )
+        is_compiling_lookaside = thunder.Lookaside(fn=is_compiling, replace_with=lambda *_: True)
 
         return [warn_lookaside, is_compiling_lookaside]
 
@@ -31,4 +28,3 @@ class HFBertBasic(thunder.Recipe):
 
     def setup_executors(self):
         return thunder.get_default_executors()
-

--- a/thunder/recipes/hf_bert.py
+++ b/thunder/recipes/hf_bert.py
@@ -22,9 +22,3 @@ class HFBertBasic(thunder.Recipe):
         is_compiling_lookaside = thunder.Lookaside(fn=is_compiling, replace_with=lambda *_: True)
 
         return [warn_lookaside, is_compiling_lookaside]
-
-    def setup_transforms(self):
-        return None
-
-    def setup_executors(self):
-        return thunder.get_default_executors()

--- a/thunder/recipes/hf_bert.py
+++ b/thunder/recipes/hf_bert.py
@@ -1,0 +1,34 @@
+import thunder
+import transformers
+import torch
+
+
+class HFBertBasic(thunder.Recipe):
+    def validate(self, model):
+        if not isinstance(model, transformers.BertForSequenceClassification):
+            raise ValueError("The model must be a BertForSequenceClassification")
+
+    def setup_lookasides(self):
+        warn_lookaside = thunder.Lookaside(
+            fn=transformers.modeling_utils.PreTrainedModel.warn_if_padding_and_no_attention_mask,
+            replace_with=lambda *args: None
+        )
+
+        if hasattr(torch, "compiler") and hasattr(torch.compiler, "is_compiling"):
+            is_compiling = torch.compiler.is_compiling
+        else:
+            is_compiling = torch._dynamo.is_compiling
+
+        is_compiling_lookaside = thunder.Lookaside(
+            fn=is_compiling,
+            replace_with=lambda *_: True
+        )
+
+        return [warn_lookaside, is_compiling_lookaside]
+
+    def setup_transforms(self):
+        return None
+
+    def setup_executors(self):
+        return thunder.get_default_executors()
+

--- a/thunder/tests/test_recipes.py
+++ b/thunder/tests/test_recipes.py
@@ -5,10 +5,6 @@ import torch
 from torch.testing import assert_close, make_tensor
 
 
-class HFBertBasicFX(thunder.Recipe):
-    compiler = "torch.compile"
-
-
 def test_recipe_basic_bert():
     bert = transformers.BertForSequenceClassification(transformers.BertConfig())
     del bert.bert.encoder.layer[1:]
@@ -26,14 +22,16 @@ def test_recipe_basic_bert():
     assert_close(actual, expected)
 
 
-def test_recipe_basic_bert_fx():
+def test_recipe_basic_bert_dynamo():
     bert = transformers.BertForSequenceClassification(transformers.BertConfig())
     del bert.bert.encoder.layer[1:]
     bert.eval()
 
     inp = torch.randint(1, 20, (1, 32))
 
-    thunder_bert = thunder.compile(bert, recipe=HFBertBasicFX())
+    from thunder.core.recipe import DynamoRecipe
+
+    thunder_bert = thunder.compile(bert, recipe=DynamoRecipe())
 
     actual = thunder_bert(inp)
     expected = bert(inp)

--- a/thunder/tests/test_recipes.py
+++ b/thunder/tests/test_recipes.py
@@ -1,0 +1,41 @@
+import thunder
+import transformers
+import torch
+
+from torch.testing import assert_close, make_tensor
+
+
+class HFBertBasicFX(thunder.Recipe):
+    compiler = "torch.compile"
+
+
+def test_recipe_basic_bert():
+    bert = transformers.BertForSequenceClassification(transformers.BertConfig())
+    del bert.bert.encoder.layer[1:]
+    bert.eval()
+
+    inp = torch.randint(1, 20, (1, 32))
+
+    from thunder.recipes.hf_bert import HFBertBasic
+
+    thunder_bert = thunder.compile(bert, recipe=HFBertBasic())
+
+    actual = thunder_bert(inp)
+    expected = bert(inp)
+
+    assert_close(actual, expected)
+
+
+def test_recipe_basic_bert_fx():
+    bert = transformers.BertForSequenceClassification(transformers.BertConfig())
+    del bert.bert.encoder.layer[1:]
+    bert.eval()
+
+    inp = torch.randint(1, 20, (1, 32))
+
+    thunder_bert = thunder.compile(bert, recipe=HFBertBasicFX())
+
+    actual = thunder_bert(inp)
+    expected = bert(inp)
+
+    assert_close(actual, expected)


### PR DESCRIPTION
Addresses #1188

This is a very simple v0, we'll be adding models and smoothen out the API as we go.

- I've opted for one recipe at a time for now (i.e. no lists of recipes) to keep things simple.
- Also I've included a ThunderFX mode to clarify usage there.
- The single operator shortcut is still TODO
- I need to extend tests to add more coverage before this is merged
