### PR TITLE
split ThunderFunction to deallocate grad_outs while computing backward

### DIFF
--- a/notebooks/writing_a_trace_transform_cpu_offloading.ipynb
+++ b/notebooks/writing_a_trace_transform_cpu_offloading.ipynb
@@ -525,7 +525,7 @@
     "\n",
     "# Verify that saved tensors are on CPU.\n",
     "saved_tensor_devices = set()\n",
-    "for t in actual.grad_fn.saved_tensors:\n",
+    "for t in actual.grad_fn.next_functions[0][0].saved_tensors:\n",
     "    saved_tensor_devices.add(str(t.device))\n",
     "\n",
     "assert \"cpu\" in saved_tensor_devices  # Verify that we actually have saved tensors on CPU\n",

--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -72,7 +72,7 @@ from thunder.core.proxies import (
 )
 from thunder.core.interpreter import print_interpreter_log, print_to_log
 from thunder.core.jit_ext import thunder_general_jit
-from thunder.executors.torch_autograd import split_forward_backward, ThunderFunction1, ThunderFunction2
+from thunder.executors.torch_autograd import split_forward_backward, connect_to_autograd
 
 # NOTE This import is intentionally pytorch so that it thunder.torch doesn't import this
 import torch as pytorch
@@ -750,19 +750,15 @@ def jit(
             # resulting tensors to PyTorch's Autograd graph using the
             # ThunderFunction (which is a torch.autograd.Function subclass)
             data_for_autograd, (saved_tensors, saved_other) = result
-            side_channel = {}
-            dummy_res = ThunderFunction1.apply(
-                cache_entry.return_none_instead_of_grads,
-                cache_entry.backward_fn,
-                side_channel,
-                saved_tensors,
-                saved_other,
-                data_for_autograd["flat_output"],
-                *data_for_autograd["flat_args"],
+
+            connect_to_autograd(
+                backward_fn=cache_entry.backward_fn,
+                flat_args=data_for_autograd["flat_args"],
+                flat_output=data_for_autograd["flat_output"],
+                saved_tensors=saved_tensors,
+                saved_other=saved_other,
+                return_none_instead_of_grads=cache_entry.return_none_instead_of_grads,
             )
-            # we need to pass the inputs to avoid "leave has moved inside the graph"
-            # if the function returns an argument as is
-            ThunderFunction2.apply(dummy_res, side_channel, *data_for_autograd["flat_args"])
             result = data_for_autograd["output"]
 
         return result

--- a/thunder/executors/torch_autograd.py
+++ b/thunder/executors/torch_autograd.py
@@ -11,6 +11,7 @@ from thunder.core.symbol import BoundSymbol
 from thunder.core.trace import TraceCtx, from_trace, set_tracectx, reset_tracectx
 from thunder.core.transform_common import replace_redundant_inputs
 from thunder.core.vjp_utils import get_saved_for_backward_tensors, set_saved_for_backward_tensors
+from .utils import is_cudagraph_capturing
 
 if TYPE_CHECKING:
     from thunder.core.trace import VariableInterface
@@ -184,7 +185,7 @@ def connect_to_autograd(
     # Of course, the real trick is to use the CUDAGraphTransform instead
     # of having something else apply it while introducing funny additional
     # conditions for success.
-    if not torch.cuda.graphs.is_current_stream_capturing():
+    if not is_cudagraph_capturing:
         side_channel = {}
     else:
         side_channel = None

--- a/thunder/executors/torch_autograd.py
+++ b/thunder/executors/torch_autograd.py
@@ -185,7 +185,7 @@ def connect_to_autograd(
     # Of course, the real trick is to use the CUDAGraphTransform instead
     # of having something else apply it while introducing funny additional
     # conditions for success.
-    if not is_cudagraph_capturing:
+    if not is_cudagraph_capturing():
         side_channel = {}
     else:
         side_channel = None

--- a/thunder/executors/utils.py
+++ b/thunder/executors/utils.py
@@ -21,6 +21,18 @@ from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
 from thunder.core.compile_data import get_compile_option
 
 
+try:
+    torch.cuda.graphs.is_current_stream_capturing()
+
+    def is_cudagraph_capturing():
+        return torch.cuda.graphs.is_current_stream_capturing()
+
+except RuntimeError:
+    # no cudagraph support (CPU only, ROCm, ...)
+    def is_cudagraph_capturing():
+        return False
+
+
 # TODO Make these tags
 comment_symbols = {
     PrimIDs.COMMENT,

--- a/thunder/tests/test_core.py
+++ b/thunder/tests/test_core.py
@@ -2510,8 +2510,8 @@ def test_grad_ctx():
         return x + 1
 
     x = torch.randn(3, 3, requires_grad=True)
-    thunder.jit(foo2)(x).sum().backward()
-    assert x.grad is None
+    res = thunder.jit(foo2)(x)
+    assert not res.requires_grad
 
     # Test `no_grad` ctx correctly disable gradient computation
     def foo3(x):

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -65,7 +65,7 @@ def test_basic(executor, device: str, dtype: dtypes.dtype, dynamic: bool | None)
 
     # out should have grad_fn and its name should be ThunderFunctionBackward
     assert out.grad_fn is not None
-    assert out.grad_fn.name() == "ThunderFunction2Backward"
+    assert out.grad_fn.name() == "ThunderOutputFunctionBackward"
 
     # We record the GraphModules that was compiled by ThunderCompiler
     backend = compiled._backend
@@ -317,7 +317,7 @@ def test_force_skip_lazy_graph_module(executor, device: str, dtype: dtypes.dtype
 
         # out should have grad_fn and its name should be ThunderFunctionBackward
         assert out.grad_fn is not None
-        assert out.grad_fn.name() == "ThunderFunction2Backward"
+        assert out.grad_fn.name() == "ThunderOutputFunctionBackward"
 
         backend = cfunc._backend
         # We record the GraphModules that was compiled by ThunderCompiler

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -65,7 +65,7 @@ def test_basic(executor, device: str, dtype: dtypes.dtype, dynamic: bool | None)
 
     # out should have grad_fn and its name should be ThunderFunctionBackward
     assert out.grad_fn is not None
-    assert out.grad_fn.name() == "ThunderFunctionBackward"
+    assert out.grad_fn.name() == "ThunderFunction2Backward"
 
     # We record the GraphModules that was compiled by ThunderCompiler
     backend = compiled._backend
@@ -317,7 +317,7 @@ def test_force_skip_lazy_graph_module(executor, device: str, dtype: dtypes.dtype
 
         # out should have grad_fn and its name should be ThunderFunctionBackward
         assert out.grad_fn is not None
-        assert out.grad_fn.name() == "ThunderFunctionBackward"
+        assert out.grad_fn.name() == "ThunderFunction2Backward"
 
         backend = cfunc._backend
         # We record the GraphModules that was compiled by ThunderCompiler

--- a/thunder/tests/test_grad.py
+++ b/thunder/tests/test_grad.py
@@ -1752,10 +1752,10 @@ def test_torch_checkpoint():
 
         # With activation checkpointing, we are saving only the original input.
         # The intermediate values are recomputed during backward pass.
-        assert len(out.grad_fn.saved_tensors) == 2
+        assert len(out.grad_fn.next_functions[0][0].saved_tensors) == 2
         # We detach the saved tensors (which returns a new Python tensor backed by same storage)
-        assert out.grad_fn.saved_tensors[0].data_ptr() == x.data_ptr()
-        assert out.grad_fn.saved_tensors[1].data_ptr() == y.data_ptr()
+        assert out.grad_fn.next_functions[0][0].saved_tensors[0].data_ptr() == x.data_ptr()
+        assert out.grad_fn.next_functions[0][0].saved_tensors[1].data_ptr() == y.data_ptr()
 
         g = torch.ones_like(out)
         out.backward(g)

--- a/thunder/tests/test_jit_general.py
+++ b/thunder/tests/test_jit_general.py
@@ -1194,7 +1194,7 @@ def test_custom_autograd_function():
     x = torch.randn((2, 2), dtype=torch.float64, requires_grad=True)
     model = Model().to(dtype=torch.float64)
     jitted = thunder.jit(model)
-    gradcheck(jitted, (x,))
+    gradcheck(jitted, (x,), check_batched_grad=False)
 
     jitted.zero_grad()
     x = torch.randn((2, 2), dtype=torch.float64, requires_grad=True)


### PR DESCRIPTION
Fixes: #1379 

Unfortunately, this does not work when using Thunder inside a cuda graphs capture, but maybe this is not the ideal way of running Thunder anyways.