### PR TITLE
Make exceptions from user code more readable

### DIFF
--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -825,7 +825,9 @@ def jit(
             def internal_to_thunder(co):
                 if co is thunder_general_jit.__code__ or co is _thunder_unwrap_inner_exception.__code__:
                     return True
-                return co.co_filename.endswith("thunder" + os.sep + "core" + os.sep + "interpreter.py") and (co.co_name in ("fn_", "fn_2"))
+                return co.co_filename.endswith("thunder" + os.sep + "core" + os.sep + "interpreter.py") and (
+                    co.co_name in ("fn_", "fn_2")
+                )
 
             # Iterate over the traceback and collect frames that don't correspond to thunder internal functions.
             tb = exc.__traceback__

--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -829,8 +829,10 @@ def jit(
                 co = tb.tb_frame.f_code
                 co_fname = co.co_filename
                 co_name = co.co_name
-                if ((co is _thunder_unwrap_inner_exception.__code__ or co is thunder_general_jit.__code__) or
-                    (co_fname.endswith("thunder" + os.sep + "core" + os.sep + "interpreter.py") and (co_name in ("fn_", "fn_2")))):
+                if (co is _thunder_unwrap_inner_exception.__code__ or co is thunder_general_jit.__code__) or (
+                    co_fname.endswith("thunder" + os.sep + "core" + os.sep + "interpreter.py")
+                    and (co_name in ("fn_", "fn_2"))
+                ):
                     pass
                 else:
                     tb_frames.append(tb)
@@ -850,7 +852,7 @@ def jit(
             except Exception as e:
                 del exc
                 del e
-                raise # re-raises current exception
+                raise  # re-raises current exception
 
         return _thunder_unwrap_inner_exception
 

--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -849,9 +849,8 @@ def jit(
             # Re-raise the exception without retaining it in this stack frame to avoid leaking tensors.
             try:
                 raise exc
-            except Exception as e:
+            except Exception:
                 del exc
-                del e
                 raise  # re-raises current exception
 
         return _thunder_unwrap_inner_exception

--- a/thunder/tests/test_interpreter.py
+++ b/thunder/tests/test_interpreter.py
@@ -864,13 +864,7 @@ def test_backtrace_filter():
 
     jfn = thunder.jit(fn1)
 
-    expected_frame_names = [
-        "test_backtrace_filter",
-        "_thunder_unwrap_inner_exception",
-        "fn1",
-        "fn2",
-        "fn3"
-    ]
+    expected_frame_names = ["test_backtrace_filter", "_thunder_unwrap_inner_exception", "fn1", "fn2", "fn3"]
 
     try:
         jfn()
@@ -883,7 +877,7 @@ def test_backtrace_filter():
         frame_names = [tb.tb_frame.f_code.co_name for tb in tb_frames]
         assert frame_names == expected_frame_names
     except BaseException as e:
-        assert False, e # Wrong exception type.
+        assert False, e  # Wrong exception type.
 
 
 def test_walrus_operator(jit):


### PR DESCRIPTION
Code:
```py
import thunder

def f1():
    raise ValueError

def f2():
    f1()

def f3():
    f2()

jfn = thunder.jit(f3)

jfn()
```

After:
```
⚡ ap-readable_exceptions ~/lightning-thunder python ti.py                       
Traceback (most recent call last):
  File "/teamspace/studios/this_studio/lightning-thunder/ti.py", line 14, in <module>
    jfn()
  File "/teamspace/studios/this_studio/lightning-thunder/thunder/__init__.py", line 849, in _thunder_unwrap_inner_exception
    raise exc
  File "/teamspace/studios/this_studio/lightning-thunder/ti.py", line 10, in f3
    f2()
  File "/teamspace/studios/this_studio/lightning-thunder/ti.py", line 7, in f2
    f1()
  File "/teamspace/studios/this_studio/lightning-thunder/ti.py", line 4, in f1
    raise ValueError
ValueError
```

Before:
```
⚡ main ~/lightning-thunder python ti.py
Traceback (most recent call last):
  File "/teamspace/studios/this_studio/lightning-thunder/ti.py", line 14, in <module>
    jfn()
  File "/teamspace/studios/this_studio/lightning-thunder/thunder/__init__.py", line 774, in wrapped
    return fn(*args, **kwargs)
  File "/teamspace/studios/this_studio/lightning-thunder/thunder/__init__.py", line 824, in fn_
    cache_entry, inps, pro_to_epi = get_computation_and_inputs(*args, **kwargs)
  File "/teamspace/studios/this_studio/lightning-thunder/thunder/__init__.py", line 756, in wrapped
    cache_entry, inps, pro_to_epi = get_computation_and_inputs_fn(*args, **kwargs)
  File "/teamspace/studios/this_studio/lightning-thunder/thunder/core/langctxs.py", line 136, in _fn
    result = fn(*args, **kwargs)
  File "/teamspace/studios/this_studio/lightning-thunder/thunder/__init__.py", line 236, in cache_info_wrapper
    res = fn(*args, **kwargs)
  File "/teamspace/studios/this_studio/lightning-thunder/thunder/__init__.py", line 529, in get_computation_and_inputs
    jit_results: TraceResults = thunder_general_jit(
  File "/teamspace/studios/this_studio/lightning-thunder/thunder/core/jit_ext.py", line 1744, in thunder_general_jit
    result = jfn(*args, **kwargs)
  File "/teamspace/studios/this_studio/lightning-thunder/thunder/core/interpreter.py", line 7231, in fn_
    raise e
  File "/teamspace/studios/this_studio/lightning-thunder/thunder/core/interpreter.py", line 7191, in fn_2
    return fn(*args, **kwargs)
  File "/teamspace/studios/this_studio/lightning-thunder/ti.py", line 10, in f3
    f2()
  File "/teamspace/studios/this_studio/lightning-thunder/ti.py", line 7, in f2
    f1()
  File "/teamspace/studios/this_studio/lightning-thunder/ti.py", line 4, in f1
    raise ValueError
ValueError
```
