### PR TITLE
fix no_grad and torch.ops.higher_order.autograd_function_apply interaction

### DIFF
--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -815,7 +815,10 @@ def _general_jit_torch_ops_higher_order_autograd_function_apply(fwd, bwd, *fwd_a
     with tracectx(trace_of_forward):
         prims.python_return(*(sequencify(output)))
 
+    # See NOTE: `autograd_function_apply` and `no_grad` interaction for details about
+    # `thunder.torch.call_higher_order_function_and_consider_outer_autograd_setting`
     @wraps(aug_fwd_trace.python_callable())
+    @thunder.torch.call_higher_order_function_and_consider_outer_autograd_setting
     def forward(*args, **kwargs):
         return interpret_trace(trace_of_forward, *args, **kwargs)
 


### PR DESCRIPTION
Fixes #1612 

As pointed in the [comment](https://github.com/Lightning-AI/lightning-thunder/pull/1463#discussion_r1905451508), the lookaside for `torch.ops.higher_order.autograd_function_apply` is handled seperately. We apply the `call_higher_order_function_and_consider_outer_autograd_setting` in the lookaside as well (with some changes).