### PR TITLE
spelling out `higher_order.autograd_function_apply`'s fwd and bwd in trace.

### DIFF
--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -850,7 +850,9 @@ def _general_jit_torch_ops_higher_order_autograd_function_apply(fwd, bwd, *fwd_a
 
     forward_op = get_jit_ctx().ad_hoc_executor.register_operator(trace_of_forward._siginfo.name, like=forward)
     unwrapped_output = forward_op(*unwrapped_fwd_args)
-    output = wrap(unwrapped_output, provenance=ProvenanceRecord(PseudoInst.LOOKASIDE, inputs=[fwd.provenance, aug_fwd_provenance]))
+    output = wrap(
+        unwrapped_output, provenance=ProvenanceRecord(PseudoInst.LOOKASIDE, inputs=[fwd.provenance, aug_fwd_provenance])
+    )
     get_jit_ctx().ad_hoc_executor.register_implementation(
         forward_op,
         execution_transform=forward,

--- a/thunder/tests/test_jit_general.py
+++ b/thunder/tests/test_jit_general.py
@@ -1232,13 +1232,6 @@ def test_autograd_function_apply():
     y_ref = my_sin(x_ref)
     torch.testing.assert_close(y, y_ref)
 
-    initial_computation_trace = thunder.last_traces(jitted)[0]
-    assert any(
-        bsym.sym.id == "torch.ops.higher_order.autograd_function_apply"
-        for bsym in initial_computation_trace.bound_symbols
-        if isinstance(bsym.sym.id, str)
-    )
-
     grad = torch.rand_like(y)
     actual_grad = torch.autograd.grad(y, x, grad)
     expect_grad = torch.autograd.grad(y_ref, x_ref, grad)

--- a/thunder/tests/test_jit_general.py
+++ b/thunder/tests/test_jit_general.py
@@ -1233,9 +1233,6 @@ def test_autograd_function_apply():
     torch.testing.assert_close(y, y_ref)
 
     initial_computation_trace = thunder.last_traces(jitted)[0]
-    bsym_str_ids = tuple(
-        bsym.sym.id for bsym in initial_computation_trace.bound_symbols if isinstance(bsym.sym.id, str)
-    )
     assert any(
         bsym.sym.id == "torch.ops.higher_order.autograd_function_apply"
         for bsym in initial_computation_trace.bound_symbols

--- a/thunder/tests/test_jit_general.py
+++ b/thunder/tests/test_jit_general.py
@@ -1236,7 +1236,11 @@ def test_autograd_function_apply():
     bsym_str_ids = tuple(
         bsym.sym.id for bsym in initial_computation_trace.bound_symbols if isinstance(bsym.sym.id, str)
     )
-    assert any(bsid.startswith("autograd_function_apply") for bsid in bsym_str_ids), bsym_str_ids
+    assert any(
+        bsym.sym.id == "torch.ops.higher_order.autograd_function_apply"
+        for bsym in initial_computation_trace.bound_symbols
+        if isinstance(bsym.sym.id, str)
+    )
 
     grad = torch.rand_like(y)
     actual_grad = torch.autograd.grad(y, x, grad)

--- a/thunder/tests/test_jit_general.py
+++ b/thunder/tests/test_jit_general.py
@@ -1204,13 +1204,16 @@ def test_custom_autograd_function():
 
 
 def test_autograd_function_apply():
+
+    # see https://github.com/Lightning-AI/lightning-thunder/issues/1248#issuecomment-2388655917
+    # for why `torch.foo` instead of `torch.Tensor.foo`
     def forward(ctx, x):
         saved_for_backward = (x,)
-        return x.sin(), saved_for_backward
+        return torch.sin(x), saved_for_backward
 
     def backward(ctx, grad_output, *saved_tensors):
         (x,) = saved_tensors
-        return grad_output * x.cos()
+        return grad_output * torch.cos(x)
 
     def my_sin(x):
         return torch.ops.higher_order.autograd_function_apply(
@@ -1230,11 +1233,10 @@ def test_autograd_function_apply():
     torch.testing.assert_close(y, y_ref)
 
     initial_computation_trace = thunder.last_traces(jitted)[0]
-    assert any(
-        bsym.sym.id == "torch.ops.higher_order.autograd_function_apply"
-        for bsym in initial_computation_trace.bound_symbols
-        if isinstance(bsym.sym.id, str)
+    bsym_str_ids = tuple(
+        bsym.sym.id for bsym in initial_computation_trace.bound_symbols if isinstance(bsym.sym.id, str)
     )
+    assert any(bsid.startswith("autograd_function_apply") for bsid in bsym_str_ids), bsym_str_ids
 
     grad = torch.rand_like(y)
     actual_grad = torch.autograd.grad(y, x, grad)

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -5637,6 +5637,46 @@ else:
         utils.check(False, lambda: "torch.distributed is not available")
 
 
+# ref: https://github.com/pytorch/pytorch/blob/b99ef1a/torch/_functorch/autograd_function.py#L715-L752
+@torchsymbol(
+    torch.ops.higher_order.autograd_function_apply,
+    id="torch.ops.higher_order.autograd_function_apply",
+    is_method=False,
+)
+def autograd_function_apply(
+    fwd: Callable[list[TensorProxy], TensorProxy | tuple[TensorProxy, ...]],
+    bwd: Callable[list[TensorProxy], TensorProxy | tuple[TensorProxy, ...]],
+    *args: Any,
+    args_tensor_mask: Sequence[bool] | None,
+    non_differentiable_idx: Sequence[int] | None = None,
+) -> TensorProxy | tuple[TensorProxy, ...]:
+    result, saved_for_backward = fwd(None, *args)
+    return result
+
+
+@register_augmented_forward("torch.ops.higher_order.autograd_function_apply")
+def augmented_forward_autograd_function_apply(
+    fwd: Callable[list[Any | TensorProxy], TensorProxy | tuple[TensorProxy, ...]],
+    bwd: Callable[list[Any | TensorProxy], tuple[TensorProxy, ...]],
+    *args: Any,
+    args_tensor_mask: Sequence[bool],
+    non_differentiable_idx: Sequence[int] | None = None,
+) -> tuple[TensorProxy | tuple[TensorProxy, ...], tuple[Any, ...]]:
+    result, saved_for_backward = fwd(None, *args)
+    return result, (saved_for_backward, bwd, args_tensor_mask, non_differentiable_idx)
+
+
+@register_backward("torch.ops.higher_order.autograd_function_apply")
+def backward_autograd_function_apply(
+    saved_for_backward: tuple[Any, ...],
+    bwd: Callable[list[Any | TensorProxy], tuple[TensorProxy, ...]],
+    args_tensor_mask: Sequence[bool],
+    non_differentiable_idx: Sequence[int] | None = None,
+    *grad_output: Sequence[TensorProxy],
+) -> tuple[Any, ...]:
+    return bwd(None, *grad_output, *saved_for_backward)
+
+
 @torchsymbol(
     torch.amp.autocast_mode._enter_autocast,
     id="torch.amp.autocast_mode._enter_autocast",

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -5637,46 +5637,6 @@ else:
         utils.check(False, lambda: "torch.distributed is not available")
 
 
-# ref: https://github.com/pytorch/pytorch/blob/b99ef1a/torch/_functorch/autograd_function.py#L715-L752
-@torchsymbol(
-    torch.ops.higher_order.autograd_function_apply,
-    id="torch.ops.higher_order.autograd_function_apply",
-    is_method=False,
-)
-def autograd_function_apply(
-    fwd: Callable[list[TensorProxy], TensorProxy | tuple[TensorProxy, ...]],
-    bwd: Callable[list[TensorProxy], TensorProxy | tuple[TensorProxy, ...]],
-    *args: Any,
-    args_tensor_mask: Sequence[bool] | None,
-    non_differentiable_idx: Sequence[int] | None = None,
-) -> TensorProxy | tuple[TensorProxy, ...]:
-    result, saved_for_backward = fwd(None, *args)
-    return result
-
-
-@register_augmented_forward("torch.ops.higher_order.autograd_function_apply")
-def augmented_forward_autograd_function_apply(
-    fwd: Callable[list[Any | TensorProxy], TensorProxy | tuple[TensorProxy, ...]],
-    bwd: Callable[list[Any | TensorProxy], tuple[TensorProxy, ...]],
-    *args: Any,
-    args_tensor_mask: Sequence[bool],
-    non_differentiable_idx: Sequence[int] | None = None,
-) -> tuple[TensorProxy | tuple[TensorProxy, ...], tuple[Any, ...]]:
-    result, saved_for_backward = fwd(None, *args)
-    return result, (saved_for_backward, bwd, args_tensor_mask, non_differentiable_idx)
-
-
-@register_backward("torch.ops.higher_order.autograd_function_apply")
-def backward_autograd_function_apply(
-    saved_for_backward: tuple[Any, ...],
-    bwd: Callable[list[Any | TensorProxy], tuple[TensorProxy, ...]],
-    args_tensor_mask: Sequence[bool],
-    non_differentiable_idx: Sequence[int] | None = None,
-    *grad_output: Sequence[TensorProxy],
-) -> tuple[Any, ...]:
-    return bwd(None, *grad_output, *saved_for_backward)
-
-
 @torchsymbol(
     torch.amp.autocast_mode._enter_autocast,
     id="torch.amp.autocast_mode._enter_autocast",


### PR DESCRIPTION
## What does this PR do?

Alternative of #1256.
Instead of keeping the signature of `torch.ops.higher_order.autograd_function_apply(fwd, bwd, *fwd_args, **fwd_kwargs)` in a trace by introducing function objects, this PR traces the both fwd and bwd and writes the body of fwd into a trace like the lookaside for `torch.autograd.Function`.