### PR TITLE
thunderFX - fix leak caused due to holding exception object

### DIFF
--- a/thunder/dynamo/utils.py
+++ b/thunder/dynamo/utils.py
@@ -73,12 +73,12 @@ class SplitReason:
     Attributes:
         reason_type: Reason for the split.
         info: String with details of what caused the split.
-        exception: Exception if there was any.
+        exception: String with details of exception if there was any.
     """
 
     reason_type: SplitReasonType
     info: str | None
-    exception: Exception | None = None
+    exception: str | None = None
 
 
 @dataclasses.dataclass(frozen=True)
@@ -248,7 +248,7 @@ def try_execute_thunder_symbol(thunder_symbol: Symbol, node: torch.fx.Node) -> t
             return False, SplitReason(
                 SplitReasonType.EXCEPTION_PROXY_THUNDER_OP,
                 f"Failed while creating proxy for node with name: {node.name} and target: {node.target}, see exception field",
-                exception=e,
+                exception=str(e),
             )
 
         # We need to be under trace context to generate proxies.
@@ -259,7 +259,7 @@ def try_execute_thunder_symbol(thunder_symbol: Symbol, node: torch.fx.Node) -> t
                 return False, SplitReason(
                     SplitReasonType.EXCEPTION_META_THUNDER_OP,
                     f"Failed while running meta for node with name: {node.name} and target: {node.target}, see exception field",
-                    exception=e,
+                    exception=str(e),
                 )
 
         # Execution with proxies was successful.
@@ -393,7 +393,7 @@ def is_node_supported_by_thunder(node: torch.fx.Node) -> tuple[bool, SplitReason
             return False, SplitReason(
                 SplitReasonType.EXCEPTION_PROXY_THUNDER_OP,
                 f"Failed while creating proxy for node with name: {node.name} and target: {node.target}, see exception field",
-                exception=e,
+                exception=str(e),
             )
         # NOTE: `get_method` may throw if relevant method is not found, so we have guarded it with `has_method`.
         method = torchctx.get_method(node.target, args, kwargs)


### PR DESCRIPTION
Fixes #1750 

The leak occurs because when we see an unsupported thunder operation, we save the exception object in SplitReason 

https://github.com/Lightning-AI/lightning-thunder/blob/f15512a9a4d96dea600866e0e92a30c9a3919700/thunder/dynamo/utils.py#L259-L263

This is a problem because Exception will hold onto frame objects which hold on to locals and also by some interaction leading to a ref cycle (see below).

Fix - We break the cycle by saving the str representation of the exception instead of the exception object. This should be enough to tell what caused the exception.

Ref Cycle Image

<details>

![cycle](https://github.com/user-attachments/assets/c03330a1-6e0a-4dbf-8d70-e7816e9afa7c)

</details>
