### PR TITLE
Add a new dynamo.last_traces entry point.

### DIFF
--- a/thunder/dynamo/compiler.py
+++ b/thunder/dynamo/compiler.py
@@ -145,7 +145,7 @@ def thunderfx(fn: Callable, /, **kwargs) -> Callable:
     compiled = torch.compile(fn, backend=backend, **torch_compile_options)
 
     # We return this object instead of just the raw `compiled` Callable so that
-    # we have a place to hang the `last_traces` property.
+    # we have a place to hang the `last_*traces` properties.
     class CompiledObject:
         def __init__(self, be, func: Callable):
             self._backend = backend

--- a/thunder/dynamo/compiler.py
+++ b/thunder/dynamo/compiler.py
@@ -157,7 +157,8 @@ def thunderfx(fn: Callable, /, **kwargs) -> Callable:
         @property
         def last_traces(self) -> [Trace]:
             """
-            Get the Thunder traces for all subgraphs of a ThunderFX callable.
+            Get the Thunder traces for all the forward subgraphs of a ThunderFX
+            callable.
 
             .. note:: The object must have been invoked before calling this
                       function.
@@ -169,7 +170,20 @@ def thunderfx(fn: Callable, /, **kwargs) -> Callable:
                     if trcs is not None and trcs != []:
                         rv.append(trcs[-1])
                     del trcs
+            return rv
 
+        @property
+        def last_backward_traces(self) -> [Trace]:
+            """
+            Get the Thunder traces for all the backward subgraphs of a
+            ThunderFX callable.
+
+            .. note:: The object must have been invoked before calling this
+                      function.
+            """
+            rv: [Trace] = []
+            for sinfo in self._backend.subgraph_infos:
+                for th_fqn in sinfo.thunder_compiled_fns:
                     trcs_bw = thunder.last_backward_traces(th_fqn)
                     if trcs_bw is not None and trcs_bw != []:
                         rv.append(trcs_bw[-1])

--- a/thunder/dynamo/compiler.py
+++ b/thunder/dynamo/compiler.py
@@ -165,7 +165,7 @@ def thunderfx(fn: Callable, /, **kwargs) -> Callable:
             """
             rv: [Trace] = []
             if not self._backend.subgraph_infos:
-              warnings.warn("Must invoke the function before using last_traces")
+                warnings.warn("Must invoke the function before using last_traces")
             for sinfo in self._backend.subgraph_infos:
                 for th_fqn in sinfo.thunder_compiled_fns:
                     trcs = thunder.last_traces(th_fqn)
@@ -185,7 +185,7 @@ def thunderfx(fn: Callable, /, **kwargs) -> Callable:
             """
             rv: [Trace] = []
             if not self._backend.subgraph_infos:
-              warnings.warn("last_backward_traces used before function invoked")
+                warnings.warn("last_backward_traces used before function invoked")
             for sinfo in self._backend.subgraph_infos:
                 for th_fqn in sinfo.thunder_compiled_fns:
                     trcs_bw = thunder.last_backward_traces(th_fqn)

--- a/thunder/dynamo/compiler.py
+++ b/thunder/dynamo/compiler.py
@@ -173,6 +173,7 @@ def thunderfx(fn: Callable, /, **kwargs) -> Callable:
                     trcs_bw = thunder.last_backward_traces(th_fqn)
                     if trcs_bw is not None and trcs_bw != []:
                         rv.append(trcs_bw[-1])
+            return rv
 
     c = CompiledObject(backend, compiled)
     return c

--- a/thunder/dynamo/compiler.py
+++ b/thunder/dynamo/compiler.py
@@ -169,7 +169,7 @@ def thunderfx(fn: Callable, /, **kwargs) -> Callable:
             for sinfo in self._backend.subgraph_infos:
                 for th_fqn in sinfo.thunder_compiled_fns:
                     trcs = thunder.last_traces(th_fqn)
-                    if trcs is not None and trcs != []:
+                    if trcs != []:
                         rv.append(trcs[-1])
                     del trcs
             return rv
@@ -189,7 +189,7 @@ def thunderfx(fn: Callable, /, **kwargs) -> Callable:
             for sinfo in self._backend.subgraph_infos:
                 for th_fqn in sinfo.thunder_compiled_fns:
                     trcs_bw = thunder.last_backward_traces(th_fqn)
-                    if trcs_bw is not None and trcs_bw != []:
+                    if trcs_bw != []:
                         rv.append(trcs_bw[-1])
             return rv
 

--- a/thunder/dynamo/compiler.py
+++ b/thunder/dynamo/compiler.py
@@ -164,6 +164,8 @@ def thunderfx(fn: Callable, /, **kwargs) -> Callable:
                       function.
             """
             rv: [Trace] = []
+            if not self._backend.subgraph_infos:
+              warnings.warn("Must invoke the function before using last_traces")
             for sinfo in self._backend.subgraph_infos:
                 for th_fqn in sinfo.thunder_compiled_fns:
                     trcs = thunder.last_traces(th_fqn)
@@ -182,6 +184,8 @@ def thunderfx(fn: Callable, /, **kwargs) -> Callable:
                       function.
             """
             rv: [Trace] = []
+            if not self._backend.subgraph_infos:
+              warnings.warn("last_backward_traces used before function invoked")
             for sinfo in self._backend.subgraph_infos:
                 for th_fqn in sinfo.thunder_compiled_fns:
                     trcs_bw = thunder.last_backward_traces(th_fqn)

--- a/thunder/dynamo/utils.py
+++ b/thunder/dynamo/utils.py
@@ -16,7 +16,6 @@ from thunder.torch.default_torch_ops import torch_auto_registered_ops
 from thunder.torch import _torch_to_thunder_function_map
 from thunder.torch.langctx import torchctx
 from thunder.core.utils import check
-import thunder
 
 if TYPE_CHECKING:
     from thunder.core.symbol import Symbol

--- a/thunder/dynamo/utils.py
+++ b/thunder/dynamo/utils.py
@@ -828,35 +828,3 @@ with record_peak_allocated_memory(benchmark):
 
         if not use_pytest_benchmark:
             print(f"\ntest_{graph_name}()", file=f)
-
-def last_traces(c: Callable) -> str:
-    """
-    Get the Thunder traces for all subgraphs of a ThunderFX callable.
-
-    .. code-block:: python
-
-        def fn(x):
-            return torch.sin(x)
-        func = thunder.dynamo.thunderfx(fn)
-        func(torch.randn((42)))
-        print(thunder.dynamo.last_traces(func))
-
-    .. note:: The Callable `c` must be created by `thunder.dynamo.thunderfx`.
-
-    .. note:: The Callable `c` must be invoked before calling this function.
-    """
-    if getattr(c, '_backend', None) == None:
-        raise ValueError("Not a ThunderFX-compiled function.")
-    rv: str = ""
-    for sinfo in c._backend.subgraph_infos:
-        for th_fqn in sinfo.thunder_compiled_fns:
-            trcs = thunder.last_traces(th_fqn)
-            if trcs is not None and trcs != []:
-                rv += str(trcs[-1])
-            del trcs
-
-            trcs_bw = thunder.last_backward_traces(th_fqn)
-            if trcs_bw is not None and trcs_bw != []:
-                print(f"{trcs_bw=}")
-                rv += str(trcs_bw[-1])
-    return rv

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -994,8 +994,8 @@ def test_thunderfx_last_traces():
     # Call it w/o invoking the function first.
     dfoo = thunderfx(foo)
     with warnings.catch_warnings(record=True) as w:
-      warnings.simplefilter("always")
-      assert dfoo.last_traces == []
-      assert "Must invoke" in str(w[0].message)
-      assert dfoo.last_backward_traces == []
-      assert "before function invoked" in str(w[1].message)
+        warnings.simplefilter("always")
+        assert dfoo.last_traces == []
+        assert "Must invoke" in str(w[0].message)
+        assert dfoo.last_backward_traces == []
+        assert "before function invoked" in str(w[1].message)

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -1011,7 +1011,7 @@ def test_thunderfx_last_traces():
         assert dfoo.last_backward_traces == []
         assert "before function invoked" in str(w[1].message)
 
-        
+
 def test_get_example_input_tensor_metadata():
     from thunder.dynamo.utils import _get_example_input_tensor_metadata
     from torch._subclasses.fake_tensor import FakeTensorMode

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -981,6 +981,7 @@ def test_thunderfx():
     trc = last_traces(thunder_compiled_fns[-1])[-1]
     assert any(bsym.sym.id == "nvtx_range_push" for bsym in trc.bound_symbols)
 
+
 def test_thunderfx_last_traces():
     def foo(x):
         return torch.sin(x) + torch.cos(x)

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -10,7 +10,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 from looseversion import LooseVersion
 
-import thunder
 from thunder import dtypes
 from thunder.dynamo import thunderfx
 from thunder.dynamo.utils import CompilerType

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -994,5 +994,9 @@ def test_thunderfx_last_traces():
 
     # Call it w/o invoking the function first.
     dfoo = thunderfx(foo)
-    assert dfoo.last_traces == []
-    assert dfoo.last_backward_traces == []
+    with warnings.catch_warnings(record=True) as w:
+      warnings.simplefilter("always")
+      assert dfoo.last_traces == []
+      assert "Must invoke" in str(w[0].message)
+      assert dfoo.last_backward_traces == []
+      assert "before function invoked" in str(w[1].message)

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -988,8 +988,8 @@ def test_thunderfx_last_traces():
     x = torch.randn((4, 4))
     cfoo = thunderfx(foo)
     cfoo(x)
-    assert cfoo.last_traces is not ''
+    assert cfoo.last_traces != []
 
     # Call it w/o invoking the function first.
     dfoo = thunderfx(foo)
-    assert thunder.dynamo.last_traces(dfoo) is ''
+    assert dfoo.last_traces == []

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -986,11 +986,13 @@ def test_thunderfx_last_traces():
     def foo(x):
         return torch.sin(x) + torch.cos(x)
 
-    x = torch.randn((4, 4))
+    x = torch.randn((4, 4), requires_grad=True)
     cfoo = thunderfx(foo)
     cfoo(x)
     assert cfoo.last_traces != []
+    assert cfoo.last_backward_traces != []
 
     # Call it w/o invoking the function first.
     dfoo = thunderfx(foo)
     assert dfoo.last_traces == []
+    assert dfoo.last_backward_traces == []

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -988,11 +988,7 @@ def test_thunderfx_last_traces():
     x = torch.randn((4, 4))
     cfoo = thunderfx(foo)
     cfoo(x)
-    assert thunder.dynamo.last_traces(cfoo) is not ''
-
-    # Needs to be a thunderfx function else we give an error.
-    with pytest.raises(ValueError):
-        thunder.dynamo.last_traces(foo)
+    assert cfoo.last_traces is not ''
 
     # Call it w/o invoking the function first.
     dfoo = thunderfx(foo)


### PR DESCRIPTION
I am constantly rewriting this so I thought upstreaming something made sense.

Not married to the implementation, but @t-vi @IvanYashchuk curious for your thoughts on having an explicitly entry point for this?

## What does this PR do?

It adds a new entry point which iterates over all the ThunderFX subgraphs and grabs the trace information.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.