### PR TITLE
Skip bert recipe test temporarily

### DIFF
--- a/thunder/tests/test_recipes.py
+++ b/thunder/tests/test_recipes.py
@@ -6,7 +6,7 @@ import pytest
 from torch.testing import assert_close, make_tensor
 from thunder.tests.framework import version_between
 
-
+@pytest.mark.skip(reason="torchvision::nms issue with transformers")
 def test_recipe_basic_bert():
     bert = transformers.BertForSequenceClassification(transformers.BertConfig())
     del bert.bert.encoder.layer[1:]


### PR DESCRIPTION
Due to torchvision::nms issue.

## What does this PR do?

Skips a test. There is an issue with current versions:

```
____________________________ test_recipe_basic_bert ____________________________
[gw3] linux -- Python 3.10.15 /opt/hostedtoolcache/Python/3.10.15/x64/bin/python

self = <module 'transformers.models.bert' from '/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/transformers/models/bert/__init__.py'>
module_name = 'modeling_bert'

    def _get_module(self, module_name: str):
        try:
>           return importlib.import_module("." + module_name, self.__name__)

/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/transformers/utils/import_utils.py:1778: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/transformers/models/bert/modeling_bert.py:47: in <module>
    from ...modeling_utils import PreTrainedModel
/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/transformers/modeling_utils.py:48: in <module>
    from .loss.loss_utils import LOSS_MAPPING
/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/transformers/loss/loss_utils.py:19: in <module>
    from .loss_deformable_detr import DeformableDetrForObjectDetectionLoss, DeformableDetrForSegmentationLoss
/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/transformers/loss/loss_deformable_detr.py:4: in <module>
    from ..image_transforms import center_to_corners_format
/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/transformers/image_transforms.py:22: in <module>
    from .image_utils import (
/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/transformers/image_utils.py:58: in <module>
    from torchvision.transforms import InterpolationMode
/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/torchvision/__init__.py:10: in <module>
    from torchvision import _meta_registrations, datasets, io, models, ops, transforms, utils  # usort:skip
/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/torchvision/_meta_registrations.py:164: in <module>
    def meta_nms(dets, scores, iou_threshold):
/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/torch/library.py:854: in register
    use_lib._register_fake(op_name, func, _stacklevel=stacklevel + 1)
/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/torch/library.py:198: in _register_fake
    handle = entry.fake_impl.register(func_to_register, source)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <torch._library.fake_impl.FakeImplHolder object at 0x7f54f717f910>
func = <function meta_nms at 0x7f54f70c4b80>
source = '/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/torchvision/_meta_registrations.py:164'

    def register(self, func: Callable, source: str) -> RegistrationHandle:
        """Register an fake impl.
    
        Returns a RegistrationHandle that one can use to de-register this
        fake impl.
        """
        if self.kernel is not None:
            raise RuntimeError(
                f"register_fake(...): the operator {self.qualname} "
                f"already has an fake impl registered at "
                f"{self.kernel.source}."
            )
>       if torch._C._dispatch_has_kernel_for_dispatch_key(self.qualname, "Meta"):
E       RuntimeError: operator torchvision::nms does not exist

/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/torch/_library/fake_impl.py:31: RuntimeError

The above exception was the direct cause of the following exception:

    def test_recipe_basic_bert():
>       bert = transformers.BertForSequenceClassification(transformers.BertConfig())

thunder/tests/test_recipes.py:11: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/transformers/utils/import_utils.py:1767: in __getattr__
    value = getattr(module, name)
/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/transformers/utils/import_utils.py:1766: in __getattr__
    module = self._get_module(self._class_to_module[name])
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <module 'transformers.models.bert' from '/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/transformers/models/bert/__init__.py'>
module_name = 'modeling_bert'

    def _get_module(self, module_name: str):
        try:
            return importlib.import_module("." + module_name, self.__name__)
        except Exception as e:
>           raise RuntimeError(
                f"Failed to import {self.__name__}.{module_name} because of the following error (look up to see its"
                f" traceback):\n{e}"
            ) from e
E           RuntimeError: Failed to import transformers.models.bert.modeling_bert because of the following error (look up to see its traceback):
E           operator torchvision::nms does not exist

/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/transformers/utils/import_utils.py:1780: RuntimeError
_________________________________ test_hf_bert _________________________________
[gw0] linux -- Python 3.10.15 /opt/hostedtoolcache/Python/3.10.15/x64/bin/python

self = <module 'transformers' from '/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/transformers/__init__.py'>
module_name = 'modeling_utils'

    def _get_module(self, module_name: str):
        try:
>           return importlib.import_module("." + module_name, self.__name__)

/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/transformers/utils/import_utils.py:1778: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/transformers/modeling_utils.py:48: in <module>
    from .loss.loss_utils import LOSS_MAPPING
/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/transformers/loss/loss_utils.py:19: in <module>
    from .loss_deformable_detr import DeformableDetrForObjectDetectionLoss, DeformableDetrForSegmentationLoss
/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/transformers/loss/loss_deformable_detr.py:4: in <module>
    from ..image_transforms import center_to_corners_format
/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/transformers/image_transforms.py:22: in <module>
    from .image_utils import (
/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/transformers/image_utils.py:58: in <module>
    from torchvision.transforms import InterpolationMode
/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/torchvision/__init__.py:10: in <module>
    from torchvision import _meta_registrations, datasets, io, models, ops, transforms, utils  # usort:skip
/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/torchvision/_meta_registrations.py:164: in <module>
    def meta_nms(dets, scores, iou_threshold):
/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/torch/library.py:854: in register
    use_lib._register_fake(op_name, func, _stacklevel=stacklevel + 1)
/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/torch/library.py:198: in _register_fake
    handle = entry.fake_impl.register(func_to_register, source)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <torch._library.fake_impl.FakeImplHolder object at 0x7efba8e71d80>
func = <function meta_nms at 0x7efba8d75e10>
source = '/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/torchvision/_meta_registrations.py:164'

    def register(self, func: Callable, source: str) -> RegistrationHandle:
        """Register an fake impl.
    
        Returns a RegistrationHandle that one can use to de-register this
        fake impl.
        """
        if self.kernel is not None:
            raise RuntimeError(
                f"register_fake(...): the operator {self.qualname} "
                f"already has an fake impl registered at "
                f"{self.kernel.source}."
            )
>       if torch._C._dispatch_has_kernel_for_dispatch_key(self.qualname, "Meta"):
E       RuntimeError: operator torchvision::nms does not exist

/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/torch/_library/fake_impl.py:31: RuntimeError

The above exception was the direct cause of the following exception:

    def test_hf_bert():
        import transformers
    
        @thunder.core.jit_ext.register_general_jit_lookaside(
>           transformers.modeling_utils.PreTrainedModel.warn_if_padding_and_no_attention_mask
        )

thunder/tests/test_networks.py:268: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/transformers/utils/import_utils.py:1769: in __getattr__
    value = self._get_module(name)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <module 'transformers' from '/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/transformers/__init__.py'>
module_name = 'modeling_utils'

    def _get_module(self, module_name: str):
        try:
            return importlib.import_module("." + module_name, self.__name__)
        except Exception as e:
>           raise RuntimeError(
                f"Failed to import {self.__name__}.{module_name} because of the following error (look up to see its"
                f" traceback):\n{e}"
            ) from e
E           RuntimeError: Failed to import transformers.modeling_utils because of the following error (look up to see its traceback):
E           operator torchvision::nms does not exist

/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/transformers/utils/import_utils.py:1780: RuntimeError
```

This is likely outside of thunder's control, so skip temporarily.