### PR TITLE
support dynamic extent in slice for nvfuser executor 

### DIFF
--- a/thunder/tests/test_nvfuser.py
+++ b/thunder/tests/test_nvfuser.py
@@ -1246,3 +1246,25 @@ def test_embedding(
 
         assert len(fwd_fusion) == 1
         torch.testing.assert_close(out, expected_out)
+
+
+@instantiate(executors=(nvFuserExecutor,), dtypes=NOTHING,)
+def test_slice_dynamic_extent(executor, device: str, dtype: dtypes.dtype):
+    def foo(b):
+        a = torch.arange(24, device=device, ).reshape(3, 8)
+        return a[..., : b]
+
+    jfoo = thunder.jit(foo, cache="symbolic values")
+
+    actual = jfoo(5)
+    expected = foo(5)
+    assert_close(actual, expected)
+
+    fw_trace = thunder.last_traces(jfoo)[-1]
+    fusion_bsyms = tuple(filter(lambda a: a.sym.is_fusion, fw_trace.bound_symbols))
+    
+    # There are two nvfuser fusion groups separated by the matmul operation.
+    assert len(fusion_bsyms) == 1
+
+    outside_fusion_syms = ["unpack_trivial", "python_return"]
+    assert {el.sym.name for el in fw_trace.bound_symbols if not el.sym.is_fusion} == set(outside_fusion_syms)

--- a/thunder/tests/test_nvfuser.py
+++ b/thunder/tests/test_nvfuser.py
@@ -1255,6 +1255,7 @@ def test_embedding(
 def test_slice_dynamic_extent(executor, device: str, dtype: dtypes.dtype):
     def foo(b):
         # TODO: 'device=device' doesn't work for "symbolic values" cache policy
+        # See issue: https://github.com/Lightning-AI/lightning-thunder/issues/1710
         a = torch.arange(24, device="cuda").reshape(3, 8)
         return a[..., :b]
 

--- a/thunder/tests/test_nvfuser.py
+++ b/thunder/tests/test_nvfuser.py
@@ -1248,12 +1248,15 @@ def test_embedding(
         torch.testing.assert_close(out, expected_out)
 
 
-@instantiate(executors=(nvFuserExecutor,), dtypes=NOTHING,)
+@instantiate(
+    executors=(nvFuserExecutor,),
+    dtypes=NOTHING,
+)
 def test_slice_dynamic_extent(executor, device: str, dtype: dtypes.dtype):
     def foo(b):
         # TODO: 'device=device' doesn't work for "symbolic values" cache policy
         a = torch.arange(24, device="cuda").reshape(3, 8)
-        return a[..., : b]
+        return a[..., :b]
 
     jfoo = thunder.jit(foo, cache="symbolic values")
 
@@ -1263,7 +1266,7 @@ def test_slice_dynamic_extent(executor, device: str, dtype: dtypes.dtype):
 
     fw_trace = thunder.last_traces(jfoo)[-1]
     fusion_bsyms = tuple(filter(lambda a: a.sym.is_fusion, fw_trace.bound_symbols))
-    
+
     # There are two nvfuser fusion groups separated by the matmul operation.
     assert len(fusion_bsyms) == 1
 


### PR DESCRIPTION
updating `nv_slice` to accept dynamic slice extent.

We attempted this previously, but backed out from it since the extra wrapping on constant made the FusionDefinition a lot more verbose.
To address that, I changed `getnv` logic to allow `inline_number`, which returns constant python number directly, instead of trying to wrap it with define constant in nvfuser.

i.e. with inline_number

```
    T17 = fd.ops.slice(T7, start_indices=[0, 0], end_indices=[3, 5], strides=[1, 1], manual_normalization=0)
```

without inline_number

```
    S8 = fd.define_scalar(0, dtype=DataType.Int)
    S9 = fd.define_scalar(0, dtype=DataType.Int)
    S10 = fd.define_scalar(3, dtype=DataType.Int)
    S11 = fd.define_scalar(5, dtype=DataType.Int)
    S12 = fd.define_scalar(1, dtype=DataType.Int)
    S13 = fd.define_scalar(1, dtype=DataType.Int)
    T17 = fd.ops.slice(T7, start_indices=[S8, S9], end_indices=[S10, S11], strides=[S12, S13], manual_normalization=0)
```