### PR TITLE
don't create dataclass instances in dataclass_new meta

### DIFF
--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -1295,7 +1295,8 @@ pack_setitem = make_prim(
 
 
 def python_dataclass_new_meta(typ, **kwargs):
-    return AnyProxy(typ(**kwargs))
+    # we are cheating here, but instantiating a dataclass can be wild. typ(**kwargs)
+    return AnyProxy(None)
 
 
 def python_dataclass_new_printer(

--- a/thunder/tests/test_jit_general.py
+++ b/thunder/tests/test_jit_general.py
@@ -1549,3 +1549,17 @@ def test_cache_symbolic_values_dict():
     expected = foo(b, "b")
 
     assert_close(actual, expected)
+
+
+def test_specific_dataclass_returns():
+    import transformers
+
+    def fn(x):
+        return transformers.modeling_outputs.BaseModelOutputWithPast(last_hidden_state=x)
+
+    jfn = thunder.jit(fn)
+    x = torch.randn(2, 2)
+    expected = fn(x)
+    res = jfn(x)
+    assert expected.last_hidden_state is x
+    assert res.last_hidden_state is x


### PR DESCRIPTION
Dataclasses can do wild things in their `__post_init__`, so it is better to be careful there.