### PR TITLE
Remove prims.embedding and prims.embedding_backward

### DIFF
--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -265,8 +265,6 @@ class PrimIDs(Enum):
     MATMUL = auto()
     # NN prims (Experimental!)
     CONVOLUTION = auto()
-    EMBEDDING = auto()
-    EMBEDDING_BACKWARD = auto()
     LINEAR = auto()
     PAD = auto()
     # Memory access methods
@@ -4077,39 +4075,6 @@ convolution = make_prim(
     "convolution",
     meta=convolution_meta,
 )
-
-
-def embedding_meta(
-    a: TensorProxy, /, weight, *, padding_idx=-1, max_norm=None, norm_type=2.0, scale_grad_by_freq=False, sparse=False
-) -> TensorProxy:
-    # TODO: canonicalize and validating padding idx with weight.shape[0]
-
-    if max_norm is not None:
-        raise NotImplementedError
-
-    utils.check(a.dtype == dtypes.int64, lambda: f"Expected a.dtype={a.dtype} to be int64")
-    utils.check(weight.ndim == 2, lambda: f"Expected weight (weight.shape={weight.shape} to be a matrix)")
-
-    shape = list(a.shape)
-    shape.append(weight.shape[1])
-
-    return TensorProxy(like=weight, shape=shape)
-
-
-embedding = make_prim(PrimIDs.EMBEDDING, "embedding", meta=embedding_meta)
-
-
-# TODO Update this so it's not a prim
-# TODO Add annotations
-# TODO Review requires_grad=False -- what about double backward?
-# TODO Once we have fusible index_put we can implement it using primitives
-# For now we just use the PyTorch implementation
-def embedding_backward_meta(grad, indices, num_weights, padding_idx, scale_grad_by_freq, sparse):
-    shape = (num_weights, grad.shape[-1])
-    return TensorProxy(shape=shape, device=grad.device, dtype=grad.dtype, requires_grad=False)
-
-
-embedding_backward = make_prim(PrimIDs.EMBEDDING_BACKWARD, "embedding_backward", meta=embedding_backward_meta)
 
 
 def copy__meta(

--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -1348,29 +1348,6 @@ register_grad(pids.MATMUL, _matmul_prim_grad)
 #
 
 
-def _embedding_prim_grad(
-    a: TensorProxy, /, weight, *, padding_idx=-1, max_norm=None, norm_type=2.0, scale_grad_by_freq=False, sparse=False
-) -> TensorProxy:
-    fwd = prims.embedding(
-        a,
-        weight,
-        padding_idx=padding_idx,
-        max_norm=max_norm,
-        norm_type=norm_type,
-        scale_grad_by_freq=scale_grad_by_freq,
-        sparse=sparse,
-    )
-
-    g = get_grad(fwd)
-    a_grad = prims.embedding_backward(g, a, weight.shape[0], padding_idx, scale_grad_by_freq, sparse)
-    put_grad(a, a_grad)
-
-    return fwd
-
-
-register_grad(pids.EMBEDDING, _embedding_prim_grad)
-
-
 def _maximum_grad(a: TensorProxy, b: TensorProxy, /):
     fwd = prims.maximum(a, b)
 

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -2633,5 +2633,4 @@ def embedding(
     return fd.ops.embedding_fwd(*nv_inputs)
 
 
-register_supported(PrimIDs.EMBEDDING, embedding, _embedding_check)
 register_supported(ltorch.embedding, embedding, _embedding_check)

--- a/thunder/executors/torchex.py
+++ b/thunder/executors/torchex.py
@@ -1714,8 +1714,6 @@ def _pad_prim_impl(
 
 
 _register_implementation(prims.convolution, checker=_always_executable, execution_transform=_convolution_transform)
-_register_implementation(prims.embedding, embedding, checker=_always_executable)
-_register_implementation(prims.embedding_backward, embedding_backward, checker=_always_executable)
 _register_implementation(prims.linear, linear, checker=_always_executable)
 
 _register_implementation(ltorch.baddbmm, baddbmm, checker=_always_executable)


### PR DESCRIPTION
We don't need `prims.embedding` and `prims.embedding_backward` because we can simply use `thunder.torch.embedding` and `thunder.torch.embedding_backward` as our transformation targets. When we added these primitives we didn't have a good idea how multi-level symbols can be targeted.

With this PR `thunder.torch.embedding` is transformed directly to `torch.nn.functional.embedding` for execution. While before this PR `thunder.torch.embedding` is decomposed into `prims.embedding` which is then transformed into `torch.nn.functional.embedding` (and similarly for `embedding_backward`).

Testing:
```
pytest thunder/tests/test_grad.py -k "embedding" -vvv
pytest thunder/tests/test_ops.py -k "embedding" -vvv
```
