### PR TITLE
Test HF's implementation of Phi 3 model

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -18,7 +18,7 @@ pandas # thunder/benchmarks/test_benchmark_litgpt.py
 xlsxwriter # thunder/benchmarks/test_benchmark_litgpt.py
 jsonargparse # thunder/benchmarks/benchmark_litgpt.py
 bitsandbytes==0.42.0  # fixed version!
-transformers==4.43.3 # for test_networks.py
+transformers==4.46.2 # for test_networks.py
 
 # Installs JAX on Linux and MacOS
 jaxlib; sys_platform == 'linux' or sys_platform == 'darwin'  # required for jax, see https://github.com/google/jax#installation

--- a/thunder/tests/test_networks.py
+++ b/thunder/tests/test_networks.py
@@ -401,13 +401,14 @@ def test_thunderfx_mistral_nemo_small():
 
 
 @thunder.tests.framework.requiresCUDA
-def test_hf_qwen2():
+@pytest.mark.parametrize("model_id", ["Qwen/Qwen2.5-7B-Instruct", "microsoft/Phi-3-mini-128k-instruct"])
+def test_hf_for_nemo(model_id):
     from thunder.dynamo import ThunderCompiler
     from transformers import AutoConfig, AutoModelForCausalLM
 
     # https://huggingface.co/Qwen/Qwen2.5-7B-Instruct/blob/main/config.json
     configuration = AutoConfig.from_pretrained(
-        "Qwen/Qwen2.5-7B-Instruct",
+        model_id,
         # Scaled down for testing
         vocab_size=16,
         pad_token_id=15,
@@ -420,8 +421,12 @@ def test_hf_qwen2():
 
     # thunder.jit doesn't work with Qwen2, so we use torch.compile
     # https://github.com/Lightning-AI/lightning-thunder/issues/1405
+
+    # fullgraph=True used to work with transformers 4.45.2, but it doesn't work
+    # with 4.46.2 because of re.findall usage in the loss function
+    fullgraph = False
     backend = ThunderCompiler()
-    compiled_model = torch.compile(model, backend=backend, fullgraph=True)
+    compiled_model = torch.compile(model, backend=backend, fullgraph=fullgraph)
 
     input_ids = torch.randint(0, configuration.vocab_size, (1, configuration.max_position_embeddings), device="cuda")
     ref_output = model(input_ids=input_ids, labels=input_ids)
@@ -435,7 +440,8 @@ def test_hf_qwen2():
     # https://github.com/Lightning-AI/lightning-thunder/issues/1407
     torch.testing.assert_close(compiled_loss, ref_loss, rtol=1e-4, atol=1e-4)
 
-    assert len(backend.subgraph_infos) == 1, "Should have exactly 1 subgraph because of fullgraph=True"
+    if fullgraph:
+        assert len(backend.subgraph_infos) == 1, "Should have exactly 1 subgraph because of fullgraph=True"
     loss_grad = torch.randn_like(compiled_loss)
 
     grads_ref = torch.autograd.grad(ref_loss, model.parameters(), grad_outputs=loss_grad)

--- a/thunder/tests/test_networks.py
+++ b/thunder/tests/test_networks.py
@@ -403,20 +403,17 @@ def test_thunderfx_mistral_nemo_small():
 @thunder.tests.framework.requiresCUDA
 def test_hf_qwen2():
     from thunder.dynamo import ThunderCompiler
-    from transformers import Qwen2Config, Qwen2ForCausalLM
+    from transformers import AutoConfig, Qwen2ForCausalLM
 
     # https://huggingface.co/Qwen/Qwen2.5-7B-Instruct/blob/main/config.json
-    configuration = Qwen2Config(
-        # Qwen2.5-7B-Instruct uses Grouped-Query Attention, while the default
-        # config uses Multi-Head Attention
-        num_attention_heads=28,
-        num_key_value_heads=4,
+    configuration = AutoConfig.from_pretrained(
+        "Qwen/Qwen2.5-7B-Instruct",
         # Scaled down for testing
         hidden_size=56,
         vocab_size=16,
         max_position_embeddings=32,
+        num_hidden_layers=1,
     )
-    configuration.num_hidden_layers = 1
     with torch.device("cuda"):
         model = Qwen2ForCausalLM(configuration).to(torch.bfloat16)
 

--- a/thunder/tests/test_networks.py
+++ b/thunder/tests/test_networks.py
@@ -406,7 +406,6 @@ def test_hf_for_nemo(model_id):
     from thunder.dynamo import ThunderCompiler
     from transformers import AutoConfig, AutoModelForCausalLM
 
-    # https://huggingface.co/Qwen/Qwen2.5-7B-Instruct/blob/main/config.json
     configuration = AutoConfig.from_pretrained(
         model_id,
         # Scaled down for testing

--- a/thunder/tests/test_networks.py
+++ b/thunder/tests/test_networks.py
@@ -403,7 +403,7 @@ def test_thunderfx_mistral_nemo_small():
 @thunder.tests.framework.requiresCUDA
 def test_hf_qwen2():
     from thunder.dynamo import ThunderCompiler
-    from transformers import AutoConfig, Qwen2ForCausalLM
+    from transformers import AutoConfig, AutoModelForCausalLM
 
     # https://huggingface.co/Qwen/Qwen2.5-7B-Instruct/blob/main/config.json
     configuration = AutoConfig.from_pretrained(
@@ -415,7 +415,7 @@ def test_hf_qwen2():
         num_hidden_layers=1,
     )
     with torch.device("cuda"):
-        model = Qwen2ForCausalLM(configuration).to(torch.bfloat16)
+        model = AutoModelForCausalLM.from_config(configuration).to(torch.bfloat16)
 
     # thunder.jit doesn't work with Qwen2, so we use torch.compile
     # https://github.com/Lightning-AI/lightning-thunder/issues/1405

--- a/thunder/tests/test_networks.py
+++ b/thunder/tests/test_networks.py
@@ -409,11 +409,12 @@ def test_hf_qwen2():
     configuration = AutoConfig.from_pretrained(
         "Qwen/Qwen2.5-7B-Instruct",
         # Scaled down for testing
-        hidden_size=56,
         vocab_size=16,
+        pad_token_id=15,
         max_position_embeddings=32,
         num_hidden_layers=1,
     )
+    configuration.hidden_size = configuration.num_attention_heads
     with torch.device("cuda"):
         model = AutoModelForCausalLM.from_config(configuration).to(torch.bfloat16)
 


### PR DESCRIPTION
This PR adds a test to verify that the computed cross-entropy loss matches between HF's implementation and application of Thunder on this model.

Ref. https://github.com/Lightning-AI/lightning-thunder/issues/1278.