### PR TITLE
Add clone -> fd.ops.set translation for nvFuser

### DIFF
--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -1708,6 +1708,14 @@ def trunc(a: TensorProxy | Number, *, fd: FusionDefinition, lc_to_nv_map: dict) 
 register_supported(PrimIDs.TRUNC, trunc, _elementwise_unary_check)
 
 
+def clone(a: TensorProxy, *, fd: FusionDefinition, lc_to_nv_map: dict) -> Any:
+    nva = getnv(a, fd, lc_to_nv_map)
+
+    return fd.ops.set(nva)
+
+
+register_supported(PrimIDs.CLONE, clone, _elementwise_unary_check)
+
 #
 # Elementwise binary operations
 #

--- a/thunder/tests/test_networks.py
+++ b/thunder/tests/test_networks.py
@@ -510,6 +510,7 @@ LLAMA_3_2_1B_CFG = {
 def test_hf_llama():
     from transformers.models.llama import LlamaForCausalLM, LlamaConfig
     from transformers.models.llama.modeling_llama import logger as llama_logger
+    from thunder.examine import get_fusion_symbols
     import logging
 
     # transformers logs a cache deprecation warning
@@ -548,9 +549,8 @@ def test_hf_llama():
     expected2 = model(past_key_values=res["past_key_values"], **args2)
     assert_close(res2, expected2, rtol=1e-1, atol=1e-1)
 
-    top_level_symbol_names = {bsym.sym.name for bsym in thunder.last_traces(jm)[-1].bound_symbols}
     # changes this to fewer as needed, the goal is to not have too many fusions
-    assert len([s for s in top_level_symbol_names if s.startswith("nvFusion")]) == 7
+    assert len(get_fusion_symbols(thunder.last_traces(jm)[-1])) == 7
 
 
 @requiresCUDA


### PR DESCRIPTION
This PR allows the nvFuser fusion pass to consume the `prims.clone` operation (a decomposition from `torch.clone`).

The tests already exist with `pytest thunder/tests/test_ops.py -k "test_core_vs_torch_consistency_clone_nvfuser_cuda_thunder"`:
```py
thunder/tests/test_ops.py::test_core_vs_torch_consistency_clone_nvfuser_cuda_thunder::dtypes::bfloat16 <- thunder/tests/framework.py PASSED
thunder/tests/test_ops.py::test_core_vs_torch_consistency_clone_nvfuser_cuda_thunder::dtypes::bool8 <- thunder/tests/framework.py PASSED
thunder/tests/test_ops.py::test_core_vs_torch_consistency_clone_nvfuser_cuda_thunder::dtypes::complex128 <- thunder/tests/framework.py SKIPPED (Skipping complex operator tests in CI for speed)
thunder/tests/test_ops.py::test_core_vs_torch_consistency_clone_nvfuser_cuda_thunder::dtypes::complex64 <- thunder/tests/framework.py SKIPPED (Skipping complex operator tests in CI for speed)
thunder/tests/test_ops.py::test_core_vs_torch_consistency_clone_nvfuser_cuda_thunder::dtypes::float16 <- thunder/tests/framework.py PASSED
thunder/tests/test_ops.py::test_core_vs_torch_consistency_clone_nvfuser_cuda_thunder::dtypes::float32 <- thunder/tests/framework.py PASSED
thunder/tests/test_ops.py::test_core_vs_torch_consistency_clone_nvfuser_cuda_thunder::dtypes::float64 <- thunder/tests/framework.py PASSED
thunder/tests/test_ops.py::test_core_vs_torch_consistency_clone_nvfuser_cuda_thunder::dtypes::int32 <- thunder/tests/framework.py PASSED
thunder/tests/test_ops.py::test_core_vs_torch_consistency_clone_nvfuser_cuda_thunder::dtypes::int64 <- thunder/tests/framework.py PASSED

=========================================================================== 7 passed, 2 skipped, 6755 deselected, 380 warnings in 2.32s
```

Fixes https://github.com/Lightning-AI/lightning-thunder/issues/1675.