### PR TITLE
cast result of sequence multiplication

### DIFF
--- a/thunder/core/interpreter.py
+++ b/thunder/core/interpreter.py
@@ -2181,13 +2181,17 @@ class SequenceWrapperMethods(WrappedValue):
             l = []
             for _ in range(n):
                 l.extend(self)
-            return l
+            return type(self)(l)
 
         return _interpret_call(impl, self, n)
 
     def __rmul__(self, n, /):
         self.track_items()
-        return self.__mul__(n)
+
+        def impl(self, n):
+            return self.__mul__(n)
+
+        return _interpret_call(impl, self, n)
 
     def __len__(self):
         self.track_items()

--- a/thunder/tests/test_interpreter.py
+++ b/thunder/tests/test_interpreter.py
@@ -3501,3 +3501,17 @@ def test_freeing_of_tensors():
         foo(i)
 
     assert l == ["run 0", "free 0", "run 1", "free 1", "run 2", "free 2"]
+
+
+def test_tuple_mul():
+
+    def fn(x):
+        d = x.dim() + 3
+        return x.shape[0:2] + (1,) * d + x.shape[2:]
+
+    jfn = thunder.jit(fn)
+    x = torch.randn(2, 2, 3, 3)
+
+    res = jfn(x)
+    expected = fn(x)
+    assert_close(res, expected)


### PR DESCRIPTION
before, we would implicitly cast to list, which is not what we want.