### PR TITLE
Add utility function to benchmark performance of fusion region with nvfuser and torch.compile

### DIFF
--- a/thunder/dev_utils/utils.py
+++ b/thunder/dev_utils/utils.py
@@ -1,4 +1,9 @@
+import collections
+
+from torch.utils.benchmark import Timer
 from thunder.core.prims import PrimIDs
+from thunder.core.symbol import BoundSymbol
+from thunder.executors.torch_compile import make_compiled as make_torch_compile_callable
 
 NON_COMPUTATION_PRIMS = (
     PrimIDs.ASSERT_TENSOR_METADATA,
@@ -36,3 +41,77 @@ NON_COMPUTATION_PRIMS = (
     PrimIDs.PRINT,
     PrimIDs.RETURN,
 )
+
+BenchmarkComparisonData = collections.namedtuple(
+    "BenchmarkComparisonData",
+    [
+        "nvfuser_walltime",
+        "torch_compile_walltime",
+        "nvfuser_kernel_time",
+        "torch_compile_kernel_time",
+        "nvfuser_profiler_data",
+    ],
+)
+
+
+def _benchmark_fusion_region_with_nvfuser_and_torch_compile(bsym: BoundSymbol) -> BenchmarkComparisonData:
+    """
+    Benchmark the performance of nvFuser and torch.compile for a given fusion region.
+
+    This function takes a BoundSymbol generated from nvFuser and performs the following:
+    1. Executes the fusion region using both nvFuser and torch.compile.
+    2. Measures wall time and kernel time for both implementations.
+    3. Collects profiling data for the nvFuser implementation.
+
+    Args:
+        bsym (BoundSymbol): A BoundSymbol generated from nvFuser.
+
+    Returns:
+        BenchmarkComparisonData: A named tuple containing:
+            - nvfuser_walltime: Wall time for nvFuser execution using `torch.utils.benchmark.Timer`.
+            - torch_compile_walltime: Wall time for torch.compile execution using `torch.utils.benchmark.Timer`.
+            - nvfuser_kernel_time: Kernel time for nvFuser execution using `triton.testing.do_bench`.
+            - torch_compile_kernel_time: Kernel time for torch.compile execution using `triton.testing.do_bench`.
+            - nvfuser_profiler_data: Profiling data for the nvFuser implementation by calling `fusion_defition.profile`.
+
+    .. note:: The function assumes that the fusion has been previously executed and inputs are recorded.
+    """
+    assert "nvFusion" in bsym.sym.name, "Expected the BoundSymbol to be generated from nvFuser"
+    import triton  # Import triton here as it may not be available in CPU only setting.
+
+    nvfuser_callable = bsym._call_ctx[bsym.sym.name]
+    inputs = nvfuser_callable.last_inputs
+    if nvfuser_callable.last_used is None:
+        raise RuntimeError(
+            "Fusion definition needs to be executed to record the inputs. You must execute the fusion first before you can query the repro."
+        )
+
+    if nvfuser_callable.last_inputs is None:
+        raise RuntimeError(
+            "Fusion definition inputs need to be recorded. Use compile option 'nv_store_fusion_inputs=True' while tracing."
+        )
+
+    torch_compile_callable = make_torch_compile_callable(bsym.subsymbols, bsym.flat_args, bsym.flat_outs)
+
+    nvfuser_callable(*inputs)
+    torch_compile_callable(*inputs)
+
+    nvfuser_timer = Timer("nvfuser_callable(*inputs)", globals={"nvfuser_callable": nvfuser_callable, "inputs": inputs})
+    tc_timer = Timer(
+        "torch_compile_callable(*inputs)", globals={"torch_compile_callable": torch_compile_callable, "inputs": inputs}
+    )
+
+    # Wall times
+    wall_time_nvfuser = nvfuser_timer.blocked_autorange(min_run_time=2)
+    wall_time_tc = tc_timer.blocked_autorange(min_run_time=2)
+
+    # Kernel Times
+    kernel_time_nvfuser = triton.testing.do_bench(lambda: nvfuser_callable(*inputs), return_mode="median")
+    kernel_time_tc = triton.testing.do_bench(lambda: torch_compile_callable(*inputs), return_mode="median")
+
+    # nvFuser's profiling utility.
+    fd = nvfuser_callable.get_fd(nvfuser_callable.to_descriptors(inputs))
+    fd.execute(inputs, profile=True)
+    nvfuser_prof = fd.profile()
+
+    return BenchmarkComparisonData(wall_time_nvfuser, wall_time_tc, kernel_time_nvfuser, kernel_time_tc, nvfuser_prof)

--- a/thunder/examine/__init__.py
+++ b/thunder/examine/__init__.py
@@ -11,7 +11,6 @@ from thunder.core.symbol import BoundSymbol
 from thunder.torch import _torch_to_thunder_function_map
 from thunder.torch.default_torch_ops import torch_auto_registered_ops
 from thunder.core.langctxs import resolve_language, LanguageContext, Languages
-
 import torch
 from warnings import warn
 from itertools import chain
@@ -401,15 +400,3 @@ def make_trace_dot(trace: TraceCtx, show_metadata=False):
     # Resize graph based on number of nodes
     resize_graph(dot)
     return dot
-
-
-BenchmarkComparisonData = collections.namedtuple(
-    "BenchmarkComparisonData",
-    [
-        "nvfuser_walltime",
-        "torch_compile_walltime",
-        "nvfuser_kernel_time",
-        "torch_compile_kernel_time",
-        "nvfuser_profiler_data",
-    ],
-)

--- a/thunder/examine/__init__.py
+++ b/thunder/examine/__init__.py
@@ -11,7 +11,11 @@ from thunder.core.symbol import BoundSymbol
 from thunder.torch import _torch_to_thunder_function_map
 from thunder.torch.default_torch_ops import torch_auto_registered_ops
 from thunder.core.langctxs import resolve_language, LanguageContext, Languages
+from thunder.executors.torch_compile import make_compiled as make_torch_compile_callable
+
 import torch
+from torch.utils.benchmark import Timer
+import triton
 from warnings import warn
 from itertools import chain
 import importlib
@@ -400,3 +404,77 @@ def make_trace_dot(trace: TraceCtx, show_metadata=False):
     # Resize graph based on number of nodes
     resize_graph(dot)
     return dot
+
+
+BenchmarkComparisonData = collections.namedtuple(
+    "BenchmarkComparisonData",
+    [
+        "nvfuser_walltime",
+        "torch_compile_walltime",
+        "nvfuser_kernel_time",
+        "torch_compile_kernel_time",
+        "nvfuser_profiler_data",
+    ],
+)
+
+
+def _benchmark_fusion_region_with_nvfuser_and_torch_compile(bsym: BoundSymbol) -> BenchmarkComparisonData:
+    """
+    Benchmark the performance of nvFuser and torch.compile for a given fusion region.
+
+    This function takes a BoundSymbol generated from nvFuser and performs the following:
+    1. Executes the fusion region using both nvFuser and torch.compile.
+    2. Measures wall time and kernel time for both implementations.
+    3. Collects profiling data for the nvFuser implementation.
+
+    Args:
+        bsym (BoundSymbol): A BoundSymbol generated from nvFuser.
+
+    Returns:
+        BenchmarkComparisonData: A named tuple containing:
+            - nvfuser_walltime: Wall time for nvFuser execution using `torch.utils.benchmark.Timer`.
+            - torch_compile_walltime: Wall time for torch.compile execution using `torch.utils.benchmark.Timer`.
+            - nvfuser_kernel_time: Kernel time for nvFuser execution using `triton.testing.do_bench`.
+            - torch_compile_kernel_time: Kernel time for torch.compile execution using `triton.testing.do_bench`.
+            - nvfuser_profiler_data: Profiling data for the nvFuser implementation by calling `fusion_defition.profile`.
+
+    .. note:: The function assumes that the fusion has been previously executed and inputs are recorded.
+    """
+    assert "nvFusion" in bsym.sym.name, "Expected the BoundSymbol to be generated from nvFuser"
+
+    nvfuser_callable = bsym._call_ctx[bsym.sym.name]
+    inputs = nvfuser_callable.last_inputs
+    if nvfuser_callable.last_used is None:
+        raise RuntimeError(
+            "Fusion definition needs to be executed to record the inputs. You must execute the fusion first before you can query the repro."
+        )
+
+    if nvfuser_callable.last_inputs is None:
+        raise RuntimeError(
+            "Fusion definition inputs need to be recorded. Use compile option 'nv_store_fusion_inputs=True' while tracing."
+        )
+
+    torch_compile_callable = make_torch_compile_callable(bsym.subsymbols, bsym.flat_args, bsym.flat_outs)
+
+    nvfuser_callable(*inputs)
+    torch_compile_callable(*inputs)
+
+    nvfuser_timer = Timer("nvfuser_callable(*inputs)", globals={"nvfuser_callable": nvfuser_callable, "inputs": inputs})
+    tc_timer = Timer(
+        "torch_compile_callable(*inputs)", globals={"torch_compile_callable": torch_compile_callable, "inputs": inputs}
+    )
+
+    # Wall times
+    wall_time_nvfuser = nvfuser_timer.blocked_autorange(min_run_time=2)
+    wall_time_tc = tc_timer.blocked_autorange(min_run_time=2)
+
+    # Kernel Times
+    kernel_time_nvfuser = triton.testing.do_bench(lambda: nvfuser_callable(*inputs), return_mode="median")
+    kernel_time_tc = triton.testing.do_bench(lambda: torch_compile_callable(*inputs), return_mode="median")
+
+    # nvFuser's profiling utility.
+    fd = nvfuser_callable.get_fd(nvfuser_callable.to_descriptors(inputs))
+    fd.execute(inputs, profile=True)
+    nvfuser_prof = fd.profile()
+
+    return BenchmarkComparisonData(wall_time_nvfuser, wall_time_tc, kernel_time_nvfuser, kernel_time_tc, nvfuser_prof)

--- a/thunder/examine/__init__.py
+++ b/thunder/examine/__init__.py
@@ -15,7 +15,6 @@ from thunder.executors.torch_compile import make_compiled as make_torch_compile_
 
 import torch
 from torch.utils.benchmark import Timer
-import triton
 from warnings import warn
 from itertools import chain
 import importlib
@@ -441,6 +440,7 @@ def _benchmark_fusion_region_with_nvfuser_and_torch_compile(bsym: BoundSymbol) -
     .. note:: The function assumes that the fusion has been previously executed and inputs are recorded.
     """
     assert "nvFusion" in bsym.sym.name, "Expected the BoundSymbol to be generated from nvFuser"
+    import triton  # Import triton here as it may not be available in CPU only setting.
 
     nvfuser_callable = bsym._call_ctx[bsym.sym.name]
     inputs = nvfuser_callable.last_inputs

--- a/thunder/examine/__init__.py
+++ b/thunder/examine/__init__.py
@@ -11,10 +11,8 @@ from thunder.core.symbol import BoundSymbol
 from thunder.torch import _torch_to_thunder_function_map
 from thunder.torch.default_torch_ops import torch_auto_registered_ops
 from thunder.core.langctxs import resolve_language, LanguageContext, Languages
-from thunder.executors.torch_compile import make_compiled as make_torch_compile_callable
 
 import torch
-from torch.utils.benchmark import Timer
 from warnings import warn
 from itertools import chain
 import importlib
@@ -415,66 +413,3 @@ BenchmarkComparisonData = collections.namedtuple(
         "nvfuser_profiler_data",
     ],
 )
-
-
-def _benchmark_fusion_region_with_nvfuser_and_torch_compile(bsym: BoundSymbol) -> BenchmarkComparisonData:
-    """
-    Benchmark the performance of nvFuser and torch.compile for a given fusion region.
-
-    This function takes a BoundSymbol generated from nvFuser and performs the following:
-    1. Executes the fusion region using both nvFuser and torch.compile.
-    2. Measures wall time and kernel time for both implementations.
-    3. Collects profiling data for the nvFuser implementation.
-
-    Args:
-        bsym (BoundSymbol): A BoundSymbol generated from nvFuser.
-
-    Returns:
-        BenchmarkComparisonData: A named tuple containing:
-            - nvfuser_walltime: Wall time for nvFuser execution using `torch.utils.benchmark.Timer`.
-            - torch_compile_walltime: Wall time for torch.compile execution using `torch.utils.benchmark.Timer`.
-            - nvfuser_kernel_time: Kernel time for nvFuser execution using `triton.testing.do_bench`.
-            - torch_compile_kernel_time: Kernel time for torch.compile execution using `triton.testing.do_bench`.
-            - nvfuser_profiler_data: Profiling data for the nvFuser implementation by calling `fusion_defition.profile`.
-
-    .. note:: The function assumes that the fusion has been previously executed and inputs are recorded.
-    """
-    assert "nvFusion" in bsym.sym.name, "Expected the BoundSymbol to be generated from nvFuser"
-    import triton  # Import triton here as it may not be available in CPU only setting.
-
-    nvfuser_callable = bsym._call_ctx[bsym.sym.name]
-    inputs = nvfuser_callable.last_inputs
-    if nvfuser_callable.last_used is None:
-        raise RuntimeError(
-            "Fusion definition needs to be executed to record the inputs. You must execute the fusion first before you can query the repro."
-        )
-
-    if nvfuser_callable.last_inputs is None:
-        raise RuntimeError(
-            "Fusion definition inputs need to be recorded. Use compile option 'nv_store_fusion_inputs=True' while tracing."
-        )
-
-    torch_compile_callable = make_torch_compile_callable(bsym.subsymbols, bsym.flat_args, bsym.flat_outs)
-
-    nvfuser_callable(*inputs)
-    torch_compile_callable(*inputs)
-
-    nvfuser_timer = Timer("nvfuser_callable(*inputs)", globals={"nvfuser_callable": nvfuser_callable, "inputs": inputs})
-    tc_timer = Timer(
-        "torch_compile_callable(*inputs)", globals={"torch_compile_callable": torch_compile_callable, "inputs": inputs}
-    )
-
-    # Wall times
-    wall_time_nvfuser = nvfuser_timer.blocked_autorange(min_run_time=2)
-    wall_time_tc = tc_timer.blocked_autorange(min_run_time=2)
-
-    # Kernel Times
-    kernel_time_nvfuser = triton.testing.do_bench(lambda: nvfuser_callable(*inputs), return_mode="median")
-    kernel_time_tc = triton.testing.do_bench(lambda: torch_compile_callable(*inputs), return_mode="median")
-
-    # nvFuser's profiling utility.
-    fd = nvfuser_callable.get_fd(nvfuser_callable.to_descriptors(inputs))
-    fd.execute(inputs, profile=True)
-    nvfuser_prof = fd.profile()
-
-    return BenchmarkComparisonData(wall_time_nvfuser, wall_time_tc, kernel_time_nvfuser, kernel_time_tc, nvfuser_prof)


### PR DESCRIPTION
Add a utility function to benchmark the performance of nvFuser and torch.compile for a given fusion region.

Example Usage -
```python
import torch
import thunder
from thunder.dev_utils.utils import _benchmark_fusion_region_with_nvfuser_and_torch_compile

def fn(x):
    y = (x * x).sum()
    z = x @ x
    return z.sin() + y.cos()

jfn = thunder.jit(fn, nv_store_fusion_inputs=True)

jfn(torch.randn(16, 16, device="cuda"))

trc = thunder.last_traces(jfn)[-1]

for bsym in trc.bound_symbols:
    if bsym.sym.is_fusion and "nvFusion" in bsym.sym.name:
        benchmark_comparison_data = _benchmark_fusion_region_with_nvfuser_and_torch_compile(bsym)
        nvfuser_walltime = benchmark_comparison_data.nvfuser_walltime
        nvfuser_kerneltime = benchmark_comparison_data.nvfuser_kernel_time
        nvfuser_prof_data = benchmark_comparison_data.nvfuser_profiler_data

        torch_compile_walltime = benchmark_comparison_data.torch_compile_walltime
        torch_compile_kerneltime = benchmark_comparison_data.torch_compile_kernel_time

        print(bsym)
        print(nvfuser_walltime)
        print(torch_compile_walltime)
        print(nvfuser_kerneltime)
        print(torch_compile_kerneltime)
        print(nvfuser_prof_data)
        print(nvfuser_prof_data.kernel_profiles[0].percentage_peak_bandwidth)
        print("----"*32)
```

<details>

<summary> Output </summary>

```python
[y] = nvFusion0(x)
  # t0 = prims.mul(x, x)  # t0: "cuda:0 f32[16, 16]"
  # y = prims.sum(t0, (0, 1))  # y: "cuda:0 f32[]"
<torch.utils.benchmark.utils.common.Measurement object at 0x7e5bccfce1d0>
nvfuser_callable(*inputs)
  Median: 31.15 us
  IQR:    0.13 us (31.10 to 31.23)
  7 measurements, 10000 runs per measurement, 1 thread
<torch.utils.benchmark.utils.common.Measurement object at 0x7e5bccfcde70>
torch_compile_callable(*inputs)
  Median: 21.16 us
  IQR:    0.29 us (21.03 to 21.32)
  93578 measurements, 1 runs per measurement, 1 thread
0.007135999854654074
0.004095999989658594
<nvfuser._C.FusionProfile object at 0x7e5be85318f0>
0.04780027949585994
--------------------------------------------------------------------------------------------------------------------------------
[t6] = nvFusion1(t8, y)
  # t3 = prims.sin(t8)  # t3: "cuda:0 f32[16, 16]"
  # t4 = prims.cos(y)  # t4: "cuda:0 f32[]"
  # t5 = prims.broadcast_in_dim(t4, (16, 16), ())  # t5: "cuda:0 f32[16, 16]"
  # t6 = prims.add(t3, t5)  # t6: "cuda:0 f32[16, 16]"
<torch.utils.benchmark.utils.common.Measurement object at 0x7e5bb0b43f10>
nvfuser_callable(*inputs)
  Median: 25.20 us
  IQR:    0.11 us (25.15 to 25.25)
  8 measurements, 10000 runs per measurement, 1 thread
<torch.utils.benchmark.utils.common.Measurement object at 0x7e5bccfcd330>
torch_compile_callable(*inputs)
  Median: 24.49 us
  IQR:    0.35 us (24.34 to 24.69)
  80906 measurements, 1 runs per measurement, 1 thread
0.004608000162988901
0.003967999946326017
<nvfuser._C.FusionProfile object at 0x7e5be85318f0>
0.151795899955459
-------------------------------------------------------------------------------------------------------------------------------
```

</details>