### PR TITLE
[nvfuser executor] Allow sm89 for fp8 types

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ For **performance experts**, Thunder is the most ergonomic framework for underst
 <div align='center'>
 
 <pre>
-✅ Run PyTorch 40% faster   ✅ Quantization                ✅ Kernel fusion        
-✅ Training recipes         ✅ FP4/FP6/FP8 precision       ✅ Distributed TP/PP/DP 
-✅ Inference recipes        ✅ Ready for NVIDIA Blackwell  ✅ CUDA Graphs          
+✅ Run PyTorch 40% faster   ✅ Quantization                ✅ Kernel fusion
+✅ Training recipes         ✅ FP4/FP6/FP8 precision       ✅ Distributed TP/PP/DP
+✅ Inference recipes        ✅ Ready for NVIDIA Blackwell  ✅ CUDA Graphs
 ✅ LLMs, non LLMs and more  ✅ Custom Triton kernels       ✅ Compose all the above
 </pre>
 

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -171,8 +171,13 @@ _low_precision_floats = (dtypes.float16, dtypes.float16_, dtypes.bfloat16, dtype
 
 
 def device_supports_fp8() -> bool:
+    cuda_version: LooseVersion | None = None
+    if torch.version.cuda is None:
+        return False
+    else:
+        cuda_version = LooseVersion(cuda_version)
     cuda_major, cuda_minor = torch.cuda.get_device_capability()
-    return (cuda_major, cuda_minor) >= (8, 9)
+    return (cuda_version >= LooseVersion("12.01") and (cuda_major, cuda_minor) >= (8, 9)) or (cuda_version >= LooseVersion("11.8") and cuda_major >= 9)
 
 
 def is_supported_dtype(dtype: type | dtypes.dtype, *, allow_low_precision_floats: bool = True) -> bool:

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -177,7 +177,7 @@ def device_supports_fp8() -> bool:
     else:
         cuda_version = LooseVersion(cuda_version)
     cuda_major, cuda_minor = torch.cuda.get_device_capability()
-    return (cuda_version >= LooseVersion("12.01") and (cuda_major, cuda_minor) >= (8, 9)) or (cuda_version >= LooseVersion("11.8") and cuda_major >= 9)
+    return (cuda_version >= LooseVersion("12.1") and (cuda_major, cuda_minor) >= (8, 9)) or (cuda_version >= LooseVersion("11.8") and cuda_major >= 9)
 
 
 def is_supported_dtype(dtype: type | dtypes.dtype, *, allow_low_precision_floats: bool = True) -> bool:

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -171,15 +171,14 @@ _low_precision_floats = (dtypes.float16, dtypes.float16_, dtypes.bfloat16, dtype
 
 
 def device_supports_fp8() -> bool:
-    cuda_version: LooseVersion | None = None
-    if torch.version.cuda is None:
-        return False
-    else:
-        cuda_version = LooseVersion(cuda_version)
     cuda_major, cuda_minor = torch.cuda.get_device_capability()
-    return (cuda_version >= LooseVersion("12.1") and (cuda_major, cuda_minor) >= (8, 9)) or (
-        cuda_version >= LooseVersion("11.8") and cuda_major >= 9
-    )
+    if (cuda_major, cuda_minor) == (8, 9):
+        cuda_version: str | None = torch.version.cuda 
+        if cuda_version is None:
+            return False
+        else:
+            return LooseVersion(cuda_version) >= LooseVersion("12.1") and nvfuser_version() >= LooseVersion("0.2.24")
+    return cuda_major > 8
 
 
 def is_supported_dtype(dtype: type | dtypes.dtype, *, allow_low_precision_floats: bool = True) -> bool:

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -173,7 +173,7 @@ _low_precision_floats = (dtypes.float16, dtypes.float16_, dtypes.bfloat16, dtype
 def device_supports_fp8() -> bool:
     cuda_major, cuda_minor = torch.cuda.get_device_capability()
     if (cuda_major, cuda_minor) == (8, 9):
-        cuda_version: str | None = torch.version.cuda 
+        cuda_version: str | None = torch.version.cuda
         if cuda_version is None:
             return False
         else:

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -171,8 +171,8 @@ _low_precision_floats = (dtypes.float16, dtypes.float16_, dtypes.bfloat16, dtype
 
 
 def device_supports_fp8() -> bool:
-    cuda_major, _ = torch.cuda.get_device_capability()
-    return cuda_major > 8
+    cuda_major, cuda_minor = torch.cuda.get_device_capability()
+    return (cuda_major, cuda_minor) >= (8, 9)
 
 
 def is_supported_dtype(dtype: type | dtypes.dtype, *, allow_low_precision_floats: bool = True) -> bool:

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -177,7 +177,9 @@ def device_supports_fp8() -> bool:
     else:
         cuda_version = LooseVersion(cuda_version)
     cuda_major, cuda_minor = torch.cuda.get_device_capability()
-    return (cuda_version >= LooseVersion("12.1") and (cuda_major, cuda_minor) >= (8, 9)) or (cuda_version >= LooseVersion("11.8") and cuda_major >= 9)
+    return (cuda_version >= LooseVersion("12.1") and (cuda_major, cuda_minor) >= (8, 9)) or (
+        cuda_version >= LooseVersion("11.8") and cuda_major >= 9
+    )
 
 
 def is_supported_dtype(dtype: type | dtypes.dtype, *, allow_low_precision_floats: bool = True) -> bool:


### PR DESCRIPTION
## What does this PR do?

With NVIDIA/Fuser#3624, devices >= sm89 get allowed to use nvfuser executor for fp8.