### PR TITLE
Simplify and fix match_fw_and_bw_saved_for_bw_proxies implementation

### DIFF
--- a/thunder/core/rematerialization.py
+++ b/thunder/core/rematerialization.py
@@ -537,19 +537,12 @@ def match_fw_and_bw_saved_for_bw_proxies(
     Returns:
         new_required_for_bakward_fw_to_bw_map: Dict[str, Proxy]: mapping of bw names to forward proxies
     """
-
-    old_saved_for_backward_fw = (*fw_trace.bound_symbols[-1].args[1][0], *fw_trace.bound_symbols[-1].args[1][1])
-    old_saved_for_backward_bw = []
-    for bsym in bw_trace.bound_symbols:
-        if bsym.sym.id == PrimIDs.UNPACK_SEQUENCE:
-            flattened_args = tree_flatten(bw_trace.args[1])[0]
-            proxy_names = {y.name for y in flattened_args if isinstance(y, ProxyInterface)}
-            if all(
-                not isinstance(out, CollectionProxy) and out.name not in proxy_names
-                for out in bsym.flat_outs
-                if out is not None
-            ):
-                old_saved_for_backward_bw += bsym.flat_outs
+    old_saved_tensors_fw = fw_trace.output[1][0]
+    old_saved_other_fw = fw_trace.output[1][1]
+    old_saved_for_backward_fw = (*old_saved_tensors_fw, *old_saved_other_fw)
+    old_saved_tensors_bw = bw_trace.args[0][0]
+    old_saved_other_bw = bw_trace.args[0][1]
+    old_saved_for_backward_bw = (*old_saved_tensors_bw, *old_saved_other_bw)
     assert len(old_saved_for_backward_fw) == len(old_saved_for_backward_bw)
     new_required_for_backward_bw_to_fw_map = {
         x.name: y for x, y in zip(old_saved_for_backward_bw, old_saved_for_backward_fw) if x is not None


### PR DESCRIPTION
This change is needed to unblock @jjsjann123 for https://github.com/Lightning-AI/lightning-thunder/issues/1732.

The previous implementation uses both tensors and non-tensors saved for backward in constructing `old_saved_for_backward_fw` but in construction of the mirrored object from the backward trace non-tensors are ignored leading to an error that @jjsjann123 observed while working on https://github.com/Lightning-AI/lightning-thunder/issues/1732.

cc @ali-alshaar7
