### PR TITLE
[nvfuser] don't allow shape only nvfuser region

### DIFF
--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -3585,7 +3585,7 @@ def stride_order_meta(a: TensorProxy, /, order: Sequence[int]) -> TensorProxy:
 # TODO Consider a more general stride manipulation primitive, like PyTorch's
 #   as_strided or set_strided operations
 # See clang.stride_order for this prim's documentation
-stride_order = make_prim(PrimIDs.STRIDE_ORDER, "stride_order", meta=stride_order_meta)
+stride_order = make_prim(PrimIDs.STRIDE_ORDER, "stride_order", meta=stride_order_meta, tags=(OpTags.SHAPE_OP,))
 
 #
 # Reduction prims

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -470,6 +470,18 @@ class FusionDefinitionWrapper:
         return f"FusionDefinitionWrapper({self.name})"
 
 
+def all_tagged(bsym: BoundSymbol, tag: prims.OpTags) -> bool:
+    """:obj:`True` if `bsym` and its subsymbols all are tagged with ``tag``."""
+    if not has_tags(bsym, {tag}):
+        return False
+
+    for sbsym in bsym.subsymbols:
+        if not has_tags(sbsym, {tag}):
+            return False
+
+    return True
+
+
 # Group bookend meta operations into separate regions
 # This function returns a List[Region] which changes the executor of meta regions to torchex
 #
@@ -506,20 +518,10 @@ def group_bookend_meta_ops(producers, consumers, region: Region) -> Mapping[str,
                     return False
         return True
 
-    def all_tagged(bsym: BoundSymbol, tags: set[prims.OpTags]) -> bool:
-        if not has_tags(bsym, tags):
-            return False
-
-        for sbsym in bsym.subsymbols:
-            if not has_tags(sbsym, tags):
-                return False
-
-        return True
-
     # traversing all bound_symbols in topo order
     for bsym in region.bound_symbols:
         # we look at meta operations that can be moved to the front
-        if all_tagged(bsym, {prims.OpTags.SHAPE_OP}) and can_move_to_front(bsym):
+        if all_tagged(bsym, prims.OpTags.SHAPE_OP) and can_move_to_front(bsym):
             # when we remove a node, we add all the bsym's flat_outs to region_inputs
             front_meta_cluster.append(bsym)
             for out in bsym.flat_outs:
@@ -530,7 +532,7 @@ def group_bookend_meta_ops(producers, consumers, region: Region) -> Mapping[str,
             middle_cluster.append(bsym)
     # traversing all bound_symbols in reverse topo order
     for bsym in reversed(copy(middle_cluster)):
-        if all_tagged(bsym, {prims.OpTags.SHAPE_OP}) and can_move_to_rear(bsym):
+        if all_tagged(bsym, prims.OpTags.SHAPE_OP) and can_move_to_rear(bsym):
             middle_cluster.remove(bsym)
             rear_meta_cluster.insert(0, bsym)
 
@@ -880,20 +882,18 @@ instantiated) this heuristic actually leads to worse code.
             else:
                 bookend_result = {"front_bsyms": [], "fusion": region, "rear_bsyms": []}
 
-            def all_tagged(bsym: BoundSymbol, tags: set[prims.OpTags]) -> bool:
-                if not has_tags(bsym, tags):
-                    return False
+            enable_shape_only_fusions: None | bool = get_compile_option(
+                "nv_enable_shape_only_fusion", "Allow nvFuser to create fusion regions with only shape operations."
+            )
+            if enable_shape_only_fusions is None:
+                # By default, don't create shape only nvFuser regions.
+                enable_shape_only_fusions = False
 
-                for sbsym in bsym.subsymbols:
-                    if not has_tags(sbsym, tags):
-                        return False
-
-                return True
-
-            all_shape_ops = all(map(lambda bsym: all_tagged(bsym, {prims.OpTags.SHAPE_OP}), bsyms))
-            if all_shape_ops:
-                fused_bsyms.extend(bsyms)
-                continue
+            if not enable_shape_only_fusions:  # i.e. shape only fusion are disabled
+                all_shape_ops = all(map(lambda bsym: all_tagged(bsym, prims.OpTags.SHAPE_OP), bsyms))
+                if all_shape_ops:
+                    fused_bsyms.extend(bsyms)
+                    continue
 
             if len(bsyms) == 1:
                 bsym: BoundSymbol = bsyms[0]

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -880,6 +880,21 @@ instantiated) this heuristic actually leads to worse code.
             else:
                 bookend_result = {"front_bsyms": [], "fusion": region, "rear_bsyms": []}
 
+            def all_tagged(bsym: BoundSymbol, tags: set[prims.OpTags]) -> bool:
+                if not has_tags(bsym, tags):
+                    return False
+
+                for sbsym in bsym.subsymbols:
+                    if not has_tags(sbsym, tags):
+                        return False
+
+                return True
+
+            all_shape_ops = all(map(lambda bsym: all_tagged(bsym, {prims.OpTags.SHAPE_OP}), bsyms))
+            if all_shape_ops:
+                fused_bsyms.extend(bsyms)
+                continue
+
             if len(bsyms) == 1:
                 bsym: BoundSymbol = bsyms[0]
                 can_fuse: bool = self.can_fuse(bsym)

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -882,18 +882,11 @@ instantiated) this heuristic actually leads to worse code.
             else:
                 bookend_result = {"front_bsyms": [], "fusion": region, "rear_bsyms": []}
 
-            enable_shape_only_fusions: None | bool = get_compile_option(
-                "nv_enable_shape_only_fusion", "Allow nvFuser to create fusion regions with only shape operations."
-            )
-            if enable_shape_only_fusions is None:
-                # By default, don't create shape only nvFuser regions.
-                enable_shape_only_fusions = False
-
-            if not enable_shape_only_fusions:  # i.e. shape only fusion are disabled
-                all_shape_ops = all(map(lambda bsym: all_tagged(bsym, prims.OpTags.SHAPE_OP), bsyms))
-                if all_shape_ops:
-                    fused_bsyms.extend(bsyms)
-                    continue
+            # Don't fuse a region which has only Shape Operations.
+            all_shape_ops = all(map(lambda bsym: all_tagged(bsym, prims.OpTags.SHAPE_OP), bsyms))
+            if all_shape_ops:
+                fused_bsyms.extend(bsyms)
+                continue
 
             if len(bsyms) == 1:
                 bsym: BoundSymbol = bsyms[0]

--- a/thunder/tests/test_networks.py
+++ b/thunder/tests/test_networks.py
@@ -520,7 +520,6 @@ def test_hf_llama():
 
     # transformers logs a cache deprecation warning
     llama_logger.setLevel(logging.CRITICAL)
-    model_id = "meta-llama/Llama-3.2-1B"
 
     config_args = LLAMA_3_2_1B_CFG.copy()
     config_args["num_hidden_layers"] = 1
@@ -557,4 +556,4 @@ def test_hf_llama():
 
     top_level_symbol_names = {bsym.sym.name for bsym in thunder.last_traces(jm)[-1].bound_symbols}
     # changes this to fewer as needed, the goal is to not have too many fusions
-    assert len([s for s in top_level_symbol_names if s.startswith("nvFusion")]) == 7
+    assert len([s for s in top_level_symbol_names if s.startswith("nvFusion")]) == 6


### PR DESCRIPTION
Related: https://github.com/Lightning-AI/lightning-thunder/issues/1251

Microbenchmark
```python
import torch
import torch.utils.benchmark
import thunder

# Seen in HF-Qwen2 Model
# [t6866] = nvFusion4(t6857)
#     # lora_res_12 = prims.reshape(t6857, (1, 4096, 16))  # lora_res_12: "cuda:0 bf16[1, 4096, 16]"
#     # t6866 = prims.reshape(lora_res_12, (4096, 16))  # t6866: "cuda:0 bf16[4096, 16]"

def fn(x):
    x = x.reshape(-1, 4096, 16)
    x = x.reshape(4096, 16)
    return x


x = torch.randn(4096, 16, device="cuda")
jfn = thunder.jit(fn, nv_enable_shape_only_fusion=False)

jfn(x)

timer = torch.utils.benchmark.Timer("jfn(x)", globals={"jfn": jfn, "x": x})

print(timer.blocked_autorange(min_run_time=1))
# print(thunder.last_traces(jfn)[-1])
```

Before PR
```python
<torch.utils.benchmark.utils.common.Measurement object at 0x7305591c54e0>
jfn(x)
  Median: 36.18 us
  3 measurements, 10000 runs per measurement, 1 thread
```

After PR
```python
<torch.utils.benchmark.utils.common.Measurement object at 0x7e533962cc10>
jfn(x)
  Median: 18.95 us
  IQR:    0.02 us (18.93 to 18.96)
  6 measurements, 10000 runs per measurement, 1 thread
```

TODO 
* [x] Add tests!
* [x] Check if CI works fine
