### PR TITLE
Default `recipe` to None in compile entrypoint

### DIFF
--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -267,7 +267,7 @@ CacheEntry = namedtuple(
 )
 
 
-def compile(fn: Callable, recipe: Recipe | None):
+def compile(fn: Callable, recipe: Recipe | None = None):
     if recipe is None:
         return thunder.jit(fn)
 


### PR DESCRIPTION
## What does this PR do?

Improves `thunder.compile` entry point when there's no need for a recipe (before it was a required argument.

Before:

```python
compiled_model = thunder.compile(model, recipe=None)
```

After:

```python
compiled_model = thunder.compile(model)
```

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
