### PR TITLE
[Thunderfx report] Adds Thunder segmentation and fusion information

### DIFF
--- a/thunder/core/utils.py
+++ b/thunder/core/utils.py
@@ -1253,8 +1253,6 @@ def create_python_callable_from_bsym(bsym: BoundSymbolInterface) -> str:
     si = SigInfo(bsym.sym.name)
     si.args = [(v.name, None) for v in bsym.flat_args]
     trace._siginfo = si
-    # trace.siginfo()
-    # trace.args = bsym.flat_args
     trace.bound_symbols = list(bsym.subsymbols)
 
     with tracectx(trace):

--- a/thunder/dynamo/report.py
+++ b/thunder/dynamo/report.py
@@ -501,7 +501,7 @@ class ThunderSplitGraphReport(FXGraphReport):
         fwd_trc: The forward trace, available only after calling :meth:`_create_thunder_traces`.
         bwd_trc: The backward trace, available only after calling :meth:`_create_thunder_traces`.
 
-    For an example, see the documentation of :func:`analyze_with_thunder`.
+    For an example, see the documentation of :func:`analyze_thunder_splits`.
     """
 
     def __init__(
@@ -534,6 +534,10 @@ class ThunderSplitGraphReport(FXGraphReport):
         self.bwd_trc = last_backward_traces(self.compiled_fn)[-1]
 
     def create_fusion_reports(self):
+        """
+        Runs the Thunder-compiled function to obtain the nvFusion definition
+        and generate the :class:`ThunderFusionReport` instance based on it.
+        """
         self._create_thunder_traces()
         for trace, prefix in [(self.fwd_trc, "forward"), (self.bwd_trc, "backward")]:
             for bsym in trace.bound_symbols:
@@ -593,7 +597,7 @@ class ThunderFusionReport:
         nvfusion_bsym (BoundSymbol): The symbolic representation of the nvFusion region.
         name (str): The name of the fusion region.
 
-    For an example, see the documentation of :func:`analyze_with_thunder`.
+    For an example, see the documentation of :func:`analyze_thunder_splits`.
     """
 
     def __init__(self, bsym: BoundSymbol, name: str):
@@ -665,7 +669,7 @@ class ThunderFXGraphReport(FXGraphReport):
         subgraph_reports (list[ThunderSplitGraphReport]): A list of reports for each
             Thunder-split FX graph. For more details, see :class:`ThunderSplitGraphReport`.
 
-    For an example, see the documentation of :func:`analyze_with_thunder`.
+    For an example, see the documentation of :func:`analyze_thunder_splits`.
     """
 
     def __init__(self, gm: torch.fx.GraphModule, gm_name: str, thunder_options: dict):
@@ -715,7 +719,7 @@ class ThunderFXGraphReport(FXGraphReport):
             )
 
 
-def analyze_with_thunder(
+def analyze_thunder_splits(
     report: FXGraphReport,
     **thunder_options,
 ) -> ThunderFXGraphReport:
@@ -733,7 +737,7 @@ def analyze_with_thunder(
         import torch
         from thunder.dynamo.report import (
             fx_report, FXReport, ThunderFXGraphReport, FXGraphReport,
-            ThunderSplitGraphReport, ThunderFusionReport, analyze_with_thunder
+            ThunderSplitGraphReport, ThunderFusionReport, analyze_thunder_splits
         )
         from pathlib import Path
 
@@ -758,7 +762,7 @@ def analyze_with_thunder(
                 # `ThunderFXGraphReport` extends `FXGraphReport`, providing the ability to save
                 # reproduction/benchmark scripts for the original FX graph. Additionally, it
                 # includes information about Thunder-split subgraphs in `subgraph_reports`.
-                thunder_fx_graph_report: ThunderFXGraphReport = analyze_with_thunder(fx_graph_report)
+                thunder_fx_graph_report: ThunderFXGraphReport = analyze_thunder_splits(fx_graph_report)
                 # Saves a reproduction script for the original FX graph
                 thunder_fx_graph_report.write_thunder_repro(tmp_path)
 

--- a/thunder/dynamo/report.py
+++ b/thunder/dynamo/report.py
@@ -411,7 +411,7 @@ class FXReport:
             graph_names = [f"graph{idx}" for idx in range(len(graphs))]
         self.fx_graph_reports: list[FXGraphReport] = [FXGraphReport(g, name) for name, g in zip(graph_names, graphs)]
 
-    def __str__(self):
+    def __repr__(self):
         return f"<FXReport with {len(self.fx_graph_reports)} FXGraphReports accessible via .fx_graph_reports>"
 
 
@@ -523,6 +523,9 @@ class ThunderSplitGraphReport(FXGraphReport):
         self.fwd_trc: TraceCtx = None
         self.bwd_trc: TraceCtx = None
 
+    def __repr__(self):
+        return f"<ThunderSplitGraphReport with {len(self.fusion_reports)} ThunderFusionReport accessible via .fusion_reports>"
+
     def _create_thunder_traces(self):
         example_inputs = eval(f"[\n{chr(10).join(arg_like(a) for a in self.example_input)}]")
         # Executes to get the trace
@@ -597,6 +600,9 @@ class ThunderFusionReport:
         self.nvfusion_bsym = bsym
         self.name = name
 
+    def __repr__(self):
+        return f"<ThunderFusionReport of bound symbol\n{self.nvfusion_bsym}>"
+
     def write_nvfuser_repro(self, folder, file_name=None):
         folder = Path(folder)
         folder.mkdir(exist_ok=True, parents=True)
@@ -668,6 +674,9 @@ class ThunderFXGraphReport(FXGraphReport):
 
         self.subgraph_reports: list[ThunderSplitGraphReport] = []
         self._create_subgraph_reports()
+
+    def __repr__(self):
+        return f"<ThunderFXGraphReport with {len(self.subgraph_reports)} ThunderSplitGraphReport accessible via .subgraph_reports>"
 
     def _create_subgraph_reports(self):
         from thunder.dynamo.utils import remove_empty_autocast, recompile_graph, get_thunder_module_names

--- a/thunder/dynamo/repro_script_template.py
+++ b/thunder/dynamo/repro_script_template.py
@@ -121,10 +121,7 @@ bsym_torch_compile_repro_template = """
 from thunder.executors.torch_compile import make_compiled as make_torch_compile_callable
 import thunder.examine
 
-# inputs
-x = torch.randn(16, 16, device="cuda")
 inputs = {inputs}
-
 
 jfn = thunder.jit({func_name})
 jfn(*inputs)

--- a/thunder/dynamo/repro_script_template.py
+++ b/thunder/dynamo/repro_script_template.py
@@ -115,7 +115,7 @@ def test_{graph_name}(benchmark, executor, compute_type):
 '''
 
 
-template_bsym_torch_compile = """
+bsym_torch_compile_repro_template = """
 {python_func}
 
 from thunder.executors.torch_compile import make_compiled as make_torch_compile_callable

--- a/thunder/dynamo/utils.py
+++ b/thunder/dynamo/utils.py
@@ -729,3 +729,12 @@ def get_split_reasons_string(subgraph_info: SubgraphInfo) -> str:
     else:
         split_reason_str += "The original graph is not split, and is entirely run by Thunder.\n"
     return split_reason_str
+
+
+def get_thunder_module_names(subgraph_info: SubgraphInfo) -> list[str]:
+    thunder_module_names = []
+    for node in subgraph_info.split_graph_module.graph.nodes:
+        target = node.target
+        if isinstance(target, str) and target.startswith("thunder_"):
+            thunder_module_names.append(target)
+    return thunder_module_names

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -1154,7 +1154,7 @@ def test_leak_on_unsupported_thunder_operator():
 
 @requiresCUDA
 def test_thunder_specific_reports(tmp_path):
-    from thunder.dynamo.report import fx_report, analyze_with_thunder
+    from thunder.dynamo.report import fx_report, analyze_thunder_splits
 
     x = torch.ones(2, 2, device="cuda", requires_grad=True)
 
@@ -1168,7 +1168,7 @@ def test_thunder_specific_reports(tmp_path):
 
     results = fx_report(foo, x)
     for idx, fx_graph_report in enumerate(results.fx_graph_reports):
-        thunder_fx_graph_report = analyze_with_thunder(fx_graph_report)
+        thunder_fx_graph_report = analyze_thunder_splits(fx_graph_report)
         thunder_fx_graph_report.write_thunder_repro(tmp_path)
         for thunder_split_report in thunder_fx_graph_report.subgraph_reports:
             split_folder = tmp_path / str(idx)

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -1153,7 +1153,7 @@ def test_leak_on_unsupported_thunder_operator():
 
 
 @requiresCUDA
-def test_thunderreports(tmp_path):
+def test_thunder_specific_reports(tmp_path):
     from thunder.dynamo.report import fx_report, analyze_with_thunder
 
     x = torch.ones(2, 2, device="cuda", requires_grad=True)
@@ -1171,14 +1171,14 @@ def test_thunderreports(tmp_path):
         thunder_fx_graph_report = analyze_with_thunder(fx_graph_report)
         thunder_fx_graph_report.write_thunder_repro(tmp_path)
         for thunder_split_report in thunder_fx_graph_report.subgraph_reports:
-            seg_folder = tmp_path / str(idx)
-            thunder_split_report.write_eager_repro(seg_folder)
-            thunder_split_report.write_thunder_repro(seg_folder)
-            thunder_split_report.write_inductor_repro(seg_folder)
+            split_folder = tmp_path / str(idx)
+            thunder_split_report.write_eager_repro(split_folder)
+            thunder_split_report.write_thunder_repro(split_folder)
+            thunder_split_report.write_inductor_repro(split_folder)
             thunder_split_report.create_fusion_reports()
             for nvf in thunder_split_report.fusion_reports:
-                nvf.write_nvfuser_repro(seg_folder / "nvfusion")
-                nvf.write_inductor_repro(seg_folder / "nvfusion")
+                nvf.write_nvfuser_repro(split_folder / "nvfusion")
+                nvf.write_inductor_repro(split_folder / "nvfusion")
                 bench_data = nvf.run_benchmark()
 
     def check(file_name, cmd):

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -1171,13 +1171,15 @@ def test_thunderreports(tmp_path):
         thunder_fx_graph_report = analyze_with_thunder(fx_graph_report)
         thunder_fx_graph_report.write_thunder_repro(tmp_path)
         for thunder_segment_report in thunder_fx_graph_report.subgraph_reports:
-            thunder_segment_report.write_eager_repro(tmp_path / str(idx))
-            thunder_segment_report.write_thunder_repro(tmp_path / str(idx))
-            thunder_segment_report.write_inductor_repro(tmp_path / str(idx))
-        for nvf in thunder_fx_graph_report.fusion_reports:
-            nvf.write_nvfuser_repro(tmp_path / "nvfusion")
-            nvf.run_inductor_repro()
-            nvf.run_benchmark()
+            seg_folder = tmp_path / str(idx)
+            thunder_segment_report.write_eager_repro(seg_folder)
+            thunder_segment_report.write_thunder_repro(seg_folder)
+            thunder_segment_report.write_inductor_repro(seg_folder)
+            thunder_segment_report.create_fusion_reports()
+            for nvf in thunder_segment_report.fusion_reports:
+                nvf.write_nvfuser_repro(seg_folder / "nvfusion")
+                nvf.run_inductor_repro()
+                nvf.run_benchmark()
 
     def check(file_name, cmd):
         cmd = cmd + [file_name]
@@ -1186,7 +1188,7 @@ def test_thunderreports(tmp_path):
 
     cmd = [sys.executable]
     py_files = list(tmp_path.rglob("*.py"))
-    assert len(py_files) == 10
+    assert len(py_files) == 12
 
     for file in py_files:
         check(file, cmd)

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -1170,16 +1170,16 @@ def test_thunderreports(tmp_path):
     for idx, fx_graph_report in enumerate(results.fx_graph_reports):
         thunder_fx_graph_report = analyze_with_thunder(fx_graph_report)
         thunder_fx_graph_report.write_thunder_repro(tmp_path)
-        for thunder_segment_report in thunder_fx_graph_report.subgraph_reports:
+        for thunder_split_report in thunder_fx_graph_report.subgraph_reports:
             seg_folder = tmp_path / str(idx)
-            thunder_segment_report.write_eager_repro(seg_folder)
-            thunder_segment_report.write_thunder_repro(seg_folder)
-            thunder_segment_report.write_inductor_repro(seg_folder)
-            thunder_segment_report.create_fusion_reports()
-            for nvf in thunder_segment_report.fusion_reports:
+            thunder_split_report.write_eager_repro(seg_folder)
+            thunder_split_report.write_thunder_repro(seg_folder)
+            thunder_split_report.write_inductor_repro(seg_folder)
+            thunder_split_report.create_fusion_reports()
+            for nvf in thunder_split_report.fusion_reports:
                 nvf.write_nvfuser_repro(seg_folder / "nvfusion")
-                nvf.run_inductor_repro()
-                nvf.run_benchmark()
+                nvf.write_inductor_repro(seg_folder / "nvfusion")
+                bench_data = nvf.run_benchmark()
 
     def check(file_name, cmd):
         cmd = cmd + [file_name]
@@ -1188,7 +1188,7 @@ def test_thunderreports(tmp_path):
 
     cmd = [sys.executable]
     py_files = list(tmp_path.rglob("*.py"))
-    assert len(py_files) == 12
+    assert len(py_files) == 16
 
     for file in py_files:
         check(file, cmd)


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes #1741 .

adds `ThunderFXGraphReport, ThunderSegmentGraphReport, ThunderFusionReport, analyze_with_thunder` to support query thunder split graph and nvfusion information
An example:
```
import tempfile
from pathlib import Path
import torch
from thunder.dynamo.report import (
    fx_report, FXReport, ThunderFXGraphReport, FXGraphReport, 
    ThunderSplitGraphReport, ThunderFusionReport, analyze_thunder_splits
)
from pathlib import Path

x = torch.ones(2, 2, device="cuda", requires_grad=True)

# Dynamo segments `foo` into two graphs. Each graph contains one Thunder-split graph, 
# and each Thunder-split graph has one nvFusion region.
def foo(x):
    x = x.exp()
    torch._dynamo.graph_break()
    y = torch.sinc(x) + torch.cos(x)
    return y + 1

# If using `torch.compile` alone, you can stop here and query the reports in `FXReport`. 
# For more details, see the example in :func:`fx_report`.
results: FXReport = fx_report(foo, x)

tmp_path = Path("tmp_repro")
fx_graph_report: FXGraphReport
for idx, fx_graph_report in enumerate(results.fx_graph_reports):
    # `ThunderFXGraphReport` extends `FXGraphReport`, providing the ability to save 
    # reproduction/benchmark scripts for the original FX graph. Additionally, it 
    # includes information about Thunder-split subgraphs in `subgraph_reports`.
    thunder_fx_graph_report: ThunderFXGraphReport = analyze_thunder_splits(fx_graph_report)
    # Saves a reproduction script for the original FX graph
    thunder_fx_graph_report.write_thunder_repro(tmp_path)

    thunder_split_report: ThunderSplitGraphReport
    for thunder_split_report in thunder_fx_graph_report.subgraph_reports:
        split_folder = tmp_path / str(idx)
        thunder_split_report.write_eager_repro(split_folder)
        thunder_split_report.write_thunder_repro(split_folder)
        thunder_split_report.write_inductor_repro(split_folder)

        # If you are only interested in the Thunder-split FX graph, you can stop here. 
        # If you want to inspect Thunder traces and nvFusion regions further, explicitly call 
        # `ThunderSplitGraphReport.create_fusion_reports()` and analyze as shown below.
        thunder_split_report.create_fusion_reports()
        print(f"fwd_trace:\n{thunder_split_report.fwd_trc}\n")
        print(f"bwd_trace:\n{thunder_split_report.bwd_trc}\n")
        nvfusion_report: ThunderFusionReport
        for nvfusion_report in thunder_split_report.fusion_reports:
            nvfusion_report.write_nvfuser_repro(split_folder / "nvfusion")
            nvfusion_report.write_inductor_repro(split_folder / "nvfusion")
            bench_data = nvfusion_report.run_benchmark()
            print(bench_data)
            print("---"*10)
```
generates files:
```
.
├── 0
│   ├── graph0_thunder_0_repro_eager.py
│   ├── graph0_thunder_0_repro_thunder.py
│   ├── graph0_thunder_0_repro_torchcompile.py
│   └── nvfusion
│       ├── graph0_thunder_0_nvFusion0_backward_repro_inductor.py
│       ├── graph0_thunder_0_nvFusion0_backward_repro_nvfuser.py
│       ├── graph0_thunder_0_nvFusion0_forward_repro_inductor.py
│       └── graph0_thunder_0_nvFusion0_forward_repro_nvfuser.py
├── 1
│   ├── graph1_thunder_1_repro_eager.py
│   ├── graph1_thunder_1_repro_thunder.py
│   ├── graph1_thunder_1_repro_torchcompile.py
│   └── nvfusion
│       ├── graph1_thunder_1_nvFusion0_backward_repro_inductor.py
│       ├── graph1_thunder_1_nvFusion0_backward_repro_nvfuser.py
│       ├── graph1_thunder_1_nvFusion0_forward_repro_inductor.py
│       └── graph1_thunder_1_nvFusion0_forward_repro_nvfuser.py
├── graph0_repro_thunder.py
└── graph1_repro_thunder.py

```
The nvfusion repro script is taken from nvfuser's `repro_script_for`

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
