### PR TITLE
Reduce `test_thunderfx_mistral_nemo_small` model size

### DIFF
--- a/thunder/tests/test_networks.py
+++ b/thunder/tests/test_networks.py
@@ -392,14 +392,14 @@ def test_thunderfx_mistral_nemo_small():
     config = transformers.models.mistral.configuration_mistral.MistralConfig(
         num_hidden_layers=1,
         torch_dtype=torch.bfloat16,
-        max_position_embeddings=1024,
+        max_position_embeddings=64,
         architectures=["MistralForCausalLM"],
-        hidden_size=5120,
+        hidden_size=1024,
         rms_norm_eps=1e-05,
         rope_theta=1000000.0,
         sliding_window=None,
         vocab_size=131072,
-        head_dim=128,
+        head_dim=32,
         _name_or_path=model_id,
     )
     model = transformers.AutoModelForCausalLM.from_config(config, trust_remote_code=False)


### PR DESCRIPTION
Reducing the models size to speedup CI and make it work in environments with constrained memory size.

cc. @tfogal since you added this, I think this change should be fine since with this test we are verifying functionality more than memory footprint. Let me know what you think. 

With this change the peak memory of the test is ~2.6GB instead of ~14GB