### PR TITLE
increase tolerance on bf16 layernorm

### DIFF
--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -7868,6 +7868,11 @@ if LooseVersion(torch.__version__) >= "2.4":
                 dtypes=(datatypes.float16,),
                 devicetypes=(devices.DeviceType.CUDA,),
             ),
+            DecorateInfo(
+                custom_comparator(partial(assert_close, atol=1e-1, rtol=2e-2)),
+                dtypes=(datatypes.bfloat16,),
+                devicetypes=(devices.DeviceType.CUDA,),
+            ),
         ),
     )
     nn_ops.append(rms_norm_opinfo)

--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -7871,7 +7871,6 @@ if LooseVersion(torch.__version__) >= "2.4":
             DecorateInfo(
                 custom_comparator(partial(assert_close, atol=1e-1, rtol=2e-2)),
                 dtypes=(datatypes.bfloat16,),
-                devicetypes=(devices.DeviceType.CUDA,),
             ),
         ),
     )


### PR DESCRIPTION
the results seems to have changed in PyTorch nightly, so we get CI flakes, hopefully this avoids them.