### PR TITLE
add information about unpacked element from prims.unpack_sequence

### DIFF
--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -878,6 +878,10 @@ def unpack_sequence_printer(
     parts.append(f"= {call_str}")
 
     lines = _make_parts_into_line_or_lines(parts)
+    # Add info about the unpacked elements as comments
+    for out in out_printables:
+        details = _make_parts_into_line_or_lines([f"# {codeutils.prettyprint(out, with_type=True)}"])
+        lines.extend(details)
     return lines
 
 


### PR DESCRIPTION
Fixes #1635 

Example 
```python
import thunder
import torch

def fn(x):
    return x.sin()

jfn = thunder.jit(fn)
jfn(torch.randn(3, requires_grad=True))

backward_trc = thunder.last_backward_traces(jfn)[-1]
print(backward_trc)
```

Backward before PR
```python
def backward_fn(saved_for_backward, cotangents):
  # saved_for_backward: "Collection"
  # cotangents: "Collection"
  C0, _, = saved_for_backward
  clear_mutable_collection(saved_for_backward)
  del saved_for_backward
  t2, = cotangents
  clear_mutable_collection(cotangents)
  del cotangents
  x, = C0
  clear_mutable_collection(C0)
  del C0
  bw_t6 = torch.cos(x)  # bw_t6: "cpu f32[3]"
    # bw_t6 = ltorch.cos(x)  # bw_t6: "cpu f32[3]"
      # bw_t6 = prims.cos(x)  # bw_t6: "cpu f32[3]"
  del x
  bw_t7 = torch.mul(t2, bw_t6)  # bw_t7: "cpu f32[3]"
    # bw_t7 = ltorch.mul(t2, bw_t6)  # bw_t7: "cpu f32[3]"
      # bw_t7 = prims.mul(t2, bw_t6)  # bw_t7: "cpu f32[3]"
  del t2, bw_t6
  return (bw_t7,)
```

Backward after PR
```python
@torch.no_grad()
@no_autocast
def backward_fn(saved_for_backward, cotangents):
  # saved_for_backward: "Collection"
  # cotangents: "Collection"
  C0, _, = saved_for_backward
  # C0: "Collection"
  # None
  clear_mutable_collection(saved_for_backward)
  del saved_for_backward
  t2, = cotangents
  # t2: "cpu f32[3]"
  clear_mutable_collection(cotangents)
  del cotangents
  x, = C0
  # x: "cpu f32[3]"
  clear_mutable_collection(C0)
  del C0
  bw_t6 = torch.cos(x)  # bw_t6: "cpu f32[3]"
    # bw_t6 = ltorch.cos(x)  # bw_t6: "cpu f32[3]"
      # bw_t6 = prims.cos(x)  # bw_t6: "cpu f32[3]"
  del x
  bw_t7 = torch.mul(t2, bw_t6)  # bw_t7: "cpu f32[3]"
    # bw_t7 = ltorch.mul(t2, bw_t6)  # bw_t7: "cpu f32[3]"
      # bw_t7 = prims.mul(t2, bw_t6)  # bw_t7: "cpu f32[3]"
  del t2, bw_t6
  return (bw_t7,)
```