### PR TITLE
[nit] Move redundant due pass

### DIFF
--- a/thunder/common.py
+++ b/thunder/common.py
@@ -649,14 +649,10 @@ def transform_for_execution(
 
     # TODO If only_execute_prims, then flatten to prims here
 
-    # Runs passes that are generally useful
-    dce_trace = dce(trace)
-    traces.append(dce_trace)
-
     # cse_trace = cse(dce_trace)
     # traces.append(cse_trace)
 
-    extrace = executors.passes.transform_for_execution(dce_trace, executors_list)
+    extrace = executors.passes.transform_for_execution(trace, executors_list)
 
     traces.append(extrace)
 

--- a/thunder/executors/passes.py
+++ b/thunder/executors/passes.py
@@ -123,7 +123,7 @@ def transform_for_execution(trace: TraceCtx, executors_list: Sequence[Executor])
     if torch.distributed.is_available():
         # Apply AllReduce bucketing if possible & needed
         from thunder.distributed.transforms.ddp import apply_bucketing_to_grad_allreduce
-
+        trace = dce(trace)
         trace = apply_bucketing_to_grad_allreduce(trace)
 
     trace = dce(trace)


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

`thunder.common.transform_for_execution` contains a redundant dce pass which is immediately followed by another dce pass if no torch.distributed is found. This PR move step first dce pass to precede `apply_bucketing_to_grad_allreduce` to avoid this redundancy

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
