### PR TITLE
make comment of `_inplace_to_out_of_place` verbose

### DIFF
--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -91,7 +91,8 @@ _torch_to_thunder_function_map: dict[Callable, Callable] = {}
 # torch operation definitions
 #
 
-# in-place sym -> out-of-place (= functional) sym with index of `inplace` argument
+# in-place sym -> out-of-place (= functional) sym with index of `inplace: bool` argument
+# If an in-place op doesn't have `inplace: bool` argument, set -1.
 _inplace_to_out_of_place: dict[Callable, tuple[Callable, int]] = {}
 
 


### PR DESCRIPTION
## What does this PR do?

I added a small bit of explanation to the comment following the confusion I noticed in https://github.com/Lightning-AI/lightning-thunder/pull/1520#discussion_r1883912089