### PR TITLE
refactor hardshrink_opinfo with singularity_fn_producer

### DIFF
--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -341,6 +341,7 @@ class OpInfo:
         test_directives=(),
         domain=(None, None),
         singularity_fn=None,
+        singularity_fn_producer=None,
         test_torch_compile_executor=False,
     ):
         self.op = op
@@ -376,6 +377,11 @@ class OpInfo:
         self.test_directives = test_directives
         self.domain = Domain(*domain)
         self.singularity_fn = singularity_fn
+        # singularity_fn_producers are expected to produce a singularity_fn based on a given SampleInput.
+        # This can be useful in cases when the definition of the op function invovles kwargs of the input.
+        self.singularity_fn_producer = (
+            (lambda _: singularity_fn) if singularity_fn_producer is None else singularity_fn_producer
+        )
         self.test_torch_compile_executor = test_torch_compile_executor
 
     def __call__(self, *args, **kwargs):
@@ -1727,35 +1733,21 @@ relu6_opinfo = OpInfo(
 elementwise_unary_ops.append(relu6_opinfo)
 
 
-# For positive lambd, hardshrink's singularities occur at lambd and -lambd, the locations of jump discontinuties
-# of its partial derivatives.  Since lambd is passed as an input kwarg, the singularity_fn depends upon the input
-# sample.  Therefore, mutliple opinfos with varying sample generator and singularity_fn pairs are added.
-def get_hardshrink_singularity_fn(lambd):
-    if lambd is None:
-        lambd = 0.5
+# fdm.jvp, which is used in test_vjp_correctness, behaves badly at jump discontinuties of the partial derviatives
+def hardshrink_singularity_fn_producer(sample: SampleInput):
+    lambd = 0.5 if "lambd" not in sample.kwargs else sample.kwargs["lambd"]
     return lambda a: torch.where(a >= 0, a - lambd, a + lambd)
 
 
-def hardshrink_opinfo_factory(lambds):
-    for lambd in lambds:
-        kwargs = {} if lambd is None else {"lambd": lambd}
-        name = "hardshrink_" + str(lambd)
-        singularity_fn = get_hardshrink_singularity_fn(lambd)
-
-        hardshrink_opinfo = OpInfo(
-            ltorch.hardshrink,
-            name=name,
-            dtypes=(datatypes.floating,),
-            sample_input_generator=get_elementwise_unary_with_kwargs_generator([kwargs]),
-            torch_reference=_elementwise_unary_torch(torch.nn.functional.hardshrink),
-            # fdm.jvp, which is used in test_vjp_correctness, behaves badly at jump discontinuties of the partial derviatives
-            singularity_fn=singularity_fn,
-            test_directives=(),
-        )
-        elementwise_unary_ops.append(hardshrink_opinfo)
-
-
-hardshrink_opinfo_factory([None, 0.25, -0.1])
+hardshrink_opinfo = OpInfo(
+    ltorch.hardshrink,
+    dtypes=(datatypes.floating,),
+    sample_input_generator=get_elementwise_unary_with_kwargs_generator([{}, {"lambd": 0.25}, {"lambd": -0.1}]),
+    torch_reference=_elementwise_unary_torch(torch.nn.functional.hardshrink),
+    singularity_fn_producer=hardshrink_singularity_fn_producer,
+    test_directives=(),
+)
+elementwise_unary_ops.append(hardshrink_opinfo)
 
 
 hardswish_opinfo = OpInfo(

--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -1735,7 +1735,7 @@ elementwise_unary_ops.append(relu6_opinfo)
 
 # fdm.jvp, which is used in test_vjp_correctness, behaves badly at jump discontinuties of the partial derviatives
 def hardshrink_singularity_fn_producer(sample: SampleInput):
-    lambd = 0.5 if "lambd" not in sample.kwargs else sample.kwargs["lambd"]
+    lambd = sample.kwargs.get("lambd", 0.5)
     return lambda a: torch.where(a >= 0, a - lambd, a + lambd)
 
 

--- a/thunder/tests/test_grad.py
+++ b/thunder/tests/test_grad.py
@@ -408,8 +408,8 @@ def test_vjp_correctness(op, device, dtype, executor, comp):
         filtered_op, filtered_args = _make_differentiable_wrapper(flat_op, flat_args)
         if len(filtered_args) == 0:
             continue
-        if op.singularity_fn is not None:
-            filtered_args = [push_away_from_singularities(arg, op.singularity_fn, eps) for arg in filtered_args]
+        if (singularity_fn := op.singularity_fn_producer(sample)) is not None:
+            filtered_args = [push_away_from_singularities(arg, singularity_fn, eps) for arg in filtered_args]
         at_least_one_differentiable_input = True
         result = run_snippet(
             snippet_vjp_correctness,
@@ -1406,7 +1406,7 @@ def test_phantom_grad_vs_torch_consistency(op, device: str, dtype: dtypes.dtype,
             op.torch_reference,
             sample,
             lambda a, b, **kwargs: comp(a, b, equal_nan=True, **kwargs),
-            op.singularity_fn,
+            op.singularity_fn_producer(sample),
         )
 
         # See [NOTE] dynamo reset

--- a/thunder/tests/test_nvfuser.py
+++ b/thunder/tests/test_nvfuser.py
@@ -36,7 +36,6 @@ from thunder.tests.framework import (
 from thunder.tests.make_tensor import make_tensor, make_tensor_like
 from thunder.tests.opinfos import (
     opinfos,
-    push_away_from_singularities,
     tensor_creation_ops,
     get_opinfo,
     linear_opinfo,


### PR DESCRIPTION
Many linear activation functions of torch.nn.functional have partial derivatives with jump discontinuities at dynamically defined values, eg, hardshrink has a kwarg `lambd` which sets the relevant discontinuities at +/-lambd.  The test `test_vjp_correctness` relies on using the technique of computing finite differences to approximate these partial derivatives to validate Thunder's computation of the partials.  These finite differences behave badly around these discontinuities.  Currently, each `OpInfo` allows the supplement of a `singularity_fn` to push test input values away from the discontinuities, but it only allows for a single `singularity_fn`, which cannot reflect the dynamic variation of the "bad" points.  This PR introduces a `singularity_fn_producer`, which is a function mapping a `SampleInput` to a `singularity_fn`, allowing the `singularity_fn` to reflect the kwargs of the `SampleInput`.
