### PR TITLE
Enable grad tests for torch 2.6

### DIFF
--- a/thunder/tests/test_grad.py
+++ b/thunder/tests/test_grad.py
@@ -1493,9 +1493,6 @@ def test_populate_grads_mlp(executor, device, dtype):
 
 @instantiate(dtypes=(thunder.float32,))
 def test_populate_grads_csa(executor, device, dtype):
-    if version_between(torch.__version__, min_ver="2.6.0dev0", max_ver="2.6.0"):
-        pytest.skip("https://github.com/Lightning-AI/lightning-thunder/issues/1254")
-
     from thunder.benchmarks import NanoGPTCSABenchmark, NanoGPTConfig
 
     # NOTE Currently setting dropout to zero for reproducibility, other settings taken from gpt2 config
@@ -1523,9 +1520,6 @@ def test_populate_grads_csa(executor, device, dtype):
 
 @instantiate(dtypes=(thunder.float32,))
 def test_populate_grads_block(executor, device, dtype):
-    if version_between(torch.__version__, min_ver="2.6.0dev0", max_ver="2.6.0"):
-        pytest.skip("https://github.com/Lightning-AI/lightning-thunder/issues/1254")
-
     from thunder.benchmarks import NanoGPTBlockBenchmark, NanoGPTConfig
 
     # NOTE Currently setting dropout to zero for reproducibility, other settings taken from gpt2 config


### PR DESCRIPTION
## What does this PR do?

This reverts commit 67d8df6aa90258375decb2f2c9f67e77d3e52e79 to enable the skipped tests.  

Fixes: #1254 (has been fixed on torch side).

(creating PR to see how it behaves in CI with latest nightly torch)