### PR TITLE
TE: disable recomputing in backward

### DIFF
--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -291,6 +291,8 @@ class OpTags(Enum):
     AUTO_REGISTERED = auto()
     # Label for operations representing enter/exit of context managers.
     CTX_MANAGER_ENTER_EXIT_OP = auto()
+    # Label to explicitly disable an operation from recomputing in backward - see function `recompute_saved_for_backward`.
+    DONT_RECOMPUTE_IN_BACKWARD = auto()
 
 
 # TODO RC1 Document this function and describe the parts of a primitive

--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -3220,7 +3220,9 @@ def recompute_saved_for_backward(fwd_trace: Trace, bwd_trace: Trace) -> tuple[Tr
 
             proxy_names_to_producers[o.name] = bsym
             all_proxies.add(vo)
-            if ProxyTag.RECOMPUTE_IN_BACKWARD in o.tags and not has_tags(bsym, {prims.OpTags.RANDOM_OP}):
+            if ProxyTag.RECOMPUTE_IN_BACKWARD in o.tags and not has_tags(
+                bsym, {prims.OpTags.RANDOM_OP, prims.OpTags.DONT_RECOMPUTE_IN_BACKWARD}
+            ):
                 all_recomputable_proxies.add(vo)
 
     rematerializable = old_saved_for_bwd & all_recomputable_proxies

--- a/thunder/executors/transformer_engineex.py
+++ b/thunder/executors/transformer_engineex.py
@@ -438,7 +438,12 @@ def _create_fp8_linear_bound_symbol(
 
     meta_fn = make_te_linear_meta(is_grad_enabled=is_grad_enabled)
     sym = Symbol(
-        name=name, meta=meta_fn, is_prim=True, executor=transformer_engine_ex, _bind_postprocess=bind_postprocess
+        name=name,
+        meta=meta_fn,
+        is_prim=True,
+        executor=transformer_engine_ex,
+        _bind_postprocess=bind_postprocess,
+        tags=(prims.OpTags.DONT_RECOMPUTE_IN_BACKWARD,),
     )
     bsym = sym.bind(a, w, b, output=meta_fn(a, w, b))
 


### PR DESCRIPTION
Fixes #1624 

This PR adds a new `OpTag.DONT_RECOMPUTE_IN_BACKWARD` to explicitly disable recomputing in backward. Also, updates the symbol created by TE executor to be tagged with the new tag.

Tested with `test_transformer_engine_executor.py`.