### PR TITLE
check if `self.sym` is ad hoc before querying the existence of `self.sym.module`

### DIFF
--- a/thunder/core/symbol.py
+++ b/thunder/core/symbol.py
@@ -619,18 +619,22 @@ class BoundSymbol(BoundSymbolInterface):
             # NOTE If the call ctx was specified directly, then no import is needed to call the function
             import_ctx = {}
         else:
+            from thunder.extend import AdHocExecutor
             # BoundSymbols of Symbols without Python implementations (either because they
             #   have Python implementations or defined call ctxs) are assumed to need
             #   a module import to run properly
-            assert self.sym.module is not None  # TODO: Is this a valid assumption?
-            module_name = self.sym.module.__name__
-            import_ctx = {module_name: self.sym.module}
+            if isinstance(self.sym.executor, AdHocExecutor):
+                import_ctx = {}
+            else:
+                assert self.sym.module is not None  # TODO: Is this a valid assumption?
+                module_name = self.sym.module.__name__
+                import_ctx = {module_name: self.sym.module}
 
-            # TODO Include the other modules on the path?
-            # Also includes the root module of this (potential) submodule
-            if "." in module_name:
-                root_name = module_name.split(".")[0]
-                import_ctx[root_name] = sys.modules[root_name]
+                # TODO Include the other modules on the path?
+                # Also includes the root module of this (potential) submodule
+                if "." in module_name:
+                    root_name = module_name.split(".")[0]
+                    import_ctx[root_name] = sys.modules[root_name]
 
         self._import_ctx.update(import_ctx)
         return self._import_ctx

--- a/thunder/core/symbol.py
+++ b/thunder/core/symbol.py
@@ -620,6 +620,7 @@ class BoundSymbol(BoundSymbolInterface):
             import_ctx = {}
         else:
             from thunder.extend import AdHocExecutor
+
             # BoundSymbols of Symbols without Python implementations (either because they
             #   have Python implementations or defined call ctxs) are assumed to need
             #   a module import to run properly


### PR DESCRIPTION
## What does this PR do?

Fixes #1543.