### PR TITLE
Add an option to be able to disable replace_uniform

### DIFF
--- a/thunder/core/rematerialization.py
+++ b/thunder/core/rematerialization.py
@@ -756,6 +756,14 @@ def rematerialize_forward_and_backward(fw_trace: TraceCtx, bw_trace: TraceCtx) -
 
 def replace_uniform(trace: TraceCtx) -> TraceCtx:
     """For better rematerialization, replace the uniform operator with the stateless uniform_philox operator and manually update the RNG state."""
+    from thunder.core.compile_data import get_compile_option
+
+    disable_replace_uniform: None | bool = get_compile_option(
+        "disable_replace_uniform", "Disables the replace_uniform transform to avoid dropout rematerialization"
+    )
+    if disable_replace_uniform:
+        return trace
+
     start_time_ns = time.perf_counter_ns()
     from thunder.core.trace import VariableInterface
     from thunder.core.proxies import Proxy


### PR DESCRIPTION
Currently, Thunder decomposes Dropout into recomputation operations and rematerializes it in the nvFuser fusions in backward computations. 

For easier experimentation what would the performance look like without dropout recomputation an option to disable the pass is added in this PR.

It's one of the requests from https://github.com/Lightning-AI/lightning-thunder/issues/1658.

cc @t-vi