### PR TITLE
bump pt to 2.5.1

### DIFF
--- a/.azure/docker-build.yml
+++ b/.azure/docker-build.yml
@@ -40,8 +40,8 @@ jobs:
       #maxParallel: "3"
       matrix:
         # CUDA 12.1
-        "cuda 12.1 | torch 2.4.0 | cudnn FE v1.5.2":
-          { CUDA_VERSION: "12.1.1", TORCH_VERSION: "2.4.0", TRITON_VERSION: "3.0.0", CUDNN_FRONTEND_VERSION: "1.5.2" }
+        "cuda 12.1 | torch 2.5.1 | cudnn FE v1.5.2":
+          { CUDA_VERSION: "12.1.1", TORCH_VERSION: "2.5.1", TRITON_VERSION: "3.0.0", CUDNN_FRONTEND_VERSION: "1.5.2" }
         "cuda 12.1 | torch 2.5 /nightly | cudnn FE v1.5.2":
           { CUDA_VERSION: "12.1.1", TORCH_VERSION: "main", TORCH_INSTALL: "source", CUDNN_FRONTEND_VERSION: "1.5.2" }
         #'cuda 12.1': # this version - '8.9.5.29-1+cuda12.1' for 'libcudnn8' was not found

--- a/.azure/docker-build.yml
+++ b/.azure/docker-build.yml
@@ -41,7 +41,7 @@ jobs:
       matrix:
         # CUDA 12.1
         "cuda 12.1 | torch 2.5.1 | cudnn FE v1.5.2":
-          { CUDA_VERSION: "12.1.1", TORCH_VERSION: "2.5.1", TRITON_VERSION: "3.0.0", CUDNN_FRONTEND_VERSION: "1.5.2" }
+          { CUDA_VERSION: "12.1.1", TORCH_VERSION: "2.5.1", TRITON_VERSION: "3.1.0", CUDNN_FRONTEND_VERSION: "1.5.2" }
         "cuda 12.1 | torch 2.5 /nightly | cudnn FE v1.5.2":
           { CUDA_VERSION: "12.1.1", TORCH_VERSION: "main", TORCH_INSTALL: "source", CUDNN_FRONTEND_VERSION: "1.5.2" }
         #'cuda 12.1': # this version - '8.9.5.29-1+cuda12.1' for 'libcudnn8' was not found

--- a/.azure/gpu-tests.yml
+++ b/.azure/gpu-tests.yml
@@ -16,11 +16,11 @@ jobs:
     strategy:
       matrix:
         # CUDA 12.1
-        "ubuntu22.04 | cuda 12.1 | python 3.10 | torch 2.4.0 | regular":
-          docker-image: "ubuntu22.04-cuda12.1.1-cudnn-fe1.5.2-py3.10-pt_2.4.0-dev"
+        "ubuntu22.04 | cuda 12.1 | python 3.10 | torch 2.5.1 | regular":
+          docker-image: "ubuntu22.04-cuda12.1.1-cudnn-fe1.5.2-py3.10-pt_2.5.1-dev"
           CUDA_VERSION_MM: "121"
-        "ubuntu22.04 | cuda 12.1 | python 3.10 | torch 2.4.0 | distributed":
-          docker-image: "ubuntu22.04-cuda12.1.1-cudnn-fe1.5.2-py3.10-pt_2.4.0-dev"
+        "ubuntu22.04 | cuda 12.1 | python 3.10 | torch 2.5.1 | distributed":
+          docker-image: "ubuntu22.04-cuda12.1.1-cudnn-fe1.5.2-py3.10-pt_2.5.1-dev"
           CUDA_VERSION_MM: "121"
           testing: "distributed"
         "ubuntu22.04 | cuda 12.1 | python 3.10 | torch-nightly | regular":

--- a/dockers/ubuntu-cuda/Dockerfile
+++ b/dockers/ubuntu-cuda/Dockerfile
@@ -160,7 +160,7 @@ RUN \
         # installing pytorch from wheels \
         CUDA_VERSION_MM=${CUDA_VERSION%.*} && \
         TORCH_VERSION_MM=${TORCH_VERSION%.*} && \
-        pip install -U --extra-index-url https://pypi.nvidia.com --pre "nvfuser-cu${CUDA_VERSION_MM/./}-torch${TORCH_VERSION_MM/./}" ; \
+        pip install -U "nvfuser-cu${CUDA_VERSION_MM/./}-torch${TORCH_VERSION_MM/./}" ; \
     fi
 
 RUN \

--- a/dockers/ubuntu-cuda/Dockerfile
+++ b/dockers/ubuntu-cuda/Dockerfile
@@ -160,7 +160,7 @@ RUN \
         # installing pytorch from wheels \
         CUDA_VERSION_MM=${CUDA_VERSION%.*} && \
         TORCH_VERSION_MM=${TORCH_VERSION%.*} && \
-        pip install -U "nvfuser-cu${CUDA_VERSION_MM/./}-torch${TORCH_VERSION_MM/./}" ; \
+        pip install -U --extra-index-url https://pypi.nvidia.com --pre "nvfuser-cu${CUDA_VERSION_MM/./}-torch${TORCH_VERSION_MM/./}" ; \
     fi
 
 RUN \


### PR DESCRIPTION
Fixes: #1372

based on the discussion in #1372

- pypi.python.org is actually the right repo for nvfuser built for stable PT,
- as of now, we have -torch25 packages there and the plan is to update these regularly (and it's not so clear with -toirch24).