### PR TITLE
cosmetic change of `codeutils`: dunder all and type hint

### DIFF
--- a/thunder/core/codeutils.py
+++ b/thunder/core/codeutils.py
@@ -15,8 +15,9 @@ import thunder.core.devices as devices
 from thunder.core.pytree import tree_flatten, tree_unflatten
 
 if TYPE_CHECKING:
-    from typing import Any, Optional
+    from typing import Any
     from collections.abc import Callable, Sequence
+    from thunder.core.trace import TraceCtx
 
 
 __all__ = [
@@ -118,7 +119,7 @@ def is_literal(x: Any) -> bool:
     return True
 
 
-def _to_printable(tracectx: Optional, x: Any) -> tuple[Any, tuple[str, Any] | None]:
+def _to_printable(tracectx: TraceCtx | None, x: Any) -> tuple[Any, tuple[str, Any] | None]:
     can_print, module_info = is_printable(x)
     if can_print:
         return x, module_info
@@ -135,7 +136,7 @@ def _to_printable(tracectx: Optional, x: Any) -> tuple[Any, tuple[str, Any] | No
 
 # TODO Improve type annotations
 def to_printable(
-    trace: Optional,
+    trace: TraceCtx | None,
     x: Any,
     *,
     import_ctx: dict | None = None,
@@ -314,8 +315,14 @@ class SigInfo:
     # TODO Print the original signature's type annotations
     # TODO Maybe be clear about what inputs are const and what aren't?
     # TODO Improve this signature's type annotations
-    def prettyprint(self, *, trace: Optional = None, import_ctx: Optional = None, object_ctx=None) -> str:
-        def _arg_printer(name: str, has_default: bool, default: Any = None) -> str:
+    def prettyprint(
+        self,
+        *,
+        trace: TraceCtx | None = None,
+        import_ctx: dict[str, Any] | None = None,
+        object_ctx: dict[str, Any] | None = None,
+    ) -> str:
+        def _arg_printer(name: str, has_default: bool, default: Any | None = None) -> str:
             # NOTE In this case the argument has a default value, like 'a' in foo(a=5)
             if has_default:
                 printable = to_printable(trace, default, import_ctx=import_ctx, object_ctx=object_ctx)

--- a/thunder/core/codeutils.py
+++ b/thunder/core/codeutils.py
@@ -299,7 +299,7 @@ def get_source_line(filename: str, lineno: int) -> str:
 
 # TODO Make this a frozen dataclass?
 class SigInfo:
-    def __init__(self, name, /):
+    def __init__(self, name: str, /):
         self.name = name
         self.args = []
         self.varargs = None

--- a/thunder/core/codeutils.py
+++ b/thunder/core/codeutils.py
@@ -19,7 +19,6 @@ from thunder.core.baseutils import ProxyInterface, check
 import thunder.core.dtypes as dtypes
 import thunder.core.devices as devices
 from thunder.core.pytree import tree_flatten, tree_unflatten
-from thunder.core.baseutils import *
 
 #
 # Functions related to analyzing and printing functions and arguments
@@ -78,7 +77,7 @@ def is_printable(x: Any) -> tuple[bool, None | tuple[str, Any]]:
 
     if isinstance(x, ContextObject):
         return True, None
-    if is_collection(x):
+    if baseutils.is_collection(x):
         # TODO RC1 Fix collection printing by testing if each item is printable and gathering the imports
         #   required (if any)
         flat, _ = tree_flatten(x)
@@ -96,7 +95,7 @@ def is_literal(x: Any) -> bool:
     if isinstance(x, (ContextObject, ProxyInterface)):
         return False
 
-    if is_collection(x):
+    if baseutils.is_collection(x):
         flat, _ = tree_flatten(x)
         for f in flat:
             if is_literal(f):
@@ -139,7 +138,7 @@ def to_printable(
         # Return the instance as printable object (as function `prettyprint` knows how to deal with it).
         return x
 
-    if is_collection(x):
+    if baseutils.is_collection(x):
         # specify namespace="" to avoid flattening dataclasses
         flat, spec = tree_flatten(x, namespace="")
         if flat and flat[0] is x:
@@ -193,7 +192,7 @@ def prettyprint(
 
     m = partial(_qm, quote_markers=_quote_markers)
 
-    if literals_as_underscores and is_literal(x) and not is_collection(x):
+    if literals_as_underscores and is_literal(x) and not baseutils.is_collection(x):
         return m("_")
 
     if type(x) is str:
@@ -232,7 +231,7 @@ def prettyprint(
         call_repr_str = ",".join(call_repr)
         return m(f"{name}({call_repr_str})")
 
-    if is_collection(x):
+    if baseutils.is_collection(x):
         # specify namespace="" to avoid flattening dataclasses
         flat, spec = tree_flatten(x, namespace="")
         printed = tuple(


### PR DESCRIPTION
## What does this PR do?

As per title.
This is on top of #1421 