### PR TITLE
Reduce CPU overhead of FusionDefinitionWrapper

### DIFF
--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -408,7 +408,9 @@ def get_tensor_descriptor(p: TensorProxy, t: torch.Tensor) -> tuple[tuple[int, .
 # TODO Inline the get_tensor_descriptor call
 def to_descriptors(proxy_args, args) -> tuple:
     def to_descriptor(proxy_arg, arg):
-        if isinstance(arg, Number):
+        if isinstance(arg, torch.Tensor):
+            return (*get_tensor_descriptor(proxy_arg, arg), arg.dtype)
+        elif isinstance(arg, Number):
             return type(arg)
         elif isinstance(arg, tuple):
             if len(arg) != 0:
@@ -419,8 +421,6 @@ def to_descriptors(proxy_args, args) -> tuple:
                     exception_type=AssertionError,
                 )
             return type(arg)
-        elif isinstance(arg, torch.Tensor):
-            return (*get_tensor_descriptor(proxy_arg, arg), arg.dtype)
 
         raise ValueError(f"unrecognized type in arguments: {type(arg)}")
 

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -12,6 +12,7 @@ import warnings
 
 from looseversion import LooseVersion
 import torch
+from torch import Tensor
 
 import thunder.core.dtypes as dtypes
 import thunder.torch as ltorch
@@ -408,7 +409,7 @@ def get_tensor_descriptor(p: TensorProxy, t: torch.Tensor) -> tuple[tuple[int, .
 # TODO Inline the get_tensor_descriptor call
 def to_descriptors(proxy_args, args) -> tuple:
     def to_descriptor(proxy_arg, arg):
-        if isinstance(arg, torch.Tensor):
+        if isinstance(arg, Tensor):
             return (*get_tensor_descriptor(proxy_arg, arg), arg.dtype)
         elif isinstance(arg, Number):
             return type(arg)

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -402,15 +402,10 @@ def compute_tensor_descriptor(
     return compute_symbolic_shape(proxy_shape, shape), *compute_contiguity(shape, stride)
 
 
-def get_tensor_descriptor(p: TensorProxy, t: torch.Tensor) -> tuple[tuple[int, ...], tuple[bool, ...], tuple[int, ...]]:
-    return compute_tensor_descriptor(p.shape, t.shape, t.stride())
-
-
-# TODO Inline the get_tensor_descriptor call
 def to_descriptors(proxy_args, args) -> tuple:
     def to_descriptor(proxy_arg, arg):
         if isinstance(arg, Tensor):
-            return (*get_tensor_descriptor(proxy_arg, arg), arg.dtype)
+            return (*compute_tensor_descriptor(proxy_arg.shape, arg.shape, arg.stride()), arg.dtype)
         elif isinstance(arg, Number):
             return type(arg)
         elif isinstance(arg, tuple):

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -40,7 +40,7 @@ from thunder.core.devices import Device, DeviceType, cpu
 import thunder.core.codeutils as codeutils
 from thunder.core.codeutils import Printable
 from thunder.core.transform_common import dce, cse_single_bsym, replace_redundant_inputs, NON_FUNCTIONAL_OPS
-from thunder.core.profile import add_markers
+from thunder.core.profile import annotate_for_profile
 from thunder.core.compile_data import get_compile_option
 
 from thunder.core.transforms import (
@@ -448,7 +448,7 @@ class FusionDefinitionWrapper:
 
         # Set device if set in one of the "factory" methods like full, iota, or uniform
         kwargs = {"device": fd._selected_device} if hasattr(fd, "_selected_device") else {}
-        with add_markers(self.name):
+        with annotate_for_profile(self.name):
             return fd.execute(args, **kwargs)
 
     def __repr__(self):

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -405,7 +405,7 @@ def compute_tensor_descriptor(
 def to_descriptors(proxy_args, args) -> tuple:
     def to_descriptor(proxy_arg, arg):
         if isinstance(arg, Tensor):
-            return (*compute_tensor_descriptor(proxy_arg.shape, arg.shape, arg.stride()), arg.dtype)
+            return (*compute_tensor_descriptor(proxy_arg._shape, arg.shape, arg.stride()), arg.dtype)
         elif isinstance(arg, Number):
             return type(arg)
         elif isinstance(arg, tuple):


### PR DESCRIPTION
This PR lowers the CPU overhead of every nvFuser fusion execution in Thunder.

This is done by improving the runtime performance of two things inside `FusionDefinitionWrapper.__call__`:
1. `to_descriptors` performance is improved
2. NVTX annotation uses a different function relying on the `nvtx` package for annotation with less Python overhead

Here's a breakdown of improvements to `to_descriptors` for a microbenchmark calling nvFuser fusion for a different number of Tensor inputs:
1. Original: 83.871 µs
2. Move "if Tensor" to top: 68.574 µs
3. Use Tensor instead of torch.Tensor: 66.805 µs
4. Inline get_tensor_descriptor: 64.152 µs
5. Use TensorProxy._shape instead of .shape: 29.003 µs

`thunder.core.profile.add_markers` is slow (constant ~30 µs overhead) because it uses `torch.profiler.record_function`, a Torch Autograd specific annotation. We're executing nvFuser fusions in a no_grad context so the record_function doesn't do anything useful for us here. `thunder.core.profile.annotate_for_profile` is a better alternative because it simply calls fast `nvtx.annotate`.

Here are graphs before and after this change (we want to see more of the yellow part):
(before)
![image](https://github.com/user-attachments/assets/34180697-6b18-4502-ad52-013d8acd26f2)
"fusion_wrapper_time_other" includes nvtx annotations and some other attribute accesses and writes we do in the `__call__` method.
(after)
![image](https://github.com/user-attachments/assets/66a10576-1201-4767-9def-622bda277323)

And here's a table of speedups for a different number of input Tensors:
| Number of input Tensors | Total time FusionWrapper | to_descriptors | NVTX Annotation + usability attribute writes |
|-------------------------|--------------------------|----------------|-------------------------------------------------------------------|
| 1                       |                    2.86x |          2.08x |                                                             5.91x |
| 2                       |                    2.50x |          2.38x |                                                             4.88x |
| 4                       |                    2.35x |          2.55x |                                                             4.65x |
| 8                       |                    2.23x |          2.67x |                                                             5.04x |
| 16                      |                    1.96x |          2.75x |                                                             4.04x |
| 32                      |                    1.74x |          2.80x |                                                             3.99x |
| 64                      |                    1.61x |          2.83x |                                                             4.00x |

Script to collect the numbers: https://gist.github.com/IvanYashchuk/1276fd7781f18c8003cbc688e8cc64df

cc @tfogal