### PR TITLE
thunderFX: delegate autocast regions to thunder

### DIFF
--- a/thunder/dynamo/utils.py
+++ b/thunder/dynamo/utils.py
@@ -179,8 +179,8 @@ def try_execute_thunder_symbol(thunder_symbol: Symbol, node: torch.fx.Node) -> t
     from thunder.core.compile_data import compile_data_and_stats
     from thunder.common import CompileData, CompileStats
 
-    # We require a corresponding `_enter_autocast` in trace to correctly pop the state,
-    # else we get error notifying that we are popping empty stack.
+    # We require a corresponding `_enter_autocast` in trace to correctly pop the
+    # state on `_exit_autocast`, else we get `IndexError: pop from an empty deque`.
     # As a work-around, we short circuit and return True.
     if hasattr(thunder_symbol, "id") and thunder_symbol.id == "torch.amp.autocast_mode._exit_autocast":
         return True, None

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -145,7 +145,8 @@ def test_splitter_autocast_ctx(executor, device: str, dtype: dtypes.dtype, dynam
     expected_grad = torch.autograd.grad(expected, x, g)
     torch.testing.assert_close(actual_grad, expected_grad)
 
-    assert len(backend.subgraph_infos) == 1  # There were no splits.
+    assert len(backend.subgraph_infos) == 1
+    assert len(backend.subgraph_infos[0].split_reasons) == 0
     compiled_functions = tuple(backend.subgraph_infos[0].submodule_to_compiled_functions.values())
     assert all(compiled_fn.compiler == CompilerType.THUNDER for compiled_fn in compiled_functions)
     assert not any(compiled_fn.compiler == CompilerType.TORCH_INDUCTOR for compiled_fn in compiled_functions)

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -155,7 +155,7 @@ def test_splitter_autocast_ctx(executor, device: str, dtype: dtypes.dtype, dynam
     dtypes=NOTHING,
     executors=[DynamoThunderExecutor],
     decorators=(
-        pytest.mark.parametrize("dynamic", (False,), ids=("static",)),
+        pytest.mark.parametrize("dynamic", (True, False, None), ids=("dynamic", "static", "auto")),
         pytest.mark.xfail(
             condition=IS_WINDOWS,
             strict=True,
@@ -178,12 +178,8 @@ def test_splitter_autocast_ctx_with_graph_break(executor, device: str, dtype: dt
     expected = torch.compile(func, dynamic=dynamic)(x)
     cfunc = torch.compile(func, backend=backend, dynamic=dynamic)
     actual = cfunc(x)
-    import thunder
 
-    # print(len(backend.subgraph_infos[1].thunder_compiled_fns))
-    print(thunder.last_traces(backend.subgraph_infos[1].thunder_compiled_fns[0])[0])
     g = torch.rand_like(actual)
-    print(actual.dtype, expected.dtype)
     torch.testing.assert_close(actual, expected)
     actual_grad = torch.autograd.grad(actual, x, g)
     expected_grad = torch.autograd.grad(expected, x, g)

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -5607,6 +5607,8 @@ def autocast_enter(device_type, dtype=None, enabled=True, _unused_cache_enabled=
     tags=(prims.OpTags.DONT_DCE, prims.OpTags.CTX_MANAGER_ENTER_EXIT_OP),
 )
 def autocast_exit(*args):
+    if get_compile_data().autocast_stack.is_empty():
+        return
     get_compile_data().autocast_stack.pop()
 
 

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -5595,6 +5595,7 @@ def autocast_enter(device_type, dtype=None, enabled=True, _unused_cache_enabled=
     # PyTorch applies autocast irrespective of device index.
     # So, here we grab the device_type from the string.
     device_type, unused_deviceno = devices._device_from_string_helper(device_type)
+    device_type = devices.devicetype_string(device_type)
     if dtype is None:
         dtype = torch.get_autocast_dtype(device_type)
     get_compile_data().autocast_stack.push(device_type, dtype, enabled)

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -5594,7 +5594,7 @@ def autocast_enter(device_type, dtype=None, enabled=True, _unused_cache_enabled=
     # We may receive device_type=cuda:0
     # PyTorch applies autocast irrespective of device index.
     # So, here we grab the device_type from the string.
-    device_type = devices.to_device(device_type).type
+    device_type, unused_deviceno = devices._device_from_string_helper(device_type)
     if dtype is None:
         dtype = torch.get_autocast_dtype(device_type)
     get_compile_data().autocast_stack.push(device_type, dtype, enabled)

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -5590,7 +5590,11 @@ def backward_autograd_function_apply(
     id="torch.amp.autocast_mode._enter_autocast",
     tags=(prims.OpTags.DONT_DCE, prims.OpTags.CTX_MANAGER_ENTER_EXIT_OP),
 )
-def autocast_enter(device_type, dtype=None, enabled=True):
+def autocast_enter(device_type, dtype=None, enabled=True, _unused_cache_enabled=True):
+    # We may receive device_type=cuda:0
+    # PyTorch applies autocast irrespective of device index.
+    # So, here we grab the device_type from the string.
+    device_type = devices.to_device(device_type).type
     if dtype is None:
         dtype = torch.get_autocast_dtype(device_type)
     get_compile_data().autocast_stack.push(device_type, dtype, enabled)


### PR DESCRIPTION
This PR updates `splitter` for thunderFX to pass regions under autocast context manager to thunder (instead of inductor as it happens currently). 

In dynamo, these regions show up bounded within `torch.amp.autocast_mode._enter_autocast` and `torch.amp.autocast_mode._exit_autocast` for which we have corresponding symbols in thunder (see PR https://github.com/Lightning-AI/lightning-thunder/pull/1262 for more details on these symbols) .

Eg. Dynamo Graph with autocast enabled.
```python
def forward(self, L_x_: "f32[2, 2]"):
      l_x_ = L_x_
      
      # No stacktrace found for following nodes
      _enter_autocast = torch.amp.autocast_mode._enter_autocast('cuda:0', None, True, None)
      
       # File: /home/kkalambarkar/lightning-thunder/scratchpad/test.py:158 in func, code: return torch.matmul(x, x)
      matmul: "f16[2, 2]" = torch.matmul(l_x_, l_x_);  l_x_ = None
      
      # No stacktrace found for following nodes
      _exit_autocast = torch.amp.autocast_mode._exit_autocast(_enter_autocast);  _enter_autocast = _exit_autocast = None
      return (matmul,)
```

Also, it works if there is a split in the `torch.autocast` region. `fx.split_module` copies _enter_autocast and _exit_autocast for each split to correctly preserve the state.

Eg program
```python
def func(x):
    with torch.autocast(device):
        x = torch.matmul(x, x)
        # We will have a split because torch.sinc is autoregistered in thunder
        # (and it will be passed to inductor)
        x = torch.sinc(x)
        return torch.matmul(x, x)
```

Split Graph
```python
class GraphModule(torch.nn.Module):
    def forward(self, l_x_: "f32[2, 2]"):
        # No stacktrace found for following nodes
        thunder_1 = self.thunder_1(l_x_);  l_x_ = None
        inductor_2 = self.inductor_2(thunder_1);  thunder_1 = None
        thunder_3 = self.thunder_3(inductor_2);  inductor_2 = None
        return (thunder_3,)
        
    class thunder_1(torch.nn.Module):
        def forward(self, l_x_: "f32[2, 2]"):
            # No stacktrace found for following nodes
            _enter_autocast = torch.amp.autocast_mode._enter_autocast('cuda:0', None, True, None)
            
             # File: /home/kkalambarkar/lightning-thunder/scratchpad/test.py:158 in func, code: x = torch.matmul(x, x)
            x: "f16[2, 2]" = torch.matmul(l_x_, l_x_);  l_x_ = None
            
            # No stacktrace found for following nodes
            _exit_autocast = torch.amp.autocast_mode._exit_autocast(_enter_autocast);  _enter_autocast = _exit_autocast = None
            return x
      
    class inductor_2(torch.nn.Module):
        def forward(self, x: "f16[2, 2]"):
            # No stacktrace found for following nodes
            _enter_autocast = torch.amp.autocast_mode._enter_autocast('cuda:0', None, True, None)
            
             # File: /home/kkalambarkar/lightning-thunder/scratchpad/test.py:159 in func, code: x = torch.sinc(x)
            x_1: "f16[2, 2]" = torch.sinc(x);  x = None
            
            # No stacktrace found for following nodes
            _exit_autocast = torch.amp.autocast_mode._exit_autocast(_enter_autocast);  _enter_autocast = _exit_autocast = None
            return x_1
            
    class thunder_3(torch.nn.Module):
        def forward(self, x_1: "f16[2, 2]"):
            # No stacktrace found for following nodes
            _enter_autocast = torch.amp.autocast_mode._enter_autocast('cuda:0', None, True, None)
            
             # File: /home/kkalambarkar/lightning-thunder/scratchpad/test.py:160 in func, code: return torch.matmul(x, x)
            matmul_1: "f16[2, 2]" = torch.matmul(x_1, x_1);  x_1 = None
            
            # No stacktrace found for following nodes
            _exit_autocast = torch.amp.autocast_mode._exit_autocast(_enter_autocast);  _enter_autocast = _exit_autocast = None
            return matmul_1
```