### PR TITLE
more general setattribute

### DIFF
--- a/thunder/core/codeutils.py
+++ b/thunder/core/codeutils.py
@@ -79,8 +79,13 @@ def _generate_dataclass_class_name(x: object):
     # x is an instance of a Dataclass.
     # We generate a name for the Dataclass based on the package name and class name so that trace won't have problem
     # if there are conflicting names.
+
     assert dataclasses.is_dataclass(x)
-    name = (x.__class__.__module__ + "_" + x.__class__.__qualname__).replace(".", "_")
+    if isinstance(x, type):
+        cls = x
+    else:
+        cls = x.__class__
+    name = (cls.__module__ + "_" + cls.__qualname__).replace(".", "_")
     # Class could be a local class in which case it will have `<locals>` in it's module name.
     name = name.replace(">", "_").replace("<", "_")
     return name
@@ -149,7 +154,11 @@ def to_printable(
 
     if dataclasses.is_dataclass(x):
         # Add `class` to the object_ctx so that we can reuse it during the trace execution.
-        object_ctx[_generate_dataclass_class_name(x)] = x.__class__
+        if isinstance(x, type):  # dataclass type
+            cls = x
+        else:  # dataclass type instance
+            cls = x.__class__
+        object_ctx[_generate_dataclass_class_name(x)] = cls
         # Return the instance as printable object (as function `prettyprint` knows how to deal with it).
         return x
 

--- a/thunder/core/interpreter.py
+++ b/thunder/core/interpreter.py
@@ -932,7 +932,9 @@ class PseudoInst(str, enum.Enum):
     SUPER = "SUPER"
     BUILTINS = "BUILTINS"
     STORE_SUBSCR = "STORE_SUBSCR"
+    STORE_ATTR = "STORE_ATTR"
     LIST_TO_TUPLE = "LIST_TO_TUPLE"
+    NEW = "NEW"
 
 
 @dataclasses.dataclass
@@ -2073,9 +2075,13 @@ def _functools_reduce_lookaside(
     return _interpret_call(impl, fn, iterable, initializer, null)
 
 
+class ThunderInterpreterObject:
+    pass
+
+
 # An iterator to be returned from Sequence.__iter__ lookasides below. This will be run in the interpreter
 # Note: this potentially might imitate a list_iterator / tuple_iterator more...
-class SequenceIter:
+class SequenceIter(ThunderInterpreterObject):
     def __init__(self, s, is_reversed=False):
         self.s = s
         self.next_pos = 0 if not is_reversed else len(s) - 1
@@ -2377,7 +2383,7 @@ class MutSequenceWrapperMethods(SequenceWrapperMethods):
         return wrap_const(None)
 
 
-class MappingKeysIterator(Iterator):
+class MappingKeysIterator(Iterator, ThunderInterpreterObject):
     # note: the __init__ will be executed by Python itself, and
     #       the caller needs to set up the wrapped_attribute for _mapping
     # The other methods are called through the interpreter mechanism.
@@ -2395,7 +2401,7 @@ class MappingKeysIterator(Iterator):
         return k
 
 
-class MappingKeysView:
+class MappingKeysView(ThunderInterpreterObject):
     def __init__(self, mapping):
         self._mapping = mapping
 
@@ -2425,7 +2431,7 @@ class MappingKeysView:
         return mapping_iter
 
 
-class MappingValuesIterator:
+class MappingValuesIterator(ThunderInterpreterObject):
     def __init__(self, mapping, is_reversed=False):
         self._mapping = mapping
         if is_reversed:
@@ -2440,7 +2446,7 @@ class MappingValuesIterator:
         return dict.__getitem__(self._mapping, next(self._key_iter))
 
 
-class MappingValuesWrapper:
+class MappingValuesWrapper(ThunderInterpreterObject):
     def __init__(self, mapping):
         self._mapping = mapping
 
@@ -2448,7 +2454,7 @@ class MappingValuesWrapper:
         return MappingValuesIterator(self._mapping)
 
 
-class MappingItemsIterator:
+class MappingItemsIterator(ThunderInterpreterObject):
     def __init__(self, mapping, is_reversed=False):
         self._mapping = mapping
         if is_reversed:
@@ -2464,7 +2470,7 @@ class MappingItemsIterator:
         return k, dict.__getitem__(self._mapping, k)
 
 
-class MappingItemsWrapper:
+class MappingItemsWrapper(ThunderInterpreterObject):
     def __init__(self, mapping):
         self._mapping = mapping
 
@@ -2476,7 +2482,7 @@ class MutMappingWrapperMethods(WrappedValue):
     def __new__(cls, /, *args, **kwds):
         uvalue = unwrap(cls)()
         # todo: for subclasses, better record the call to the constructor
-        return wrap_const(uvalue)
+        return wrap(uvalue, provenance=ProvenanceRecord(PseudoInst.NEW, inputs=[cls.provenance]))
 
     def __init__(self, *other, **kwds):
         MutMappingWrapperMethods.update(self, *other, **kwds)
@@ -2775,7 +2781,6 @@ def _type_call_lookaside(wrapped_typ, *args, **kwargs):
     obj = _interpret_call(typ.__new__, wrapped_typ, *args, **kwargs)
     if obj is INTERPRETER_SIGNALS.EXCEPTION_RAISED:
         return obj
-
     wrapped_init = _interpret_call(getattr, obj, wrap_const("__init__"))
     assert not isinstance(wrapped_init, INTERPRETER_SIGNALS)
     populate_attribute_wrapper(wrapped_init, "__self__", obj)
@@ -7151,6 +7156,7 @@ def interpret(
     callbacks: dict[INTERPRETER_CALLBACKS, Callable] = default_callbacks,
     debug_log: None | StringIO = None,
     with_provenance_tracking: bool = False,
+    unwrap_result: bool = True,
     uncacheable_classes: list[type] | None = None,
     record_history: bool = False,
 ) -> Callable:
@@ -7205,7 +7211,8 @@ def interpret(
                     populate_attribute_wrapper(wrapped_cell, "cell_contents", fn_wrapped)
 
                 interpretation_result: Any = _interpret_call(wrapped_fn_2, args, kwargs)
-                interpretation_result = unwrap(interpretation_result)
+                if unwrap_result:
+                    interpretation_result = unwrap(interpretation_result)
 
             except BaseException as e:
                 # TODO Highlight the portion of the line that originated the opcode on Python versions that include

--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -1837,13 +1837,12 @@ def process_recorded_modifications(ctx, epilogue_trace):
                 if inst == PseudoInst.STORE_SUBSCR:
                     (value,) = args
 
-                    assert isinstance(value.value, (Proxy, int, tuple))  ## todo: better criterion
-
                     if (
                         modified_object.provenance.inst is PseudoInst.LOAD_ATTR
                         and modified_object.provenance.inputs[1].inst is PseudoInst.CONSTANT
                         and modified_object.provenance.inputs[1].value == "_buffers"
                     ):
+                        assert isinstance(value.value, (Proxy, int, tuple, NoneType))  ## todo: better criterion
                         typ, name, root_module_provenance = get_parameter_or_buffer_or_submodule_name_and_root(
                             modified_object.provenance.inputs[0]
                         )
@@ -1867,6 +1866,7 @@ def process_recorded_modifications(ctx, epilogue_trace):
                         name = k
                         setattr_obj_provenance = modified_object.provenance.inputs[0]
                         if hasattr(setattr_obj_provenance, "proxy"):
+                            assert isinstance(value.value, (Proxy, int, tuple, NoneType))  ## todo: better criterion
                             setattr_obj_proxy = setattr_obj_provenance.proxy
                             with tracectx(epilogue_trace):
                                 bsym = prims.pack_attr.bind(setattr_obj_proxy, name, value.value, output=None)

--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -553,7 +553,7 @@ def _raw_object_setattr(obj: Any, name: str, value: Any):
 @register_general_jit_lookaside(object.__setattr__)
 def _general_jit_object_setattr_lookaside(obj: Any, name: str, value: Any):
     uobj = unwrap(obj)
-    if is_created_during_tracing(obj.provenance) or type(uobj) in _TORCH_DYNAMIC_TYPES:
+    if is_created_during_tracing(obj.provenance) or type(uobj) in _TORCH_DYNAMIC_TYPES or not hasattr(uobj, "__dict__"):
         return _raw_object_setattr(obj, name, value)
 
     if should_register_for_prologue(obj.provenance) and (obj.original_value is obj.nothing):

--- a/thunder/core/pytree.py
+++ b/thunder/core/pytree.py
@@ -87,6 +87,8 @@ _registered_dataclasses = set()
 def register_pytree_node_dataclass(cls):
     # We don't use `dataclasses.asdict` as it recursively flattens all data classes (including
     # thunder internal ones like `VJPDual` (and also it is relatively slower as it calls copy.deepcopy()).
+    assert cls is not type
+
     def unpack(cls) -> dict:
         return {field.name: getattr(cls, field.name) for field in dataclasses.fields(cls)}
 
@@ -97,7 +99,7 @@ def register_pytree_node_dataclass(cls):
 
 
 def _maybe_register_dataclass(t):
-    if dataclasses.is_dataclass(t) and t.__class__ not in _registered_dataclasses:
+    if dataclasses.is_dataclass(t) and not isinstance(t, type) and t.__class__ not in _registered_dataclasses:
         return True
     return False
 

--- a/thunder/tests/test_networks.py
+++ b/thunder/tests/test_networks.py
@@ -510,7 +510,6 @@ LLAMA_3_2_1B_CFG = {
 @requiresCUDA
 def test_hf_llama():
     from transformers.models.llama import LlamaForCausalLM, LlamaConfig
-    from transformers import DynamicCache
     from transformers.models.llama.modeling_llama import logger as llama_logger
     import logging
 
@@ -582,3 +581,50 @@ def test_memory_litgpt_llama3():
     mem_eager = forward_backward_peak(m, inp)
 
     assert mem_thunder < mem_eager
+
+
+@requiresCUDA
+def test_hf_kvcache():
+    from transformers.models.llama import LlamaForCausalLM, LlamaConfig
+    from transformers.models.llama.modeling_llama import logger as llama_logger
+    import logging
+
+    # transformers logs a cache deprecation warning
+    llama_logger.setLevel(logging.CRITICAL)
+
+    config_args = LLAMA_3_2_1B_CFG.copy()
+    config_args["num_hidden_layers"] = 1
+    with torch.device("cuda"):
+        model = LlamaForCausalLM(LlamaConfig(**config_args)).to(torch.bfloat16).requires_grad_(False).eval()
+        model2 = LlamaForCausalLM(LlamaConfig(**config_args)).to(torch.bfloat16).requires_grad_(False).eval()
+        model2.load_state_dict(model.state_dict())
+
+    jm = thunder.jit(model)
+
+    j_static_cache = model._get_cache("static", 1, 128, "cuda", config_args)
+    ref_static_cache = model2._get_cache("static", 1, 128, "cuda", config_args)
+
+    args1 = dict(
+        cache_position=torch.tensor([0, 1, 2, 3, 4, 5], device="cuda:0"),
+        input_ids=torch.tensor([[128000, 791, 1401, 311, 2324, 374]], device="cuda:0"),
+        inputs_embeds=None,
+        attention_mask=torch.tensor([[1, 1, 1, 1, 1, 1]], device="cuda:0"),
+        use_cache=True,
+    )
+
+    args1["past_key_values"] = j_static_cache
+    res = jm(**args1)
+    args1["past_key_values"] = ref_static_cache
+    expected = model2(**args1)
+
+    assert res.past_key_values is j_static_cache
+    assert expected.past_key_values is ref_static_cache
+
+    # we cannot compare the StaticCache instances in assert_close
+    res["past_key_values"] = None
+    expected["past_key_values"] = None
+
+    assert_close(res, expected, rtol=1e-1, atol=1e-1)
+
+    assert_close(j_static_cache.key_cache, ref_static_cache.key_cache, rtol=1e-1, atol=1e-1)
+    assert_close(j_static_cache.value_cache, ref_static_cache.value_cache, rtol=1e-1, atol=1e-1)


### PR DESCRIPTION
Consult the wrappers in order to build return value. This gives us a more general setattribute, e.g. for HF static KVCache.

In pseudocode
```
# best implemented after Polenta e Osei and Coffee

def setattr_lookaside(obj, name, attr):
    if obj is an input:
        make an anyproxy that gives obj a name
        record proxy in provenance
        # but don't replace the obj with the proxy
   do previous setattr (including recording modifications as needed)

# get build an object from a wrapped value
def build_from_wrap_value(obj):
   # this is a sibling of pretty print in the sense that it considers types
   if we have a proxy (from setattr above or otherwise):
        return existing proxy
   if it is an object of a complex datatype (currently: dataclass):
        return prims.python_dataclass_new(cls, **{k: build_from_wrapped_value(obj.attribute_wrappers[k]) for k in obj.attributes})
   if it is an object of a "printable" type:
        return unwrapped obj
   if printable collection:  # dict, list, tuple, OrderedDict, ...
        return collection(build_from_wrap_value(wrapped item) for wrapped item in wrapped collection members)
   raise NotImplementedError

def run_jit(fn, *args, **kwargs):
    ....
    interpreted_fn = interpreter.interpret(fn, .unwrap_result=False)
    wrapped_result = interpeted_fn(*args, **kwargs)
    ...
    with tracectx(epilogue_trc):
          prims.python_recturn(build_from_wrapped_value(wrapped_result)) 
    ...
```

So for example for the "existing" HF Static Cache, we have the following epilogue, note how the static cache (provided as an input) is inserted into the model output rather than trying to construct a new one (which was what it tried to do before).

```python
import torch
from thunder.executors.torchex import no_autocast

@torch.no_grad()
@no_autocast
def epilogue(p0, logits):
  # p0: "<class 'transformers.cache_utils.StaticCache'>"
  # logits: "cuda:0 bf16[1, 6, 128256]"
  p1 = transformers_modeling_outputs_CausalLMOutputWithPast(loss=None, logits=logits, past_key_values=p0, hidden_states=None, attentions=None)
  return p1
```
