### PR TITLE
versioning scheme for nightlies with dev

### DIFF
--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -452,7 +452,7 @@ def test_where_nonzero_overload(executor, device: str, dtype: dtypes.dtype):
             reason="Skip until the Torch bug is fixed - https://github.com/pytorch/pytorch/pull/139275",
         ),
         pytest.mark.skipif(
-            version_between(torch.__version__, min_ver="2.6.0a0", max_ver="2.6.0a99"),
+            version_between(torch.__version__, min_ver="2.6.0dev0", max_ver="2.6.0a99"),
             reason="https://github.com/Lightning-AI/lightning-thunder/issues/1471",
         ),
     ),

--- a/thunder/tests/test_grad.py
+++ b/thunder/tests/test_grad.py
@@ -1472,7 +1472,7 @@ def test_populate_grads_mlp(executor, device, dtype):
 
 @instantiate(dtypes=(thunder.float32,))
 def test_populate_grads_csa(executor, device, dtype):
-    if version_between(torch.__version__, min_ver="2.6.0a0", max_ver="2.6.0"):
+    if version_between(torch.__version__, min_ver="2.6.0dev0", max_ver="2.6.0"):
         pytest.skip("https://github.com/Lightning-AI/lightning-thunder/issues/1254")
 
     from thunder.benchmarks import NanoGPTCSABenchmark, NanoGPTConfig
@@ -1502,7 +1502,7 @@ def test_populate_grads_csa(executor, device, dtype):
 
 @instantiate(dtypes=(thunder.float32,))
 def test_populate_grads_block(executor, device, dtype):
-    if version_between(torch.__version__, min_ver="2.6.0a0", max_ver="2.6.0"):
+    if version_between(torch.__version__, min_ver="2.6.0dev0", max_ver="2.6.0"):
         pytest.skip("https://github.com/Lightning-AI/lightning-thunder/issues/1254")
 
     from thunder.benchmarks import NanoGPTBlockBenchmark, NanoGPTConfig

--- a/thunder/tests/test_networks.py
+++ b/thunder/tests/test_networks.py
@@ -225,7 +225,7 @@ def test_nanogpt_mlp(executor, device, dtype):
     executors=all_test_executors_and_dynamo,
     decorators=(
         pytest.mark.skipif(
-            version_between(torch.__version__, min_ver="2.6.0a0", max_ver="2.6.0a99"),
+            version_between(torch.__version__, min_ver="2.6.0dev0", max_ver="2.6.0a99"),
             reason="https://github.com/Lightning-AI/lightning-thunder/issues/1471",
         ),
     ),
@@ -285,7 +285,7 @@ def test_hf_bert():
 
 
 @pytest.mark.skipif(
-    version_between(torch.__version__, min_ver="2.6.0a0", max_ver="2.6.0a99"),
+    version_between(torch.__version__, min_ver="2.6.0dev0", max_ver="2.6.0a99"),
     reason="https://github.com/bitsandbytes-foundation/bitsandbytes/pull/1413",
 )
 @requiresCUDA
@@ -369,7 +369,7 @@ def test_quantization():
 
 
 @pytest.mark.skipif(
-    version_between(torch.__version__, min_ver="2.6.0a0", max_ver="2.6.0a99"),
+    version_between(torch.__version__, min_ver="2.6.0dev0", max_ver="2.6.0a99"),
     reason="https://github.com/Lightning-AI/lightning-thunder/issues/1471",
 )
 @thunder.tests.framework.requiresCUDA
@@ -424,7 +424,7 @@ def test_thunderfx_mistral_nemo_small():
 
 
 @pytest.mark.skipif(
-    version_between(torch.__version__, min_ver="2.6.0a0", max_ver="2.6.0a99"),
+    version_between(torch.__version__, min_ver="2.6.0dev0", max_ver="2.6.0a99"),
     reason="https://github.com/Lightning-AI/lightning-thunder/issues/1471",
 )
 @thunder.tests.framework.requiresCUDA

--- a/thunder/tests/test_recipes.py
+++ b/thunder/tests/test_recipes.py
@@ -25,7 +25,7 @@ def test_recipe_basic_bert():
 
 
 @pytest.mark.skipif(
-    version_between(torch.__version__, min_ver="2.6.0a0", max_ver="2.6.0a99"),
+    version_between(torch.__version__, min_ver="2.6.0dev0", max_ver="2.6.0a99"),
     reason="https://github.com/Lightning-AI/lightning-thunder/issues/1471",
 )
 def test_recipe_basic_bert_dynamo():

--- a/thunder/tests/test_transforms.py
+++ b/thunder/tests/test_transforms.py
@@ -113,7 +113,7 @@ def test_materialization():
 
 
 @pytest.mark.skipif(
-    version_between(torch.__version__, min_ver="2.6.0a0", max_ver="2.6.0a99"),
+    version_between(torch.__version__, min_ver="2.6.0dev0", max_ver="2.6.0a99"),
     reason="https://github.com/bitsandbytes-foundation/bitsandbytes/pull/1413",
 )
 @pytest.mark.skipif(not package_available("bitsandbytes"), reason="`bitsandbytes` is not available")
@@ -190,7 +190,7 @@ def test_quantization_on_meta():
 
 
 @pytest.mark.skipif(
-    version_between(torch.__version__, min_ver="2.6.0a0", max_ver="2.6.0a99"),
+    version_between(torch.__version__, min_ver="2.6.0dev0", max_ver="2.6.0a99"),
     reason="https://github.com/bitsandbytes-foundation/bitsandbytes/pull/1413",
 )
 @pytest.mark.skipif(
@@ -301,7 +301,7 @@ def test_cudagraph_warmup_runs_with_correct_buffers():
 
 
 @pytest.mark.skipif(
-    version_between(torch.__version__, min_ver="2.6.0a0", max_ver="2.6.0a99"),
+    version_between(torch.__version__, min_ver="2.6.0dev0", max_ver="2.6.0a99"),
     reason="https://github.com/bitsandbytes-foundation/bitsandbytes/pull/1413",
 )
 @pytest.mark.skipif(not package_available("bitsandbytes"), reason="`bitsandbytes` is not available")


### PR DESCRIPTION
PyTorch 2.6 uses devYYYYMMDD not the old a0...