### PR TITLE
Embedding support for nvfuser in inference

### DIFF
--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -1471,7 +1471,6 @@ def _get_gradfn_and_executor(
     bsym: BoundSymbol, *, executors_list: Sequence[Any] = tuple()
 ) -> tuple[Callable | None, Executor | None]:
     cd = get_compile_data()
-    breakpoint()
     executors_list = cd.executors_list if cd is not None else executors_list
     # Checks if the executor which has priority for this operation has a specific grad transform for it
     for ex in executors_list:

--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -1471,6 +1471,7 @@ def _get_gradfn_and_executor(
     bsym: BoundSymbol, *, executors_list: Sequence[Any] = tuple()
 ) -> tuple[Callable | None, Executor | None]:
     cd = get_compile_data()
+    breakpoint()
     executors_list = cd.executors_list if cd is not None else executors_list
     # Checks if the executor which has priority for this operation has a specific grad transform for it
     for ex in executors_list:

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -2595,15 +2595,16 @@ ex.register_supported(
     grad_transform=scaled_dot_product_flash_attention_grad,
 )
 
+
 def _embedding_check(
-  input: TensorProxy, 
-  weight: TensorProxy,
-  padding_idx: None | int,
-  max_norm: None | float,
-  norm_type: None | float,
-  scale_grad_by_freq: None | bool,
-  sparse: None | bool,
-  ) -> bool:
+    input: TensorProxy,
+    weight: TensorProxy,
+    padding_idx: None | int,
+    max_norm: None | float,
+    norm_type: None | float,
+    scale_grad_by_freq: None | bool,
+    sparse: None | bool,
+) -> bool:
     if nvfuser_version() < LooseVersion("0.2.25"):
         return False
     enable_embedding: None | bool = get_compile_option("nv_enable_embedding", "Enable nvFuser embedding.")
@@ -2616,7 +2617,7 @@ def _embedding_check(
 
 
 def embedding(
-    input: TensorProxy, 
+    input: TensorProxy,
     weight: TensorProxy,
     padding_idx: None | int = None,
     max_norm: None | float = None,
@@ -2633,6 +2634,7 @@ def embedding(
         nv_inp = getnv(inp, fd, lc_to_nv_map) if inp is not None else None
         nv_inputs.append(nv_inp)
     return fd.ops.embedding_fwd(*nv_inputs)
+
 
 register_supported(PrimIDs.EMBEDDING, embedding, _embedding_check)
 register_supported(ltorch.embedding, embedding, _embedding_check)

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -2593,3 +2593,45 @@ ex.register_supported(
     execution_transform=scaled_dot_product_flash_attention,
     grad_transform=scaled_dot_product_flash_attention_grad,
 )
+
+def _embedding_check(
+  input: TensorProxy, 
+  weight: TensorProxy,
+  padding_idx: None | int,
+  max_norm: None | float,
+  norm_type: None | float,
+  scale_grad_by_freq: None | bool,
+  sparse: None | bool,
+  ) -> bool:
+    if nvfuser_version() < LooseVersion("0.2.25"):
+        return False
+    enable_embedding: None | bool = get_compile_option("nv_enable_embedding", "Enable nvFuser embedding.")
+    breakpoint()
+    if not enable_embedding:
+        return False
+    # Verify input and weight are supported tensors.
+    if not are_supported_tensors(input, weight) or (weight.ndim != 2):
+        return False
+    return True
+
+
+def embedding(
+    input: TensorProxy, 
+    weight: TensorProxy,
+    padding_idx: None | int = None,
+    max_norm: None | float = None,
+    norm_type: None | float = 2.0,
+    scale_grad_by_freq: None | bool = False,
+    sparse: None | bool = False,
+    *
+    fd: FusionDefinition,
+    lc_to_nv_map: dict,
+) -> Any:
+    inputs = [input, weight, padding_idx, max_norm, norm_type, scale_grad_by_freq, sparse]
+    nv_inputs = []
+    for inp in inputs:
+        nv_inp = getnv(inp, fd, lc_to_nv_map) if inp is not None else None
+        nv_inputs.append(nv_inp)
+    return fd.ops.embedding(*nv_inputs)
+
+register_supported(PrimIDs.EMBEDDING, embedding, _embedding_check)

--- a/thunder/tests/test_nvfuser.py
+++ b/thunder/tests/test_nvfuser.py
@@ -40,6 +40,7 @@ from thunder.tests.opinfos import (
     get_opinfo,
     linear_opinfo,
     matmul_opinfo,
+    embedding_opinfo
 )
 from looseversion import LooseVersion
 
@@ -1167,46 +1168,23 @@ def test_no_shape_only_fusion_region(executor, device: str, thunder_dtype: dtype
             nvfuser_version() is None or nvfuser_version() < LooseVersion("0.2.25"),
             reason="Requires nvFuser version 0.2.25 or later",
         ),
-        # pytest.mark.skipif(
-        #     torch.cuda.is_available() and torch.cuda.get_device_capability(0)[0] < 9,
-        #     reason="Requires CUDA compute capability >= 9.0",
-        # ),
-        # pytest.mark.parametrize("dropout_p", [0.0, 0.2]),
-        # pytest.mark.parametrize("is_causal", [False, True]),
-        # pytest.mark.parametrize("scale", [None, 1e-3]),
     ),
 )
 def test_embedding(
     executor,
     device: str,
-    thunder_dtype: dtypes.dtype,
-    # dropout_p: None | float,
-    # is_causal: None | bool,
-    # scale: None | float,
+    dtype: dtypes.dtype,
 ):
 
-    def embedding_fn(input, weight):
-        return torch.nn.functional.embedding(
-            input, weight
-        )
+    def embedding_fn(inputs):
+        return torch.nn.functional.embedding(*inputs)
 
-    # torch.manual_seed(0)
-    dtype = ltorch.to_torch_dtype(thunder_dtype)
+    for sample in embedding_opinfo.sample_inputs(device, dtype):
+      compiled_func = thunder.jit(embedding_fn, executors_list=executor.executors_list(), nv_enable_embedding=True)
+      out = compiled_func(sample.args)
+      expected_out = torch.nn.functional.embedding(*sample.args)
+      fwd_trace = thunder.last_traces(compiled_func)[-1]
+      fwd_fusion = examine.get_fusions(fwd_trace)
 
-    N, S = 10, 3
-    input = torch.randint(N, (S,), dtype=torch.int64, device='cuda', requires_grad=False)
-    weight = torch.randn(N, S, dtype=torch.bfloat16, device='cuda', requires_grad=True)
-    grad_out = torch.randn(S, S, dtype=torch.bfloat16, device='cuda')
-
-    compiled_func = thunder.jit(embedding_fn, executors_list=executor.executors_list(), nv_enable_embedding=True)
-    out = compiled_func(input, weight)
-    # out.backward(grad_out)
-    fwd_trace = thunder.last_traces(compiled_func)[-1]
-    breakpoint()
-    # bwd_trace = thunder.last_backward_traces(compiled_func)[-1]
-    fwd_fusion = examine.get_fusions(fwd_trace)
-    # bwd_fusion = examine.get_fusions(bwd_trace)
-
-    # assert len(fwd_fusion) == 1
-    # assert len(bwd_fusion) == 1
-    print (fwd_trace)
+      assert len(fwd_fusion) == 1
+      

--- a/thunder/tests/test_nvfuser.py
+++ b/thunder/tests/test_nvfuser.py
@@ -1187,4 +1187,5 @@ def test_embedding(
       fwd_fusion = examine.get_fusions(fwd_trace)
 
       assert len(fwd_fusion) == 1
+      torch.testing.assert_close(out, expected_out)
       

--- a/thunder/tests/test_nvfuser.py
+++ b/thunder/tests/test_nvfuser.py
@@ -1161,7 +1161,7 @@ def test_no_shape_only_fusion_region(executor, device: str, thunder_dtype: dtype
 
 
 @instantiate(
-    dtypes=(thunder.float16,),
+    dtypes=(thunder.float16, thunder.bfloat16),
     devicetypes=(devices.DeviceType.CUDA,),
     executors=(nvFuserExecutor,),
     decorators=(

--- a/thunder/tests/test_nvfuser.py
+++ b/thunder/tests/test_nvfuser.py
@@ -40,7 +40,7 @@ from thunder.tests.opinfos import (
     get_opinfo,
     linear_opinfo,
     matmul_opinfo,
-    embedding_opinfo
+    embedding_opinfo,
 )
 from looseversion import LooseVersion
 
@@ -1159,8 +1159,9 @@ def test_no_shape_only_fusion_region(executor, device: str, thunder_dtype: dtype
     # Make sure there is a fusion symbol.
     assert any(bsym.sym.is_fusion for bsym in fwd_trace.bound_symbols)
 
+
 @instantiate(
-    dtypes=(thunder.float16, ),
+    dtypes=(thunder.float16,),
     devicetypes=(devices.DeviceType.CUDA,),
     executors=(nvFuserExecutor,),
     decorators=(
@@ -1180,12 +1181,11 @@ def test_embedding(
         return torch.nn.functional.embedding(*inputs)
 
     for sample in embedding_opinfo.sample_inputs(device, dtype):
-      compiled_func = thunder.jit(embedding_fn, executors_list=executor.executors_list(), nv_enable_embedding=True)
-      out = compiled_func(sample.args)
-      expected_out = torch.nn.functional.embedding(*sample.args)
-      fwd_trace = thunder.last_traces(compiled_func)[-1]
-      fwd_fusion = examine.get_fusions(fwd_trace)
+        compiled_func = thunder.jit(embedding_fn, executors_list=executor.executors_list(), nv_enable_embedding=True)
+        out = compiled_func(sample.args)
+        expected_out = torch.nn.functional.embedding(*sample.args)
+        fwd_trace = thunder.last_traces(compiled_func)[-1]
+        fwd_fusion = examine.get_fusions(fwd_trace)
 
-      assert len(fwd_fusion) == 1
-      torch.testing.assert_close(out, expected_out)
-      
+        assert len(fwd_fusion) == 1
+        torch.testing.assert_close(out, expected_out)


### PR DESCRIPTION
This PR enables nvfuser to accept the embedding operator for the forward pass.
Since Thunder uses `prims.TAKE` instead of `prims.EMBEDDING` in certain cases, the nvfuser operator is also registered against `ltorch.embedding`. For backward pass, a separate operator would need to be registered against `ltorch.embedding_backward`.