### PR TITLE
[lookaside][torch.autograd.Function lookaside] use `shallow_copy` iff forward is empty

### DIFF
--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -636,9 +636,12 @@ def _convert_pytorchfunc_to_thundertrace(
         return wrapped_func_result, None
 
     trace = TraceCtx()
-    trace.bound_symbols.extend(active_jit_ctx.computation_trace.pop_scope())
+    bsyms = active_jit_ctx.computation_trace.pop_scope()
+    trace.bound_symbols.extend(bsyms)
     func_result = unwrap(wrapped_func_result)
-    if shallow_copy_output:
+    if shallow_copy_output and not bsyms:
+        from thunder.core.baseutils import sequencify
+
         out_to_shallow_copy: dict[Variable, TensorProxy] = {}
         for a in sequencify(func_result):
             shallow_copy_of_a = prims.shallow_copy.meta(a)


### PR DESCRIPTION
## What does this PR do?

As per #1221 description, we don't strongly need `shallow_copy` if a trace representing a custom `torch.autograd.Function.forward` has multiple bsyms.