### PR TITLE
remove redundant `if backward_trc is None`

### DIFF
--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -678,8 +678,6 @@ def jit(
                 )
                 computation_traces.extend(extraces)
                 computation_trc = computation_traces[-1]
-
-            if backward_trc is None:
                 computation_trc = thunder.executors.passes.del_last_used(computation_trc)
 
             if not compile_options.get("disable_inplace_copy_check", False):


### PR DESCRIPTION
## What does this PR do?

As per title, `if backward_trc is None` check does not look necessary.