### PR TITLE
[litgpt benchmark] enable `force_recompute_fp8_weight_in_bwd` when `torchao.float8` is used with FSDP2

### DIFF
--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -170,6 +170,7 @@ class TorchAOFP8Handler:
             cast_config_grad_output=CastConfig(ScalingType.DYNAMIC),
             enable_fsdp_float8_all_gather=self.use_fp8_allgather and self.is_fsdp2,
             enable_pre_and_post_forward=False,
+            force_recompute_fp8_weight_in_bwd=self.is_fsdp2,
         )
         self.precompute_scale = (
             self.is_fsdp2 and self.use_fp8_allgather and self.use_torchao_fp8_precompute_float8_dynamic_scale_for_fsdp


### PR DESCRIPTION
## What does this PR do?

As per title.

ref: https://github.com/pytorch/ao/commit/e9195580013eab3195f982598d63ce27ad8bdc93

With 8 H100s and pjnl-20241209.
Used command is: `torchrun --nproc-per-node 8 --local-ranks-filter 0 --role rank --tee 3 thunder/benchmarks/benchmark_litgpt.py --model_name <MODEL_NAME> --compile inductor --distributed_mode fsdp2 --shard_mode zero2 --use_torchao_fp8_linear true --use_torchao_fp8_allgather true --use_torchao_fp8_precompute_scale_for_fsdp true`

### Llama-2-7b-hf.

| branch | perf (tokens/s/gpu) | mem usage (GB) |
|--------|------|-----|
| main   | 13947.29 | 34.26 |
| this PR | 13995.80 | 27.69 | 

### Llama-3-8B

| branch | perf (tokens/s/gpu) | mem usage (GB) |
|--------|------|-----|
| main   | 12404.18 | 58.65 |
| this PR | 12414.15 | 51.67 |

cc @crcrpar