### PR TITLE
Grad transform patch

### DIFF
--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -634,7 +634,7 @@ def register_grad(sym_or_id: Symbol | Any, gradfn: Callable, skip: bool = False)
         id = sym_or_id.id
 
     if skip:
-        _grad_skip_ids.insert(id)
+        _grad_skip_ids.add(id)
 
     # The gradfn are expected to be written in terms of torch functions by
     # default even if the original forward function could be written in terms of


### PR DESCRIPTION
This PR refactors grad transform to add a `_grad_skip_ids`, which allows us to skip symbols that does not participate in grad transformation.

The main motivation is to ensure that `prims.shape` does not break the saved for backward in the transform.