### PR TITLE
add extensible DebugOptions class

### DIFF
--- a/docs/source/reference/thunder.rst
+++ b/docs/source/reference/thunder.rst
@@ -21,6 +21,7 @@ Querying information on compiled functions and modules
 .. autosummary::
     :toctree: generated/
 
+    DebugOptions
     compile_data
     compile_stats
     last_traces

--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -16,6 +16,7 @@ from thunder.core.interpreter import InterpreterLogItem
 from thunder.core.options import (
     CACHE_OPTIONS,
     SHARP_EDGES_OPTIONS,
+    DebugOptions,
 )
 from thunder.core.trace import (
     TraceResults,
@@ -124,6 +125,7 @@ __all__ = [
     "nvfuser_executor",
     "pytorch_executor",
     # debugging functions
+    "DebugOptions",
     "set_execution_callback_file",
     "jit",
     "resolve_executors",
@@ -275,7 +277,6 @@ def compile(fn: Callable, recipe: Recipe | None):
 
 
 # This function will replace compile() (below) before RC1
-# TODO RC1 Consider adding a debug_log parameter to control debug printing
 # TODO RC1 Consider renaming compile_options to additional_compile_options
 def jit(
     fn: Callable,
@@ -287,7 +288,7 @@ def jit(
     cache: None | CACHE_OPTIONS | str = None,
     disable_torch_autograd: bool = False,  # TODO Revisit this UX for RC1
     transforms: list[Transform] | None = None,
-    record_history: bool = False,
+    debug_options: DebugOptions | None = None,
     **compile_options,  # TODO RC1 Make this explicit -- dict of options
 ) -> Callable:
     """Just-in-time compile a callable (function or model).
@@ -313,7 +314,9 @@ def jit(
                - ``"constant values"`` - require Tensors to be of the same shape, device, dtype etc., and integers and strings to match exactly,
                - ``"same input"`` - don't check, but just assume that a cached function works if it exists.
 
-        transforms: List of transforms to be applied. It should be an instance :class:`thunder.core.transforms.Transform`. Default: ``None``
+        transforms: optional list of transforms to be applied. It should be a list of instances of :class:`thunder.core.transforms.Transform`. Default: ``None``
+
+        debug_options: optional :class:`thunder.DebugOptions` instance. See the doc string of :class:`DebugOptions` for supported debug options. Default: ``None``
     """
 
     if "executors_list" in compile_options:
@@ -345,8 +348,6 @@ def jit(
         # TODO: sharp edge if lookasides are shadowed?
         executor_lookasides.update(ex._lookasides)
 
-    assert type(record_history) is bool
-
     # TODO RC1 Refine the compile data option to remove unused options
     # TODO: refine options
     cd = CompileData(
@@ -361,6 +362,7 @@ def jit(
         disable_preprocessing=True,
         compile_options=compile_options,
         executor_lookasides=executor_lookasides,
+        debug_options=debug_options,
     )
     cs = CompileStats()
 
@@ -524,7 +526,6 @@ def jit(
                 args,
                 kwargs,
                 ad_hoc_executor=ad_hoc_executor,
-                record_history=record_history,
                 sharp_edges=cd.sharp_edges,
             )
             prologue_trc = jit_results.prologue_trace

--- a/thunder/common.py
+++ b/thunder/common.py
@@ -12,6 +12,7 @@ from thunder.core.options import (
     resolve_cache_option,
     SHARP_EDGES_OPTIONS,
     resolve_sharp_edges_option,
+    DebugOptions,
 )
 from thunder.core.utils import check, is_collection, AutocastStack
 from thunder.core.pytree import tree_flatten, tree_map
@@ -202,6 +203,7 @@ class CompileData:
         compile_options: dict[str, Any] = {},
         get_computation_and_inputs: Callable | None = None,
         executor_lookasides: dict[Callable, Callable] | None = None,
+        debug_options: DebugOptions | None = None,
     ):
         # Records whether we're using the thunder.jit() entrypoint or not
         #   The thunder.jit() entrypoint introduces important architectural updates,
@@ -257,6 +259,7 @@ class CompileData:
         self.disable_preprocessing = disable_preprocessing
         self.disable_torch_autograd_support = disable_torch_autograd_support
         self.debug_log = debug_log
+        self.debug_options = DebugOptions() if debug_options is None else debug_options
 
         # TODO Consider validating that this dict has exclusively string keys
         self.compile_options = compile_options

--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -101,7 +101,7 @@ from thunder.core.baseutils import extract_callable_name
 from thunder.core.codeutils import get_siginfo, SigInfo
 import thunder.core.prims as prims
 from thunder.common import transform_for_execution
-from thunder.core.options import CACHE_OPTIONS, SHARP_EDGES_OPTIONS
+from thunder.core.options import CACHE_OPTIONS, SHARP_EDGES_OPTIONS, DebugOptions
 from thunder.core.symbol import Symbol, BoundSymbol, is_traceable
 
 from thunder.extend import Executor
@@ -1685,13 +1685,17 @@ def update_tags(proxy_swapmap: dict[Variable, Proxy]) -> None:
         new.tags.update(unvariableify(old).tags)
 
 
+DebugOptions.register_option(
+    "record_interpreter_history", bool, False, "record interpreter history (use thunder.last_interpreter_log to access)"
+)
+
+
 def thunder_general_jit(
     fn: Callable,
     args: tuple[Any, ...],
     kwargs: dict[str, Any],
     /,
     *,
-    record_history: bool = False,
     sharp_edges: SHARP_EDGES_OPTIONS,
     ad_hoc_executor,
 ) -> TraceResults:
@@ -1732,7 +1736,7 @@ def thunder_general_jit(
         callbacks=general_jit_callbacks,
         with_provenance_tracking=True,
         uncacheable_classes=(torch.Tensor, int, float, str, NoneType),
-        record_history=record_history,
+        record_history=compile_data.debug_options.record_interpreter_history,
     )
 
     with jit_ctx(ctx):

--- a/thunder/tests/test_core.py
+++ b/thunder/tests/test_core.py
@@ -3021,3 +3021,30 @@ def test_saved_view_of_output_of_autograd_function_does_not_leak():
 
     for ref in prev_iter_refs:
         assert ref() is None
+
+
+def test_debug_options():
+    from thunder import DebugOptions
+    import dill
+
+    initial_state = dill.dumps(dict(DebugOptions.__dict__))
+    print(DebugOptions.__dict__)
+    DebugOptions.register_option("test_option", bool, False, "Test Option")
+
+    assert "Test Option" in DebugOptions.__doc__
+
+    do = DebugOptions(test_option=True)
+    assert do.test_option is True
+
+    with pytest.raises(TypeError, match="test_option"):
+        do = DebugOptions(test_option=5)
+
+    del DebugOptions._docs["test_option"]
+    del DebugOptions._defaults["test_option"]
+    del DebugOptions.__annotations__["test_option"]
+    del DebugOptions.test_option
+
+    DebugOptions._set_docstring()
+
+    print(DebugOptions.__dict__)
+    assert dill.dumps(dict(DebugOptions.__dict__)) == initial_state


### PR DESCRIPTION
This intends to make debug options more discoverable:

- dynamic registration,
- automatic docstring support,
- also included in documentation.

