### PR TITLE
remove unused outputs of `read` of `bsym.args` and `bsym.kwargs`

### DIFF
--- a/thunder/core/trace_interpreter.py
+++ b/thunder/core/trace_interpreter.py
@@ -322,9 +322,6 @@ class TraceSubstitutionProcessor:
                     self.new_trace.bound_symbols.append(bsym.from_bsym())
                     continue
 
-                args = tree_map(self.read, bsym.args)
-                kwargs = tree_map(self.read, bsym.kwargs)
-
                 # this should be prettier
                 self.replacement_result = self.NULL
                 self.new_bsyms = []


### PR DESCRIPTION
## What does this PR do?

Remove unused `args` and `kwargs`