### PR TITLE
Add _native_mult_head_attention to auto registered ops

### DIFF
--- a/thunder/torch/default_torch_ops.py
+++ b/thunder/torch/default_torch_ops.py
@@ -2,6 +2,7 @@ import torch
 
 torch_auto_registered_ops = {
     torch: [
+        torch._native_multi_head_attention,
         torch.lobpcg,
         torch.unravel_index,
         torch.absolute,


### PR DESCRIPTION
## What does this PR do?

Fixes support for ViT from torchvision.

```python
import torch
import torchvision.models as models

import thunder

with torch.device("cuda:0"):
    model = models.vit_b_16().requires_grad_(False).eval()
    x = torch.randn(128, 3, 224, 224)

compiled_model = thunder.compile(model)

y = compiled_model(x)
```

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
