### PR TITLE
Fix tensor parallel distributed tests by requesting PyTorch not to destroy PG upon exit

### DIFF
--- a/thunder/tests/distributed/helper.py
+++ b/thunder/tests/distributed/helper.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 from functools import partial
 from functools import wraps
 from typing import ClassVar, TYPE_CHECKING
-import inspect
 import math
 import os
 import sys
@@ -130,14 +129,10 @@ class DistributedParallelTestCase(common_distributed.MultiProcessTestCase):
         local_rank = self.rank % torch.cuda.device_count()
         torch.cuda.set_device(local_rank)
         os.environ["LOCAL_RANK"] = str(local_rank)
-        if "destroy_process_group" in inspect.signature(self.run_test).parameters:
-            run_test_kwargs = {"destroy_process_group": False}
-        else:
-            run_test_kwargs = {}
 
         torch.distributed.barrier()
         try:
-            self.run_test(test_name, pipe, **run_test_kwargs)
+            self.run_test(test_name, pipe)
         except Exception:
             raise
         finally:

--- a/thunder/tests/distributed/helper.py
+++ b/thunder/tests/distributed/helper.py
@@ -111,6 +111,11 @@ class DistributedParallelTestCase(common_distributed.MultiProcessTestCase):
     def init_method(self):
         return f"{common_utils.FILE_SCHEMA}{self.file_name}"
 
+    @property
+    def destroy_pg_upon_exit(self) -> bool:
+        # Overriding base test class: do not auto destroy PG upon exit.
+        return False
+
     @classmethod
     def _run(cls, rank, test_name, file_name, pipe, *, fake_pg=False):
         assert not fake_pg, "Not yet supported here..."


### PR DESCRIPTION
Before this PR tensor parallel tests were failing. Example
```
pytest thunder/tests/distributed/test_tensor_parallel.py::TensorParallelTest::test_embedding_name_column

ValueError: Default process group has not been initialized, please make sure to call init_process_group.
Process process 1:
Traceback (most recent call last):
  File "/usr/lib/python3.12/multiprocessing/process.py", line 314, in _bootstrap
    self.run()
  File "/usr/lib/python3.12/multiprocessing/process.py", line 108, in run
    self._target(*self._args, **self._kwargs)
  File "/opt/pytorch/lightning-thunder/thunder/tests/distributed/helper.py", line 144, in _run
    torch.distributed.barrier()
  File "/usr/local/lib/python3.12/dist-packages/torch/distributed/c10d_logger.py", line 81, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/distributed/distributed_c10d.py", line 4462, in barrier
    opts.device = torch.device(_get_object_coll_device(group))
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/distributed/distributed_c10d.py", line 774, in _get_object_coll_device
    group = group or _get_default_group()
                     ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/distributed/distributed_c10d.py", line 1276, in _get_default_group
    raise ValueError(
ValueError: Default process group has not been initialized, please make sure to call init_process_group.
```

And now it works.

cc @borda @crcrpar