### PR TITLE
dce all-const returning symbols in subsymbols

### DIFF
--- a/thunder/core/transform_common.py
+++ b/thunder/core/transform_common.py
@@ -54,7 +54,11 @@ def _remove_noop_subsymbols(bsym: BoundSymbol) -> None:
     for sbsym in bsym.subsymbols:
         if len(sbsym.subsymbols) == 0 and not sbsym.sym.is_prim:
             continue
-
+        # if all outputs are constants, we elmininate the subsymbol
+        if not has_tags(bsym, {prims.OpTags.DONT_DCE}) and not any(
+            o is not None for o in sbsym.flat_proxy_outs
+        ):  # is not None to avoid cast to bool
+            continue
         _remove_noop_subsymbols(sbsym)
         nsbsyms.append(sbsym)
 

--- a/thunder/tests/test_networks.py
+++ b/thunder/tests/test_networks.py
@@ -528,6 +528,6 @@ def test_hf_llama():
     expected2 = model(past_key_values=res["past_key_values"], **args2)
     assert_close(res2, expected2, rtol=1e-1, atol=1e-1)
 
-    top_level_symbol_names = set([bsym.sym.name for bsym in thunder.last_traces(jm)[-1].bound_symbols])
+    top_level_symbol_names = {bsym.sym.name for bsym in thunder.last_traces(jm)[-1].bound_symbols}
     # changes this to fewer as needed, the goal is to not have too many fusions
     assert len([s for s in top_level_symbol_names if s.startswith("nvFusion")]) == 7

--- a/thunder/tests/test_networks.py
+++ b/thunder/tests/test_networks.py
@@ -527,3 +527,7 @@ def test_hf_llama():
     res2 = jm(past_key_values=res["past_key_values"], **args2)
     expected2 = model(past_key_values=res["past_key_values"], **args2)
     assert_close(res2, expected2, rtol=1e-1, atol=1e-1)
+
+    top_level_symbol_names = set([bsym.sym.name for bsym in thunder.last_traces(jm)[-1].bound_symbols])
+    # changes this to fewer as needed, the goal is to not have too many fusions
+    assert len([s for s in top_level_symbol_names if s.startswith("nvFusion")]) == 7


### PR DESCRIPTION
This gets us from 10 to 7 nvFusion groups in a 1-layer llama 3.2 1b.