### PR TITLE
Remove requires_grad from regular TensorProxy and add specialized TensorProxy with requires_grad and is_leaf attributes

### DIFF
--- a/thunder/common.py
+++ b/thunder/common.py
@@ -393,7 +393,7 @@ def _unpack_inputs(fn, tracectx: TraceCtx, args, kwargs, *, rename_proxies: bool
 # TODO Update cacheable types
 def _make_subkey_for(x: Any) -> tuple[bool, None | tuple]:
     if isinstance(x, (torch.Tensor, TensorProxy)):
-        return True, (type(x), x.shape, x.device, x.dtype, x.requires_grad)
+        return True, (type(x), x.shape, x.device, x.dtype, getattr(x, "requires_grad", False))
 
     # TODO Add NumPy ndarray support
     if isinstance(x, np.ndarray):

--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -2846,7 +2846,7 @@ def _randn_meta(
     utils.check_type(dtype, dtypes.dtype)
     utils.check_type(shape, tuple)
     utils.check_valid_shape(shape)
-    return TensorProxy(shape=shape, device=device, dtype=dtype, requires_grad=False)
+    return TensorProxy(shape=shape, device=device, dtype=dtype)
 
 
 randn = make_prim(PrimIDs.RANDN, "randn", meta=_randn_meta)

--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -2642,8 +2642,7 @@ def _where_meta(pred: Number | TensorProxy, a: Number | TensorProxy, b: Number |
     shapes = tuple(x.shape for x in (pred, a, b) if isinstance(x, TensorProxy))
     resultshape = shapes[0]
 
-    requires_grad = (isinstance(a, TensorProxy) and a.requires_grad) or (isinstance(b, TensorProxy) and b.requires_grad)
-    return TensorProxy(shape=resultshape, device=resultdevice, dtype=dtype, requires_grad=requires_grad)
+    return TensorProxy(shape=resultshape, device=resultdevice, dtype=dtype)
 
 
 where = make_prim(

--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -2314,18 +2314,15 @@ def _elementwise_binary_meta_factory(
             tensor = a if (isinstance(a, TensorProxy) and not utils.is_cpu_scalar_tensor(a)) else b
         else:
             tensor = a if isinstance(a, TensorProxy) else b
-        requires_grad = (isinstance(a, TensorProxy) and a.requires_grad) or (
-            isinstance(b, TensorProxy) and b.requires_grad
-        )
 
         if output_dtype_kind == ELEMENTWISE_PRIM_OUTPUT_DTYPE_KIND.SAME:
             # NOTE that this is not just like=tensor, because one tensor could have a weak dtype
             #   and the other a strong dtype, and these are the "same"
-            return TensorProxy(like=tensor, dtype=dtype, requires_grad=requires_grad)
+            return TensorProxy(like=tensor, dtype=dtype)
         if output_dtype_kind == ELEMENTWISE_PRIM_OUTPUT_DTYPE_KIND.ALWAYS_BOOL:
-            return TensorProxy(like=tensor, dtype=dtypes.bool8, requires_grad=requires_grad)
+            return TensorProxy(like=tensor, dtype=dtypes.bool8)
         if output_dtype_kind == ELEMENTWISE_PRIM_OUTPUT_DTYPE_KIND.COMPLEX_TO_FLOAT and dtypes.is_complex_dtype(dtype):
-            return TensorProxy(like=tensor, dtype=dtypes.corresponding_real_dtype(dtype), requires_grad=requires_grad)
+            return TensorProxy(like=tensor, dtype=dtypes.corresponding_real_dtype(dtype))
 
         raise AssertionError(f"Unknown {output_dtype_kind=}")
 

--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -2580,11 +2580,7 @@ def _lerp_meta(start: TensorProxy, end: TensorProxy, weight: Number | TensorProx
     utils.check_same_shape(start, end, weight)
     utils.check_same_device(start, end, weight)
 
-    requires_grad = (
-        start.requires_grad or end.requires_grad or (isinstance(weight, TensorProxy) and weight.requires_grad)
-    )
-
-    return TensorProxy(like=start, dtype=dtype, requires_grad=requires_grad)
+    return TensorProxy(like=start, dtype=dtype)
 
 
 lerp = make_prim(

--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -2862,7 +2862,7 @@ def _empty_meta(
     utils.check_type(dtype, dtypes.dtype)
     utils.check_type(shape, tuple)
     utils.check_valid_shape(shape)
-    return TensorProxy(shape=shape, device=device, dtype=dtype, requires_grad=False)
+    return TensorProxy(shape=shape, device=device, dtype=dtype)
 
 
 empty = make_prim(PrimIDs.EMPTY, "empty", meta=_empty_meta)

--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -2994,7 +2994,7 @@ def _multinomial_meta(
 
     shape = (*input.shape[:-1], num_samples)
 
-    return TensorProxy(shape=shape, device=input.device, dtype=dtypes.int64, requires_grad=False)
+    return TensorProxy(shape=shape, device=input.device, dtype=dtypes.int64)
 
 
 multinomial = make_prim(

--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -3083,8 +3083,7 @@ def cat_meta(tensors: list[TensorProxy], /, dim: int) -> TensorProxy:
             )
         shape[dim] = shape[dim] + ai.shape[dim]
 
-    requires_grad = any(list([t.requires_grad for t in tensors]))
-    return TensorProxy(like=tensors[0], shape=shape, requires_grad=requires_grad)
+    return TensorProxy(like=tensors[0], shape=shape)
 
 
 cat = make_prim(

--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -4012,12 +4012,11 @@ embedding = make_prim(PrimIDs.EMBEDDING, "embedding", meta=embedding_meta)
 
 # TODO Update this so it's not a prim
 # TODO Add annotations
-# TODO Review requires_grad=False -- what about double backward?
 # TODO Once we have fusible index_put we can implement it using primitives
 # For now we just use the PyTorch implementation
 def embedding_backward_meta(grad, indices, num_weights, padding_idx, scale_grad_by_freq, sparse):
     shape = (num_weights, grad.shape[-1])
-    return TensorProxy(shape=shape, device=grad.device, dtype=grad.dtype, requires_grad=False)
+    return TensorProxy(shape=shape, device=grad.device, dtype=grad.dtype)
 
 
 embedding_backward = make_prim(PrimIDs.EMBEDDING_BACKWARD, "embedding_backward", meta=embedding_backward_meta)

--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -2826,7 +2826,7 @@ def _uniform_philox_meta(
     utils.check_same_shape(shape, seed, offset)
     utils.check_same_device(device, seed, offset)
 
-    return TensorProxy(shape=shape, device=device, dtype=dtype, requires_grad=False)
+    return TensorProxy(shape=shape, device=device, dtype=dtype)
 
 
 uniform_philox = make_prim(

--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -2689,10 +2689,6 @@ exogenous_like = make_prim(
 )
 
 
-# TODO Review always setting requires_grad=False
-#   Logically these tensors are constructed intermediate to a trace, so there's no mechanism for a user to
-#   extract their grad, but we could support compiling forward and backward and accessing grad attributes
-#   in the future
 def _full_meta(
     shape: tuple[int, ...], fill_value: Number, *, device: devices.Device, dtype: dtypes.dtype
 ) -> TensorProxy:
@@ -2708,7 +2704,7 @@ def _full_meta(
 
     utils.check_type(shape, tuple)
     utils.check_valid_shape(shape)
-    return TensorProxy(shape=shape, device=device, dtype=dtype, requires_grad=False)
+    return TensorProxy(shape=shape, device=device, dtype=dtype)
 
 
 full = make_prim(

--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -3770,8 +3770,7 @@ def linear_meta(a: TensorProxy, w: TensorProxy, bias: None | TensorProxy) -> Ten
 
     out_shape = batch_dims + (out_length,)
 
-    requires_grad = any((a.requires_grad, w.requires_grad, False if bias is None else bias.requires_grad))
-    return TensorProxy(shape=out_shape, device=a.device, dtype=dtype, requires_grad=requires_grad)
+    return TensorProxy(shape=out_shape, device=a.device, dtype=dtype)
 
 
 linear = make_prim(PrimIDs.LINEAR, "linear", meta=linear_meta, tags=(OpTags.MATMUL_OP,))

--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -2741,10 +2741,6 @@ iota = make_prim(PrimIDs.IOTA, "iota", meta=_iota_meta)
 
 
 # TODO Should the uniform prim include minval maxval or always be [0, 1)?
-# TODO Review always setting requires_grad=False
-#   Logically these tensors are constructed intermediate to a trace, so there's no mechanism for a user to
-#   extract their grad, but we could support compiling forward and backward and accessing grad attributes
-#   in the future
 def _uniform_meta(
     shape: Sequence[int], minval: Number, maxval: Number, *, device: devices.Device, dtype: dtypes.dtype
 ) -> TensorProxy:
@@ -2754,7 +2750,7 @@ def _uniform_meta(
     utils.check_type(device, devices.Device)
     utils.check_type(dtype, dtypes.dtype)
 
-    return TensorProxy(shape=shape, device=device, dtype=dtype, requires_grad=False)
+    return TensorProxy(shape=shape, device=device, dtype=dtype)
 
 
 uniform = make_prim(

--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -2870,7 +2870,7 @@ empty = make_prim(PrimIDs.EMPTY, "empty", meta=_empty_meta)
 
 # TODO(crcrpar): Cover `memory_format` kwarg
 def _clone_meta(a: TensorProxy, **kwargs) -> TensorProxy:
-    return TensorProxy(like=a, requires_grad=a.requires_grad)
+    return TensorProxy(like=a)
 
 
 clone = make_prim(PrimIDs.CLONE, "clone", meta=_clone_meta)

--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -2943,9 +2943,7 @@ def _tensor_from_sequence_meta(
         # NOTE: In future, we should rely on something like [thunder/torch].get_default_dtype.
         dtype = inferred_dtype if inferred_dtype is not None else float
 
-    # We set `requires_grad` to False as this tensor will show up only in trace and
-    # user won't have access to it. See also, the note on _full_meta.
-    return TensorProxy(shape=shape, device=device, dtype=dtype, requires_grad=False)
+    return TensorProxy(shape=shape, device=device, dtype=dtype)
 
 
 # Prim to construct a Tensor from sequence/nested sequence of Numbers.

--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -2734,7 +2734,7 @@ def _iota_meta(
 
     shape = () if length == 0 else (length,)
 
-    return TensorProxy(shape=shape, device=device, dtype=dtype, requires_grad=False)
+    return TensorProxy(shape=shape, device=device, dtype=dtype)
 
 
 iota = make_prim(PrimIDs.IOTA, "iota", meta=_iota_meta)

--- a/thunder/core/proxies.py
+++ b/thunder/core/proxies.py
@@ -1961,25 +1961,6 @@ def tensorproxy(t: torch.Tensor, /, *, name: None | str, history: None | tuple =
     )
 
 
-def futuretensorproxy(
-    t: torch.Tensor | TensorProxy | FutureTensorProxy, /, *, name: None | str, history: None | tuple = None
-) -> FutureTensorProxy:
-    if hasattr(t, "_thunder_device"):
-        torch_device = t._thunder_device
-    else:
-        torch_device = t.device
-    device = devices.to_device(torch_device)
-    dtype = dtypes.to_dtype(t.dtype)
-    # NOTE Without tuple(t.shape) then the shape would be a torch.Size object
-    return FutureTensorProxy(
-        name,
-        shape=tuple(t.shape),
-        device=device,
-        dtype=dtype,
-        history=history,
-    )
-
-
 def numberproxy(cls: type, value: Number | None, constraint: None | CONSTRAINT = None) -> NumberProxy:
     pcls = _cls_to_number_proxy_map[cls]
     return pcls(value=value, constraint=constraint)

--- a/thunder/core/proxies.py
+++ b/thunder/core/proxies.py
@@ -1197,7 +1197,6 @@ def _infer_tensor_properties(
     shape: ShapeLike | None = None,
     device: devices.Device | None = None,
     dtype: dtypes.dtype | None = None,
-    requires_grad: bool | None = None,
     grad: TensorProxy | None = None,
     distparallel_type: DistParallelType | None = None,
     thunder_fsdp_padding_size: int | None = None,
@@ -1205,7 +1204,6 @@ def _infer_tensor_properties(
     _shape = None
     _device = None
     _dtype = None
-    _requires_grad: None | bool = None
     _grad = None
     _dist_parallel_type = DistParallelType.NONE
     _thunder_fsdp_padding_size = None
@@ -1215,7 +1213,6 @@ def _infer_tensor_properties(
         _shape = tuple(like.shape)
         _device = like.device
         _dtype = like.true_dtype
-        _requires_grad = like.requires_grad
         _grad = like.grad
         _dist_parallel_type = getattr(like, "distparallel_type", DistParallelType.NONE)
 
@@ -1226,10 +1223,7 @@ def _infer_tensor_properties(
     _device = device if device is not None else _device
     _dtype = dtype if dtype is not None else _dtype
     _dtype = dtypes.numbertype_to_dtype(_dtype) if dtypes.is_numbertype(_dtype) else _dtype
-    _requires_grad = requires_grad if requires_grad is not None else _requires_grad
-    _requires_grad = False if not dtypes.is_inexact_dtype(_dtype) else _requires_grad
     _grad = grad if grad is not None else _grad
-    _grad = None if not _requires_grad else _grad
     _dist_parallel_type = distparallel_type if distparallel_type is not None else _dist_parallel_type
     _thunder_fsdp_padding_size = (
         thunder_fsdp_padding_size if thunder_fsdp_padding_size is not None else _thunder_fsdp_padding_size
@@ -1251,7 +1245,6 @@ def _infer_tensor_properties(
     # Validates inputs
     baseutils.check_type(_device, devices.Device)
     baseutils.check_type(_dtype, dtypes.dtype)
-    baseutils.check_type(_requires_grad, bool)
     baseutils.check_type(_dist_parallel_type, DistParallelType)
     if isinstance(_thunder_fsdp_padding_size, int):
         baseutils.check(
@@ -1275,7 +1268,6 @@ def _infer_tensor_properties(
         _true_dtype,
         _numel,
         _ndim,
-        _requires_grad,
         _grad,
         _dist_parallel_type,
         _thunder_fsdp_padding_size,
@@ -1306,7 +1298,6 @@ class FutureTensorProxy(Proxy, TensorProxyInterface):
             self._true_dtype,
             self._numel,
             self._ndim,
-            self._requires_grad,
             _,  # grad
             _,  # distparallel_type
             _,  # thunder_fsdp_padding_size
@@ -1347,10 +1338,6 @@ class FutureTensorProxy(Proxy, TensorProxyInterface):
         return self._true_dtype
 
     @property
-    def requires_grad(self):
-        return self._requires_grad
-
-    @property
     def grad(self):
         return None  # FutureTensorProxies never require grad
 
@@ -1380,7 +1367,6 @@ class FutureTensorProxy(Proxy, TensorProxyInterface):
             true_dtype,
             numel,
             ndim,
-            requires_grad,
             _,  # grad
             _,  # distparallel_type
             _,  # thunder_fsdp_padding_size
@@ -1414,7 +1400,6 @@ class TensorProxy(Proxy, TensorProxyInterface):
         shape: ShapeLike | None = None,
         device: devices.Device | None = None,
         dtype: dtypes.dtype | None = None,
-        requires_grad: bool = False,
         grad: TensorProxy | None = None,
         prefix: None | str = None,
         distparallel_type: DistParallelType | None = None,
@@ -1431,7 +1416,6 @@ class TensorProxy(Proxy, TensorProxyInterface):
             self._true_dtype,
             self._numel,
             self._ndim,
-            self._requires_grad,
             self._grad,
             self._distparallel_type,
             self._thunder_fsdp_padding_size,
@@ -1440,7 +1424,6 @@ class TensorProxy(Proxy, TensorProxyInterface):
             shape,
             device,
             dtype,
-            requires_grad,
             grad,
             distparallel_type,
             thunder_fsdp_padding_size,
@@ -1475,10 +1458,6 @@ class TensorProxy(Proxy, TensorProxyInterface):
         return self._true_dtype
 
     @property
-    def requires_grad(self):
-        return self._requires_grad
-
-    @property
     def grad(self):
         return self._grad
 
@@ -1502,7 +1481,7 @@ class TensorProxy(Proxy, TensorProxyInterface):
 
     def replace(self, **changes):
         r"""Return a copy of the TensorProxy object with new values for the specified fields as given to the constructor as arguments.
-        Valid keyword arguments are ``name``, ``history``, ``shape``, ``dtype``, ``device``, ``requires_grad``, ``distparallel_type``,  ``thunder_fsdp_padding_size``.
+        Valid keyword arguments are ``name``, ``history``, ``shape``, ``dtype``, ``device``, ``distparallel_type``,  ``thunder_fsdp_padding_size``.
         ``like`` is also a valid keyword and will take metadata from the tensor proxy argument
         in preference to the old values but overridable by keyword arguments.
         Note that the copy will use the current (environment) tracectx."""
@@ -1515,7 +1494,6 @@ class TensorProxy(Proxy, TensorProxyInterface):
             true_dtype,
             numel,
             ndim,
-            requires_grad,
             grad,
             distparallel_type,
             thunder_fsdp_padding_size,
@@ -1524,7 +1502,6 @@ class TensorProxy(Proxy, TensorProxyInterface):
             changes.get("shape", self._shape if like is None else None),
             changes.get("device", self._device if like is None else None),
             changes.get("dtype", self._dtype if like is None else None),
-            changes.get("requires_grad", self._requires_grad if like is None else None),
             changes.get("grad", self._grad if like is None else None),
             changes.get("distparallel_type", self._distparallel_type if like is None else None),
             changes.get("thunder_fsdp_padding_size", self._thunder_fsdp_padding_size if like is None else None),
@@ -1538,7 +1515,6 @@ class TensorProxy(Proxy, TensorProxyInterface):
             shape=shape,
             device=device,
             dtype=dtype,
-            requires_grad=requires_grad,
             distparallel_type=distparallel_type,
             thunder_fsdp_padding_size=thunder_fsdp_padding_size,
             history=history,
@@ -1978,7 +1954,6 @@ def tensorproxy(t: torch.Tensor, /, *, name: None | str, history: None | tuple =
         shape=tuple(shape),
         device=device,
         dtype=dtype,
-        requires_grad=t.requires_grad,
         grad=grad,
         distparallel_type=distparallel_type,
         history=history,

--- a/thunder/core/proxies.py
+++ b/thunder/core/proxies.py
@@ -1844,6 +1844,52 @@ class TensorProxy(Proxy, TensorProxyInterface):
         return method(self)
 
 
+class RuntimeTensorProxy(TensorProxy):
+    def __init__(
+        self,
+        name: str | None = None,
+        *,
+        like: TensorProxy | None = None,
+        shape: ShapeLike | None = None,
+        device: devices.Device | None = None,
+        dtype: dtypes.dtype | None = None,
+        grad: TensorProxy | None = None,
+        prefix: None | str = None,
+        distparallel_type: DistParallelType | None = None,
+        history: None | tuple = None,
+        tags: set | None = None,
+        thunder_fsdp_padding_size: int | None = None,
+        requires_grad: bool = False,
+        is_leaf: bool = True,
+    ):
+        super().__init__(
+            name,
+            like=like,
+            shape=shape,
+            device=device,
+            dtype=dtype,
+            grad=grad,
+            prefix=prefix,
+            distparallel_type=distparallel_type,
+            history=history,
+            tags=tags,
+            thunder_fsdp_padding_size=thunder_fsdp_padding_size,
+        )
+        self._requires_grad = requires_grad
+        self._is_leaf = is_leaf
+
+    def __repr__(self):
+        return f'<{type(self).__name__}(name="{self.name}", dtype={self.dtype}, shape={self.shape}, requires_grad={self.requires_grad}, is_leaf={self.is_leaf})>'
+
+    @property
+    def requires_grad(self):
+        return self._requires_grad
+
+    @property
+    def is_leaf(self):
+        return self._is_leaf
+
+
 class TorchAutogradFunctionCtxProxy(Proxy, TorchAutogradFunctionCtxProxyInterface):
     def __init__(
         self,
@@ -1949,7 +1995,7 @@ def tensorproxy(t: torch.Tensor, /, *, name: None | str, history: None | tuple =
     else:
         # NOTE Without tuple(t.shape) then the shape would be a torch.Size object
         shape = tuple(t.shape)
-    return TensorProxy(
+    return RuntimeTensorProxy(
         name,
         shape=tuple(shape),
         device=device,
@@ -1958,6 +2004,8 @@ def tensorproxy(t: torch.Tensor, /, *, name: None | str, history: None | tuple =
         distparallel_type=distparallel_type,
         history=history,
         thunder_fsdp_padding_size=_thunder_fsdp_padding_size,
+        requires_grad=t.requires_grad,
+        is_leaf=t.is_leaf,
     )
 
 

--- a/thunder/executors/utils.py
+++ b/thunder/executors/utils.py
@@ -191,7 +191,6 @@ def _convert_to_meta_tensor(a: None | TensorProxy) -> None | torch.Tensor:
     return torch.empty(
         a.shape,
         dtype=_thunder_to_torch_dtype_map[a.dtype],
-        requires_grad=a.requires_grad,
         device="meta",
     )
 

--- a/thunder/tests/test_networks.py
+++ b/thunder/tests/test_networks.py
@@ -419,10 +419,6 @@ def test_thunderfx_mistral_nemo_small():
     assert mdl._backend.subgraph_infos, "Should have at least 1 subgraph"
 
 
-@pytest.mark.skipif(
-    version_between(torch.__version__, min_ver="2.6.0dev0", max_ver="2.6.0a99"),
-    reason="https://github.com/Lightning-AI/lightning-thunder/issues/1471",
-)
 @thunder.tests.framework.requiresCUDA
 @pytest.mark.parametrize("model_id", ["Qwen/Qwen2.5-7B-Instruct", "microsoft/Phi-3-mini-128k-instruct"])
 def test_hf_for_nemo(model_id):


### PR DESCRIPTION
PyTorch tensors have attributes that affect the computation and Thunder should mirror those in TensorProxies. However, some of the attributes (`requires_grad`, `is_leaf`, `stride`) are tricky to model precisely and propagate the values in Thunder's meta functions. This PR removes the possibility of querying and specifying `requires_grad` on regular TensorProxies which are used for intermediate values and reintroduces the attribute with a special class `RuntimeTensorProxy` that should be constructed through a corresponding real PyTorch tensor.
A new attribute is added, `is_leaf`, which is useful for raising errors when in-place copies should be disallowed (https://github.com/Lightning-AI/lightning-thunder/issues/1577, https://github.com/Lightning-AI/lightning-thunder/pull/1458).
It's not part of this PR but an extension to query static strides information will be easy to add in the future.

Ref https://github.com/Lightning-AI/lightning-thunder/issues/1577, https://github.com/Lightning-AI/lightning-thunder/issues/1570.