### PR TITLE
Use the prologue in check_vjp

### DIFF
--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -1648,12 +1648,7 @@ celu_opinfo = OpInfo(
     dtypes=(datatypes.floating,),
     sample_input_generator=celu_sample_generator,
     torch_reference=_elementwise_unary_torch(torch.celu),
-    test_directives=(
-        DecorateInfo(
-            custom_comparator(partial(assert_close, atol=1e-6, rtol=1e-6)),
-            "test_vjp_correctness",
-        ),
-    ),
+    test_directives=(),
 )
 elementwise_unary_ops.append(celu_opinfo)
 

--- a/thunder/tests/test_grad.py
+++ b/thunder/tests/test_grad.py
@@ -296,9 +296,7 @@ def check_vjp(f, *primals, comp, executor="torch", set_compile_data: bool = Fals
 
     u = tree_map(make, primals)
 
-    # dirty little trick for speed: skip the prologue
-    jf = executor.make_callable(f, disable_torch_autograd=True)
-    comp_f = thunder.compile_data(jf).get_computation_and_inputs(*primals)[0].computation_fn
+    comp_f = thunder.jit(f)
 
     outs_p, J_u = numerical_jvp(comp_f)(primals, u)
 

--- a/thunder/tests/test_grad.py
+++ b/thunder/tests/test_grad.py
@@ -304,7 +304,7 @@ def check_vjp(f, *primals, comp, executor="torch", set_compile_data: bool = Fals
 
     v = tree_map(make, outs_p)
     if set_compile_data:
-        with thunder.core.compile_data.compile_data_and_stats(thunder.compile_data(jf), None):
+        with thunder.core.compile_data.compile_data_and_stats(thunder.compile_data(comp_f), None):
             initial_trace_vjp_f = thunder.trace()(vjp(f), primals, v)
     else:
         initial_trace_vjp_f = thunder.trace()(vjp(f), primals, v)


### PR DESCRIPTION
In adding support for the elu op (https://github.com/Lightning-AI/lightning-thunder/pull/1417), it was discovered that 'alpha' parameters are not being included in the calculations of jacobian vector products as the prologue is being skipped in this test.  Here the prologue is added and the celu op, which also suffers from this inaccuracy, is adapted.
