### PR TITLE
ThunderFX: handles the callable input of fx.Node

### DIFF
--- a/thunder/dynamo/splitter.py
+++ b/thunder/dynamo/splitter.py
@@ -135,6 +135,7 @@ def _splitter(
         return partition_cnt
 
     # `split_module` iterates over nodes and determines the partition to place them based on the callback.
+    gm.graph.eliminate_dead_code()
     original_split_gm: torch.fx.GraphModule = split_module(
         gm, root_m=None, split_callback=callback, keep_original_order=True, keep_original_node_name=True
     )


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes #1539.

As the analysis in https://github.com/Lightning-AI/lightning-thunder/issues/1539#issuecomment-2536046742, this PR try to fix it by adding a dead code elimination and processing the get_attr node

