### PR TITLE
[visualization] update make_trace_dot

### DIFF
--- a/thunder/examine/__init__.py
+++ b/thunder/examine/__init__.py
@@ -365,7 +365,7 @@ def make_trace_dot(trace: TraceCtx, show_metadata=False):
                 dot.node(arg_id, _repr_tensor_proxy(arg, show_metadata))
                 dot.edge(arg_id, str(node_id))
 
-        # Add node for outputs and connect outputs
+        # Connect outputs
         for out in node.bsym.flat_outs:
             if isinstance(out, TensorProxy):
                 out_id = out.name

--- a/thunder/examine/__init__.py
+++ b/thunder/examine/__init__.py
@@ -297,17 +297,20 @@ def _repr_tensor_proxy(t_proxy, show_metadata=False):
     return f"name:{t_proxy.name}" + extra_meta
 
 
-def make_trace_dot(trace: TraceCtx, show_proxy_metadata=False):
+def make_trace_dot(trace: TraceCtx, show_metadata=False):
     """
     Creates a directed graph of the given trace.
 
     This function is intended to be used to use graphviz to visualize the computation graph of a trace.
     Beware, rendering out a graph for large traces might take a while.
 
+    Roots nodes are colored "green", intermediates are colored "lightblue" and leaves are colored "orange"
+
     Requires graphviz to be installed, for more information check out -> https://graphviz.readthedocs.io/en/stable/index.html
 
     Args:
         trace (TraceCtx): The Thunder trace to be made into a graph.
+        show_metadata (bool): Add more meta-data (like shape, dtype) to the nodes representing the Tensor. Defaults to False.
 
     Returns:
         graphviz.Digraph: A graphviz directed graph.
@@ -359,7 +362,7 @@ def make_trace_dot(trace: TraceCtx, show_proxy_metadata=False):
         for arg in node.bsym.flat_args:
             if isinstance(arg, TensorProxy):
                 arg_id = arg.name
-                dot.node(arg_id, _repr_tensor_proxy(arg, show_proxy_metadata))
+                dot.node(arg_id, _repr_tensor_proxy(arg, show_metadata))
                 dot.edge(arg_id, str(node_id))
 
         # Add node for outputs and connect outputs

--- a/thunder/examine/__init__.py
+++ b/thunder/examine/__init__.py
@@ -312,6 +312,16 @@ def make_trace_dot(trace: TraceCtx, show_metadata=False):
 
     Requires graphviz to be installed, for more information check out -> https://graphviz.readthedocs.io/en/stable/index.html
 
+    .. note::
+        To improve the rendering time, one can update `nslimit` and `nslimit1` graph attributes on the returned Digraph before
+        calling the `render`.
+        Eg. dot_graph.graph_attr["nslimit"] = 5
+
+        Refer the following links for more details:
+        [1] https://graphviz.org/docs/attrs/nslimit/
+        [2] https://graphviz.org/docs/attrs/nslimit1/
+
+
     Args:
         trace (TraceCtx): The Thunder trace to be made into a graph.
         show_metadata (bool): Add more meta-data (like shape, dtype) to the nodes representing the Tensor. Defaults to False.


### PR DESCRIPTION
Builds on great feature introduced by @riccardofelluga 

Changes 
* We add a seperate node for input/output to a Symbol (with option to add more metadata)
* Symbol node prints the python repr to show more information (currently we print the symbol name)
* Update color scheme - `Roots nodes are colored "green", intermediates are colored "lightblue" and leaves are colored "orange"`

```python
import thunder
from thunder.examine import make_trace_dot
import torch

def foo(x, y):
    return x + y / (x * y)

jfoo = thunder.jit(foo)

jfoo(torch.randn(3, requires_grad=True), torch.randn(3,))

t = thunder.last_traces(jfoo)[-3]
dot = make_trace_dot(t)
dot.render(format='png')

```

Output

Forward Graph
![image](https://github.com/user-attachments/assets/358cde2f-2855-4bad-8d3d-9c486d00574b)

Backward Graph
![image](https://github.com/user-attachments/assets/78daf7e7-249d-4554-8a86-3d327e27f1bb)

