### PR TITLE
add `from numbers import Number`

### DIFF
--- a/thunder/core/transform_common.py
+++ b/thunder/core/transform_common.py
@@ -17,6 +17,7 @@ from thunder.core.trace import from_trace, TraceProvenance, TraceCtx as Trace, t
 from thunder.core.utils import ProxyDict, producers, check
 
 if TYPE_CHECKING:
+    from numbers import Number
     from typing import Any
     from thunder.core.module import ThunderModule
 


### PR DESCRIPTION
## What does this PR do?

It doesn't seem that `Number` is imported but it is used https://github.com/Lightning-AI/lightning-thunder/blob/8f5026f91a1f85f858aa8ffd042af067961fe623/thunder/core/transform_common.py#L41.
So add an import statement for clarity.