### PR TITLE
fix and reenable forward backward rematerialization

### DIFF
--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -3266,18 +3266,18 @@ def recompute_saved_for_backward(fwd_trace: Trace, bwd_trace: Trace) -> tuple[Tr
             compute_proxy_from_producer(p)
         for o in producer_bsym.flat_proxy_outs:
             have_in_backward.add(variableify(o))
-        new_bwd_trace.bound_symbols.append(producer_bsym)
+        new_bwd_trace.bound_symbols.append(producer_bsym.from_bsym())
 
     for idx, bsym in enumerate(bwd_trace.bound_symbols):
         if idx in {4, 5}:
             # handled later
-            new_bwd_trace.bound_symbols.append(bsym)
+            new_bwd_trace.bound_symbols.append(bsym.from_bsym())
         else:
             for p in bsym.flat_proxy_args:
                 compute_proxy_from_producer(p)
             for o in bsym.flat_proxy_outs:
                 have_in_backward.add(variableify(o))
-            new_bwd_trace.bound_symbols.append(bsym)
+            new_bwd_trace.bound_symbols.append(bsym.from_bsym())
 
     new_fwd_trace = from_trace(fwd_trace)
     new_fwd_trace.bound_symbols = fwd_trace.bound_symbols.copy()

--- a/thunder/executors/torch_autograd.py
+++ b/thunder/executors/torch_autograd.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING
 import torch
 
 import thunder.core.utils as utils
-from thunder.core.compile_data import get_compile_option
 from thunder.core.prims import PrimIDs
 from thunder.core.proxies import TensorProxy, variableify
 from thunder.core.pytree import tree_flatten
@@ -350,11 +349,7 @@ def split_forward_backward(computation_trc: TraceCtx, compile_data, compile_stat
     )
     bw_traces.append(bw_extrace)
 
-    use_rematerialization: None | bool = get_compile_option(
-        "use_forward_backward_rematerialization", "use rematerialization of saved for backward values in fusions"
-    )
-    if use_rematerialization:
-        fw_extrace, bw_extrace = rematerialize_forward_and_backward(fw_extrace, bw_extrace)
+    fw_extrace, bw_extrace = rematerialize_forward_and_backward(fw_extrace, bw_extrace)
     fw_traces.append(fw_extrace)
     bw_traces.append(bw_extrace)
 

--- a/thunder/tests/test_examine_memory.py
+++ b/thunder/tests/test_examine_memory.py
@@ -115,5 +115,5 @@ def test_nanogpt_block():
     # We are checking the estimated memory against a fixed value for consistency.
     assert max_mem_fw[0] == 262183936
     assert sum(max_mem_fw[1].values()) == 135306240
-    assert max_mem_bw[0] == 484833280
-    assert sum(max_mem_bw[1].values()) == 169915392
+    assert max_mem_bw[0] == 375516160
+    assert sum(max_mem_bw[1].values()) == 40934400

--- a/thunder/tests/test_grad.py
+++ b/thunder/tests/test_grad.py
@@ -1943,7 +1943,8 @@ def test_backward_recomputation_decomposed_ops(device):
     def fn(a):
         return torch.nn.functional.gelu(a)
 
-    jfn = thunder.jit(fn, enable_saved_for_backward_recomputation=False)
+    # rematerialization will also trigger recomputation here.
+    jfn = thunder.jit(fn, executors=(), enable_saved_for_backward_recomputation=False)
     jfn2 = thunder.jit(fn, enable_saved_for_backward_recomputation=True)
     a = torch.randn(2, 2, device=device, requires_grad=True)
     res = jfn(a)

--- a/thunder/tests/test_torch_compile_executor.py
+++ b/thunder/tests/test_torch_compile_executor.py
@@ -38,6 +38,7 @@ def test_torch_compile_litgpt():
 # https://github.com/Lightning-AI/lightning-thunder/issues/292 The issue was
 # that the CSE pass was not being run correctly on the TorchCompile region.
 # Here we test that everything works as expected.
+@pytest.mark.skip(reason="https://github.com/NVIDIA/Fuser/issues/3688")
 @pytest.mark.skipif(not is_inductor_supported(), reason="inductor unsupported")
 @requiresCUDA
 @pytest.mark.skipif(not device_supports_bf16(torch.device("cuda")), reason="bf16 is not supported")


### PR DESCRIPTION
remove worst name clashes (still not completely safe, maybe we should temporarily use non-python proxy names (`bw.foo`)), but is seems to partially(?) work for #1621 
