### PR TITLE
LitGPT benchmarking: Use native PyTorch checkpointing in the dynamo+thunder path

### DIFF
--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -532,7 +532,7 @@ class Benchmark_litGPT:
         return model
 
     def setup_activation_checkpointing(self):
-        if "thunder" in self.compile:
+        if "thunder" in self.compile and "dynamo" not in self.compile:
             # checkpointing is an option to thunder.jit
             return
 
@@ -571,11 +571,6 @@ class Benchmark_litGPT:
 
                 executors.insert(0, transformer_engine_ex)
 
-            jit_options = {
-                "enable_saved_for_backward_recomputation": self.checkpoint_activations,
-                "recomputation_policy": None,
-            }
-
             if "dynamo" in self.compile:
                 if self.distributed_mode == "fsdp2":
                     print("Resetting cache size for when fsdp2 and using thunder as backend torch.compile")
@@ -583,13 +578,16 @@ class Benchmark_litGPT:
 
                     dynamo_config.cache_size_limit = 64
 
-                backend = ThunderCompiler(executors=executors, **jit_options)
+                self.backend = ThunderCompiler(executors=executors)
                 # Because Lightning Fabric is imported in this script it monkey patches the torch.compile function
                 # https://github.com/Lightning-AI/pytorch-lightning/blob/828fd998961f6a60f92c35254bb94d6e049ad069/src/lightning/fabric/wrappers.py#L421
                 # using __wrapped__ to access the original torch.compile function did not work
                 # so we are using the lower level torch._dynamo.optimize function
-                model = torch._dynamo.optimize(backend=backend)(model)
+                model = torch._dynamo.optimize(backend=self.backend)(model)
             else:
+                jit_options = {
+                    "enable_saved_for_backward_recomputation": self.checkpoint_activations,
+                }
                 jit_options["fp8_shard_intermediate_activation"] = self.fp8_shard_intermediate_activation
                 model = thunder.jit(model, executors=executors, **jit_options)
 
@@ -844,16 +842,24 @@ def benchmark_main(return_metrics_as_json=False, json_path="", **kwargs) -> None
                 for jitted in benchmark.thunder_as_torch_compile_backend.gm_to_thunder.values():
                     fwd_traces.append(thunder.last_traces(jitted))
                     bwd_traces.append(thunder.last_backward_traces(jitted))
-            else:
+            elif "dynamo" not in benchmark.compile:
                 fwd_traces = [thunder.last_traces(benchmark.model)]
                 bwd_traces = [thunder.last_backward_traces(benchmark.model)]
 
-            for i, f_traces in enumerate(fwd_traces, start=1):
-                print(f"##########\n#{i}-th ThunderModule\n##########")
-                print(f_traces[-1])
-            for i, b_traces in enumerate(bwd_traces, start=1):
-                print(f"##########\n#{i}-th ThunderModule\n##########")
-                print(b_traces[-1])
+            if "dynamo" in benchmark.compile:
+                for gid, infos in enumerate(benchmark.backend.subgraph_infos):
+                    for subgid, thunder_fn in enumerate(infos.thunder_compiled_fns):
+                        print(f"##########\n#Graph{gid}-ThunderFn{subgid} last forward trace\n##########")
+                        print(thunder.last_traces(thunder_fn)[-1])
+                        print(f"##########\n#Graph{gid}-ThunderFn{subgid} last backward trace\n##########")
+                        print(thunder.last_backward_traces(thunder_fn)[-1])
+            else:
+                for i, f_traces in enumerate(fwd_traces, start=1):
+                    print(f"##########\n#{i}-th ThunderModule\n##########")
+                    print(f_traces[-1])
+                for i, b_traces in enumerate(bwd_traces, start=1):
+                    print(f"##########\n#{i}-th ThunderModule\n##########")
+                    print(b_traces[-1])
 
     if global_rank in [0, None]:
         if return_metrics_as_json:


### PR DESCRIPTION
Use the native PyTorch checkpoint option in litgpt benchmark for the Thunder Dynamo path

Ref #1298.

H100*8 ZeRO3 with checkpointing
`torchrun --nproc_per_node=8 --nnodes=1 thunder/benchmarks/benchmark_litgpt.py --model_name CodeLlama-34b-hf --micro_batch_size 1 --compile thunder-dynamo --checkpoint_activations=True --distributed_mode=fsdp --shard_mode zero3 --max_iters=4 --warmup_iters=1`
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/wayan/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/wayan/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">

</head>

<body link="#467886" vlink="#96607D">


  | micro batch size | peak mem
-- | -- | --
longchat-13b-16k | 3 | 50.40 GB
CodeLlama-34b-hf | 1 | 48.07 GB
Gemma-2-27b | 1 | OOM
Llama-3-70B | 1 | 78.77 GB
Mistral-7B-v0.2 | 3 | 67.44 GB
vicuna-7b-v1.5-16k | 5 | 54.81 GB



</body>

</html>


Note:
This PR enable the ThunderFX + native PyTorch checkpointing

Single GPU: 
the splitter creates the module as follows:
```
GraphModule(
  (thunder_1): ThunderModule(
    (_model): GraphModule()
  )
  (inductor_2): OptimizedModule(
    (_orig_mod): GraphModule(
      (wrap_body_0): GraphModule()
    )
  )
  (thunder_3): ThunderModule(
    (_model): GraphModule()
  )
  (inductor_4): OptimizedModule(
    (_orig_mod): GraphModule(
      (wrap_body_1): GraphModule()
    )
  )
  (thunder_5): ThunderModule(
    (_model): GraphModule()
  )
)
```
The checkpoint operator is not supported by Thunder and fallback to running with inductor(the converter PR #1261 can fix this)

ZeRO3:
Dynamo only passes parts of the original model to the backend (the `gm` in `ThunderCompiler.__call__`) that do not contain a checkpoint operator when `--bucketing_mode=none` is used.
