### PR TITLE
Add `nv_enable_options` and `nv_disable_options`

### DIFF
--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -460,7 +460,7 @@ class FusionDefinitionWrapper:
 
         elif self.enable_options or self.disable_options:
             warnings.warn(
-                f"nvFuser _enable_options/_disable_options requires version 0.2.23 and above, using version {nvfuser_version()}. These options will be ignored."
+                f"nv_enable_options/nv_disable_options require nvFuser version 0.2.23 and above, found version {nvfuser_version()}. These options will be ignored."
             )
 
         with annotate_for_profile(self.name):

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -454,6 +454,7 @@ class FusionDefinitionWrapper:
             kwargs["device"] = fd._selected_device
 
         if nvfuser_version() >= LooseVersion("0.2.23"):
+            # nvFuser expects empty list instead of None values.
             kwargs["_enable_options"] = self._enable_options if self._enable_options is not None else []
             kwargs["_disable_options"] = self._disable_options if self._disable_options is not None else []
 

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -437,8 +437,8 @@ class FusionDefinitionWrapper:
     cache_clear: None | Callable = None
     last_used: None | FusionDefinition = None
     last_inputs: None | Sequence[tuple] = None
-    store_inputs: bool = False,
-    _enable_options: None | list[str] = None,
+    store_inputs: bool = (False,)
+    _enable_options: None | list[str] = (None,)
     _disable_options: None | list[str] = None
 
     def __call__(self, *args):
@@ -553,8 +553,12 @@ def create_fusion_definition_wrapper(
     store_inputs: None | bool = get_compile_option(
         "nv_store_fusion_inputs", "Allow nvFuser to store fusion inputs for repro."
     )
-    _enable_options: None | list[str] = get_compile_option("nv_enable_options", "List of NVFUSER_ENABLE options to set.")
-    _disable_options: None | list[str] = get_compile_option("nv_disable_options", "List of NVFUSER_DISABLE options to set.")
+    _enable_options: None | list[str] = get_compile_option(
+        "nv_enable_options", "List of NVFUSER_ENABLE options to set."
+    )
+    _disable_options: None | list[str] = get_compile_option(
+        "nv_disable_options", "List of NVFUSER_DISABLE options to set."
+    )
 
     tensor_indices = []
     for idx, x in enumerate(sorted_unique_inputs):

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -552,10 +552,13 @@ def create_fusion_definition_wrapper(
     _enable_options: None | list = get_compile_option(
         "nv_enable_options", "List of NVFUSER_ENABLE options to set."
     )
+    _enable_options = _enable_options if _enable_options is not None else []
+        
     _disable_options: None | list = get_compile_option(
         "nv_disable_options", "List of NVFUSER_DISABLE options to set."
     )
-
+    _disable_options = _disable_options if _disable_options is not None else []
+    print(_enable_options, _disable_options)
     tensor_indices = []
     for idx, x in enumerate(sorted_unique_inputs):
         if isinstance(x, TensorProxy):

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -459,8 +459,10 @@ class FusionDefinitionWrapper:
             kwargs["_disable_options"] = self.disable_options if self.disable_options is not None else []
 
         elif self.enable_options or self.disable_options:
-            warnings.warn(f"nvFuser _enable_options/_disable_options requires version 0.2.23 and above, using version {nvfuser_version()}. These options will be ignored.")
-            
+            warnings.warn(
+                f"nvFuser _enable_options/_disable_options requires version 0.2.23 and above, using version {nvfuser_version()}. These options will be ignored."
+            )
+
         with annotate_for_profile(self.name):
             return fd.execute(args, **kwargs)
 
@@ -553,9 +555,7 @@ def create_fusion_definition_wrapper(
     store_inputs: None | bool = get_compile_option(
         "nv_store_fusion_inputs", "Allow nvFuser to store fusion inputs for repro."
     )
-    enable_options: None | list[str] = get_compile_option(
-        "nv_enable_options", "List of NVFUSER_ENABLE options to set."
-    )
+    enable_options: None | list[str] = get_compile_option("nv_enable_options", "List of NVFUSER_ENABLE options to set.")
     disable_options: None | list[str] = get_compile_option(
         "nv_disable_options", "List of NVFUSER_DISABLE options to set."
     )

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -438,7 +438,6 @@ class FusionDefinitionWrapper:
     last_used: None | FusionDefinition = None
     last_inputs: None | Sequence[tuple] = None
     store_inputs: bool = False,
-    profile: bool = False,
     _enable_options: list = [],
     _disable_options: list = [],
 

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -437,8 +437,8 @@ class FusionDefinitionWrapper:
     cache_clear: None | Callable = None
     last_used: None | FusionDefinition = None
     last_inputs: None | Sequence[tuple] = None
-    store_inputs: bool = (False,)
-    _enable_options: None | list[str] = (None,)
+    store_inputs: bool = False
+    _enable_options: None | list[str] = None
     _disable_options: None | list[str] = None
 
     def __call__(self, *args):

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -578,8 +578,8 @@ def create_fusion_definition_wrapper(
         get_fd.cache_info,
         get_fd.cache_clear,
         store_inputs=store_inputs,
-        _enable_options=_enable_options if _enable_options is not None else [],
-        _disable_options=_disable_options if _disable_options is not None else [],
+        _enable_options=_enable_options,
+        _disable_options=_disable_options,
     )
     return fdw
 

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -438,8 +438,8 @@ class FusionDefinitionWrapper:
     last_used: None | FusionDefinition = None
     last_inputs: None | Sequence[tuple] = None
     store_inputs: bool = False
-    _enable_options: None | list[str] = None
-    _disable_options: None | list[str] = None
+    enable_options: None | list[str] = None
+    disable_options: None | list[str] = None
 
     def __call__(self, *args):
         fd = self.get_fd(self.to_descriptors(args))
@@ -455,10 +455,10 @@ class FusionDefinitionWrapper:
 
         if nvfuser_version() >= LooseVersion("0.2.23"):
             # nvFuser expects empty list instead of None values.
-            kwargs["_enable_options"] = self._enable_options if self._enable_options is not None else []
-            kwargs["_disable_options"] = self._disable_options if self._disable_options is not None else []
+            kwargs["_enable_options"] = self.enable_options if self.enable_options is not None else []
+            kwargs["_disable_options"] = self.disable_options if self.disable_options is not None else []
 
-        elif self._enable_options or self._disable_options:
+        elif self.enable_options or self.disable_options:
             warnings.warn(f"nvFuser _enable_options/_disable_options requires version 0.2.23 and above, using version {nvfuser_version()}. These options will be ignored.")
             
         with annotate_for_profile(self.name):
@@ -553,10 +553,10 @@ def create_fusion_definition_wrapper(
     store_inputs: None | bool = get_compile_option(
         "nv_store_fusion_inputs", "Allow nvFuser to store fusion inputs for repro."
     )
-    _enable_options: None | list[str] = get_compile_option(
+    enable_options: None | list[str] = get_compile_option(
         "nv_enable_options", "List of NVFUSER_ENABLE options to set."
     )
-    _disable_options: None | list[str] = get_compile_option(
+    disable_options: None | list[str] = get_compile_option(
         "nv_disable_options", "List of NVFUSER_DISABLE options to set."
     )
 
@@ -580,8 +580,8 @@ def create_fusion_definition_wrapper(
         get_fd.cache_info,
         get_fd.cache_clear,
         store_inputs=store_inputs,
-        _enable_options=_enable_options,
-        _disable_options=_disable_options,
+        enable_options=enable_options,
+        disable_options=disable_options,
     )
     return fdw
 

--- a/thunder/tests/test_nvfuser.py
+++ b/thunder/tests/test_nvfuser.py
@@ -1104,11 +1104,11 @@ def test_enable_disable_options(executor, device: str, thunder_dtype: dtypes.dty
     ]
 
     compiled_func = thunder.jit(
-        fn, 
-        executors_list=executor.executors_list(), 
-        nv_enable_matmul=True, 
+        fn,
+        executors_list=executor.executors_list(),
+        nv_enable_matmul=True,
         nv_enable_options=["fuse_matmul"],
-        nv_disable_options=["matmul_expr_eval", "kernel_reuse"]
+        nv_disable_options=["matmul_expr_eval", "kernel_reuse"],
     )
     # The above combination of options enables matmul codegen and disables expr evaluation for matmul.
     # Since matmul scheduler does not support float32 inputs, the execution should raise an error.

--- a/thunder/tests/test_nvfuser.py
+++ b/thunder/tests/test_nvfuser.py
@@ -1113,6 +1113,8 @@ def test_enable_disable_options(executor, device: str, thunder_dtype: dtypes.dty
     # The above combination of options enables matmul codegen and disables expr evaluation for matmul.
     # Since matmul scheduler does not support float32 inputs, the execution should raise an error.
     # By default, without using these options, the given fusion will run through expr eval scheduler correctly.
-
+    # NOTE: This test relies on `float32` being unsupported by nvFuser matmul scheduler.
+    # If this support is added, the test will need to be updated since it will no longer
+    # verify the functionality of the above flags.
     with pytest.raises(RuntimeError, match="Can not find a scheduler to schedule fusion segment"):
         out = compiled_func(*inps)

--- a/thunder/tests/test_nvfuser.py
+++ b/thunder/tests/test_nvfuser.py
@@ -1106,9 +1106,16 @@ def test_enable_disable_options(executor, device: str, dtype: dtypes.dtype):
     ]
 
     compiled_func = thunder.jit(fn, executors_list=executor.executors_list(), nv_enable_matmul=True, nv_disable_options=["matmul_expr_eval", "kernel_reuse"])
-
-    out = compiled_func(*inps)
-    traces = thunder.last_traces(compiled_func)
-    fusions = examine.get_fusions(traces[-1])
-    assert len(fusions) == 1
-    torch.testing.assert_close(out, torch.matmul(*inps))
+    try:
+        out = compiled_func(*inps)
+        raise RuntimeError(
+            'RuntimeError:  INTERNAL ASSERT FAILED at "/opt/pytorch/nvfuser/csrc/fusion_segmenter.cpp":3718, please report a bug with repro script to NVFuser at https://github.com/NVIDIA/Fuser/issues. Can not find a scheduler to schedule fusion segment'
+        )
+    except:
+        pass
+        
+    # out = compiled_func(*inps)
+    # traces = thunder.last_traces(compiled_func)
+    # fusions = examine.get_fusions(traces[-1])
+    # assert len(fusions) == 1
+    # torch.testing.assert_close(out, torch.matmul(*inps))


### PR DESCRIPTION
`nvFuser version >= 0.2.23` will support setting `NVFUSER_ENABLE/NVFUSER_DISABLE` through the python frontend using `_enable_options` and `_disable_options` flags. This is to enable matmul/linear codegen for nvfuser through Thunder using flags `nv_enable_options=["fuse_matmul"], nv_disable_options=["matmul_expr_eval"]`
Issue: https://github.com/NVIDIA/Fuser/issues/3022

nvFuser PR: https://github.com/NVIDIA/Fuser/pull/3270