### PR TITLE
patching shape query in TensorProxy to avoid prims

### DIFF
--- a/thunder/common.py
+++ b/thunder/common.py
@@ -392,8 +392,12 @@ def _unpack_inputs(fn, tracectx: TraceCtx, args, kwargs, *, rename_proxies: bool
 
 # TODO Update cacheable types
 def _make_subkey_for(x: Any) -> tuple[bool, None | tuple]:
-    if isinstance(x, (torch.Tensor, TensorProxy)):
+    if isinstance(x, torch.Tensor):
         return True, (type(x), x.shape, x.device, x.dtype, x.requires_grad)
+
+    if isinstance(x, TensorProxy):
+        # calling _shape instead shape to avoid leaving a prims.shape in the trace
+        return True, (type(x), x._shape, x.device, x.dtype, x.requires_grad)
 
     # TODO Add NumPy ndarray support
     if isinstance(x, np.ndarray):

--- a/thunder/core/proxies.py
+++ b/thunder/core/proxies.py
@@ -1219,7 +1219,7 @@ def _infer_tensor_properties(
 
     if like is not None:
         baseutils.check_type(like, (TensorProxy, FutureTensorProxy))
-        _shape = tuple(like.shape)
+        _shape = tuple(like._shape)
         _device = like.device
         _dtype = like.true_dtype
         _requires_grad = like.requires_grad

--- a/thunder/tests/test_transforms.py
+++ b/thunder/tests/test_transforms.py
@@ -856,7 +856,7 @@ def test_cache_symbolic_values_grad_unsqueeze():
         cache = torch.arange(0, 128, 1)
         cache_unsqueezed = cache.unsqueeze(0)
         return x + cache_unsqueezed
-    
+
     jfoo = thunder.jit(foo, cache="symbolic values")
     set_requires_grad = lambda x: x.requires_grad_()
 


### PR DESCRIPTION
We should avoid calling `TensorProxy.shape` directly during trace transformations, but use `TensorProxy._shape` instead.

The difference is that `shape` would leave a `prims.shape` symbol in the trace, if under a tracing context. Which is the case during grad transform. 

Without this change, the trace will be corrupted with `prims.shape` calling on non-existing TensorProxy.