### PR TITLE
Relax test_te_with_retain_graph xfail strictness in test_transformer_engine_executor.py 

### DIFF
--- a/thunder/tests/test_transformer_engine_executor.py
+++ b/thunder/tests/test_transformer_engine_executor.py
@@ -191,7 +191,7 @@ def test_te_with_autocast():
     assert any(bsym.sym.name.startswith("te_linear") for bsym in fwd_traces[-1].bound_symbols)
 
 
-@pytest.mark.xfail(strict=True, raises=AssertionError, reason="Retain graph is not supported by TE")
+@pytest.mark.xfail(strict=False, raises=AssertionError, reason="Retain graph is not supported by TE")
 @requiresCUDA
 def test_te_with_retain_graph():
     def foo(x, w):


### PR DESCRIPTION

As this test no longer seems to fail with CUDA12.8/sm_100.

<details>
  <summary><b>Before submitting</b></summary>

- [] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes # (issue). 
Failures in the case of unit test passage -- the unit test succeeds, the xfail (strict=True...) failed it

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
