### PR TITLE
fix TE distributed tests with fsdp_v2 and ddp_v2

### DIFF
--- a/thunder/distributed/transforms/fsdp_v2.py
+++ b/thunder/distributed/transforms/fsdp_v2.py
@@ -124,6 +124,7 @@ class FSDPTransform(Transform):
         cd = get_compile_data(thunder_model)
         # TODO: promote use_fsdp and use_ddp to public members of CompileData
         cd.use_fsdp = True
+        cd.process_group_for_ddp = self.process_group
         orig_module: torch.nn.Module = cd.fn
         utils.check(
             isinstance(orig_module, torch.nn.Module) and not isinstance(orig_module, ThunderModule),

--- a/thunder/tests/distributed/test_ddp.py
+++ b/thunder/tests/distributed/test_ddp.py
@@ -391,15 +391,17 @@ def _test_ddp_transformer_engine(input_data):
     thunder_model.fc1.weight.data = fc1_weight.clone()
     thunder_model.fc2.weight.data = fc2_weight.clone()
 
-    jit_model = thunder.jit(
-        thunder.distributed.ddp(thunder_model),
-        executors=[
-            transformer_engine_ex,
-        ]
-        + executor.executors_list(),
+    jit_model = thunder.distributed.ddp(
+        thunder.jit(
+            thunder_model,
+            executors=[
+                transformer_engine_ex,
+            ]
+            + executor.executors_list(),
+        )
     )
 
-    optim = torch.optim.SGD(thunder_model.parameters())
+    optim = torch.optim.SGD(jit_model.parameters())
 
     for _ in range(n_iter):
         o = jit_model(x).sum()


### PR DESCRIPTION
TE Distributed tests were failing with `only ThunderModules support the FSDP Transform`

Tested with `thunder/tests/distributed/test_fsdp.py -k transformer -v` and `thunder/tests/distributed/test_ddp.py -k transformer -v` on TE v1.14

Related: #1640