### PR TITLE
Disable enable_saved_for_backward_recomputation path by default

### DIFF
--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -3160,8 +3160,6 @@ def forward_and_backward_from_trace(trace: Trace, torch_autograd=False) -> Forwa
     enable_saved_for_backward_recomputation: None | bool = get_compile_option(
         "enable_saved_for_backward_recomputation", "Enable save for backward tensors recomputation."
     )
-    if enable_saved_for_backward_recomputation is None or remat_policy:
-        enable_saved_for_backward_recomputation = True
     if enable_saved_for_backward_recomputation:
         forward_trace, backward_trace = recompute_saved_for_backward(forward_trace, backward_trace)
 

--- a/thunder/tests/test_transforms.py
+++ b/thunder/tests/test_transforms.py
@@ -375,7 +375,7 @@ def test_saved_for_backward_recomputation():
     model = MyModel()
 
     # Do not recompute anything
-    jmodel = thunder.jit(model)
+    jmodel = thunder.jit(model, enable_saved_for_backward_recomputation=True)
     jmodel(a)
 
     fwd_trace = None


### PR DESCRIPTION
Let's wait a bit before using the changes introduced in #1615 by default. The feature is available by passing `enable_saved_for_backward_recomputation=True` to thunder.jit.

Disabling auto-recomputation as suggested in https://github.com/Lightning-AI/lightning-thunder/issues/1658#issuecomment-2599598645.