### PR TITLE
remove redundant square brackets from type hint

### DIFF
--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -349,7 +349,7 @@ def compute_symbolic_shape(
 
 def compute_contiguity(
     shape: torch.Size | Sequence[int], stride: Sequence[int]
-) -> tuple[[tuple[bool, ...], tuple[int, ...]]]:
+) -> tuple[tuple[bool, ...], tuple[int, ...]]:
     """
     Computes the contiguity and stride_order of a tensor using nvFuser's notion.
 


### PR DESCRIPTION
## What does this PR do?

As per title. One pair of square brackets doesn't look necessary.