### PR TITLE
TE: avoid proxy name clash

### DIFF
--- a/thunder/core/proxies.py
+++ b/thunder/core/proxies.py
@@ -393,8 +393,17 @@ class Proxy(VariableInterface, ProxyInterface):
 # Unlike many other proxies, this does not mimic the type of the object it wraps
 # TODO RC1 Rename ._o to ._value for consistency
 class AnyProxy(Proxy):
-    def __init__(self, o: Any, /, *, name: str | None = None, history: None | tuple = None, tags: set | None = None):
-        super().__init__(name=name, history=history, tags=tags)
+    def __init__(
+        self,
+        o: Any,
+        /,
+        *,
+        prefix: str | None = None,
+        name: str | None = None,
+        history: None | tuple = None,
+        tags: set | None = None,
+    ):
+        super().__init__(prefix=prefix, name=name, history=history, tags=tags)
         self._o = o
 
     def __repr__(self) -> str:

--- a/thunder/executors/transformer_engineex.py
+++ b/thunder/executors/transformer_engineex.py
@@ -327,7 +327,7 @@ def make_te_linear_meta(is_grad_enabled: bool = False):
         output_shape[-1] = w.shape[0]
         if is_grad_enabled:
             global LINEAR_CALLS_COUNTER
-            ctx_dict = AnyProxy(object(), name=f"ctx_te_{LINEAR_CALLS_COUNTER}")
+            ctx_dict = AnyProxy(object(), prefix=f"ctx_te_{LINEAR_CALLS_COUNTER}")
 
             # It's not critical to model the exact shape and dtype of
             # saved_tensors since they are not used in Thunder's meta functions.


### PR DESCRIPTION
With https://github.com/Lightning-AI/lightning-thunder/pull/1596, seeing the following errors
```python
================================================================================================================================================ short test summary info =================================================================================================================================================
FAILED thunder/tests/distributed/test_fsdp.py::test_fsdp_transformer_engine_bucketing_torch_cuda_thunder.dtypes.float32[thunder_fsdp_strategy_and_bucketing0] - RuntimeError: Trying to add the name ctx_te_30 to a trace, but that name is already used
FAILED thunder/tests/distributed/test_fsdp.py::test_fsdp_transformer_engine_bucketing_torch_cuda_thunder.dtypes.float32[thunder_fsdp_strategy_and_bucketing1] - RuntimeError: Trying to add the name ctx_te_30 to a trace, but that name is already used
=========================================================================================================================================== 2 failed, 55 deselected in 32.73s ============================================================================================================================================
```

<details>

<summary> Error Trace </summary>

```python
Traceback (most recent call last):
  File "/usr/lib/python3.12/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
                    ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/multiprocessing/pool.py", line 48, in mapstar
    return list(map(*args))
           ^^^^^^^^^^^^^^^^
  File "/opt/pytorch/lightning-thunder/thunder/tests/distributed/test_fsdp.py", line 1035, in _test_fsdp_transformer_engine_bucketing
    raise e
  File "/opt/pytorch/lightning-thunder/thunder/tests/distributed/test_fsdp.py", line 1023, in _test_fsdp_transformer_engine_bucketing
    out = jit_model(x, y).sum()
          ^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1740, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1751, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pytorch/lightning-thunder/thunder/core/module.py", line 80, in forward
    res = self._forward_fn(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pytorch/lightning-thunder/thunder/__init__.py", line 741, in wrapped
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/opt/pytorch/lightning-thunder/thunder/__init__.py", line 777, in fn_
    cache_entry, inps, pro_to_epi = get_computation_and_inputs(*args, **kwargs)
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pytorch/lightning-thunder/thunder/__init__.py", line 723, in wrapped
    cache_entry, inps, pro_to_epi = get_computation_and_inputs_fn(*args, **kwargs)
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pytorch/lightning-thunder/thunder/core/langctxs.py", line 136, in _fn
    result = fn(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^
  File "/opt/pytorch/lightning-thunder/thunder/__init__.py", line 235, in cache_info_wrapper
    res = fn(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^
  File "/opt/pytorch/lightning-thunder/thunder/__init__.py", line 629, in get_computation_and_inputs
    computation_trc, backward_trc = split_forward_backward(computation_trc, cd, cs, *inps)
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pytorch/lightning-thunder/thunder/executors/torch_autograd.py", line 271, in split_forward_backward
    fw_trace = _fsdp_comm_bucketing.apply_bucketing_to_forward_trace(fw_trace)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pytorch/lightning-thunder/thunder/distributed/transforms/fsdp.py", line 576, in apply_bucketing_to_forward_trace
    new_trace = visitor_transform(
                ^^^^^^^^^^^^^^^^^^
  File "/opt/pytorch/lightning-thunder/thunder/core/transforms.py", line 413, in visitor_transform
    visit_type = visit(bsym)
                 ^^^^^^^^^^^
  File "/opt/pytorch/lightning-thunder/thunder/distributed/transforms/fsdp.py", line 330, in __call__
    if not (bsym_updated := maybe_swap_proxies_of_bsym_and_update_swap_map(bsym)):
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pytorch/lightning-thunder/thunder/distributed/transforms/fsdp.py", line 244, in maybe_swap_proxies_of_bsym_and_update_swap_map
    updated_output = new_bsym.sym(*new_bsym.args, **new_bsym.kwargs)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pytorch/lightning-thunder/thunder/core/symbol.py", line 319, in __call__
    result = self.meta(*args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pytorch/lightning-thunder/thunder/executors/transformer_engineex.py", line 330, in _te_functional_linear_meta
    ctx_dict = AnyProxy(object(), name=f"ctx_te_{LINEAR_CALLS_COUNTER}")
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pytorch/lightning-thunder/thunder/core/proxies.py", line 397, in __init__
    super().__init__(name=name, history=history, tags=tags)
  File "/opt/pytorch/lightning-thunder/thunder/core/proxies.py", line 135, in __init__
    self._name = make_proxy_name(name=name, prefix=prefix)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pytorch/lightning-thunder/thunder/core/proxies.py", line 85, in make_proxy_name
    return trc.make_name(name=name, prefix=prefix)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/pytorch/lightning-thunder/thunder/core/trace.py", line 223, in make_name
    self.add_name(name)
  File "/opt/pytorch/lightning-thunder/thunder/core/trace.py", line 181, in add_name
    baseutils.check(
  File "/opt/pytorch/lightning-thunder/thunder/core/baseutils.py", line 146, in check
    raise exception_type(s())
RuntimeError: Trying to add the name ctx_te_30 to a trace, but that name is already used
```

</details>


Fix - We specify `prefix` while creating `AnyProxy` so that we can create a similar named proxy in the same trace (This is required for FSDP + Bucketing path).

Post the fix, failings tests pass again.