### PR TITLE
disable auto-recompute

### DIFF
--- a/thunder/tests/test_examine_memory.py
+++ b/thunder/tests/test_examine_memory.py
@@ -113,7 +113,7 @@ def test_nanogpt_block():
 
     # Actual memory usage may vary depending on hardware and cuBLAS settings.
     # We are checking the estimated memory against a fixed value for consistency.
-    assert max_mem_fw[0] == 293641216
-    assert sum(max_mem_fw[1].values()) == 249601024
-    assert max_mem_bw[0] == 399633408
+    assert max_mem_fw[0] == 381754368
+    assert sum(max_mem_fw[1].values()) == 375462912
+    assert max_mem_bw[0] == 437292032
     assert sum(max_mem_bw[1].values()) == 40934400

--- a/thunder/tests/test_grad.py
+++ b/thunder/tests/test_grad.py
@@ -1943,8 +1943,8 @@ def test_backward_recomputation_decomposed_ops(device):
         return torch.nn.functional.gelu(a)
 
     # rematerialization will also trigger recomputation here.
-    jfn = thunder.jit(fn, executors=(), enable_saved_for_backward_recomputation=False)
-    jfn2 = thunder.jit(fn, enable_saved_for_backward_recomputation=True)
+    jfn = thunder.jit(fn, executors=())
+    jfn2 = thunder.jit(fn, auto_recompute_intermediates=True)
     a = torch.randn(2, 2, device=device, requires_grad=True)
     res = jfn(a)
     res2 = jfn2(a)


### PR DESCRIPTION
To unblock #1658 , as a replacement for #1659 

@IvanYashchuk this si what I had in mind, not #1659. LMK if that also does the trick for you.

P.S.: @riccardofelluga @IvanYashchuk  I'd be keen to remove the recompute for backward options from Riccardo's original checkpointing. Do you still need them?