### PR TITLE
bump transformers version

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -18,7 +18,7 @@ pandas # thunder/benchmarks/test_benchmark_litgpt.py
 xlsxwriter # thunder/benchmarks/test_benchmark_litgpt.py
 jsonargparse # thunder/benchmarks/benchmark_litgpt.py
 bitsandbytes==0.42.0  # fixed version!
-transformers==4.46.3 # for test_networks.py
+transformers==4.48.1 # for test_networks.py
 
 # Installs JAX on Linux and MacOS
 jaxlib; sys_platform == 'linux' or sys_platform == 'darwin'  # required for jax, see https://github.com/google/jax#installation

--- a/thunder/tests/test_networks.py
+++ b/thunder/tests/test_networks.py
@@ -508,6 +508,11 @@ LLAMA_3_2_1B_CFG = {
 
 @requiresCUDA
 def test_hf_llama():
+    import transformers
+
+    if version_between(transformers.__version__, min_ver="4.46.4"):
+        pytest.skip("Dynamic cache is not supported, see static cache 'test_hf_kvcache'")
+
     from transformers.models.llama import LlamaForCausalLM, LlamaConfig
     from transformers.models.llama.modeling_llama import logger as llama_logger
     from thunder.examine import get_fusion_symbols


### PR DESCRIPTION
try to bump transformers version to lates as the lib changed a lot from 4.46.x

I considered using the >= symbol but maybe better to stay safe and keep 48.1 for now, let me know in case of other opinions

fyi cc. @kshitij12345 @IvanYashchuk 

cc @borda