### PR TITLE
Update vjp implementation to attach residuals to all outputs

### DIFF
--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -2302,6 +2302,19 @@ def iter_bound_symbols(bound_symbols):
             yield symbol
 
 
+def get_first_proxy(proxies) -> Proxy | None:
+    """Get the first proxy from a list of proxies.
+
+    Args:
+        proxies (List[Proxy]): List of proxies
+
+    Returns:
+        Proxy: First proxy from the list
+    """
+    proxies = sequencify(proxies)
+    return next((proxy for proxy in proxies if isinstance(proxy, Proxy)), None)
+
+
 def deconstruct_forward_env_for_backward(trace, env):
     # Note [Saving the forward environment in the backward rule]
     # We cannot save the trace object in the residuals because executors may not
@@ -2313,7 +2326,7 @@ def deconstruct_forward_env_for_backward(trace, env):
     # arguments. See test_grad.py:test_torch_autograd_function for an example
     # where this is tested.
     bound_symbols = iter_bound_symbols(trace.bound_symbols)
-    saved_for_backward = tuple(env[sequencify(symbol.output)[0].name].residuals for symbol in bound_symbols)
+    saved_for_backward = tuple(env[get_first_proxy(symbol.output).name].residuals for symbol in bound_symbols)
     return saved_for_backward
 
 
@@ -2323,7 +2336,7 @@ def reconstruct_forward_env_for_backward(trace, saved_for_backward):
     reconstructed_env = {}
 
     for idx, sym in enumerate(bound_symbols):
-        k = sequencify(sym.output)[0].name
+        k = get_first_proxy(sym.output).name
         v = VJPDual(None, saved_for_backward[idx])
         reconstructed_env[k] = v
 
@@ -2572,12 +2585,7 @@ def vjp_symbol_mapper(symbol: prims.Symbol, *args, **kwargs):
     def _vjp_impl(*args, **kwargs):
         primals, kwargs = tree_map(lambda x: x.primal if isinstance(x, VJPDual) else x, (args, kwargs))
         out_primal, out_residuals = vjp_impl(*primals, **kwargs)
-        # We are saving the residuals and pullback only in the first output
-        # backward_pass then retrieves the residuals and pullback from the first output
-        if isinstance(out_primal, Sequence):
-            return (VJPDual(out_primal[0], out_residuals), *(VJPDual(o, tuple()) for o in out_primal[1:]))
-
-        return (VJPDual(out_primal, out_residuals),)
+        return tree_map(lambda x: VJPDual(x, out_residuals), sequencify(out_primal))
 
     return _vjp_impl
 
@@ -2732,7 +2740,7 @@ def backward_pass(forward_env, trace, init_cotangents):
         # Having a single cotangent is a common case, so we flatten it
         # Otherwise, we will need to rewrite the pullback functions
         cotangents = tree_flatten(cotangents)[0]
-        residuals = forward_env[symbol_output[0].name].residuals
+        residuals = forward_env[get_first_proxy(symbol_output).name].residuals
         if is_constant_for_vjp(symbol):
             # We can skip the pullback if all the arguments are constant
             continue

--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -56,6 +56,7 @@ from thunder.core.utils import (
     OrderedSet,
     ProxyDict,
 )
+from thunder.core.codeutils import is_literal
 import thunder.clang as clang
 from thunder.clang import (
     empty,
@@ -2292,6 +2293,8 @@ def iter_bound_symbols(bound_symbols):
     """
     for symbol in bound_symbols:
         if symbol.sym.id in trace_interpreter_skip_list:
+            continue
+        elif all(is_literal(sym_out) for sym_out in symbol.flat_outs):
             continue
         elif symbol.output is None:
             continue

--- a/thunder/tests/test_grad.py
+++ b/thunder/tests/test_grad.py
@@ -1934,6 +1934,18 @@ def test_adhoc_executor_grad(executor, device, _):
     torch.testing.assert_close(actual_gr, expected_gr)
 
 
+# See https://github.com/Lightning-AI/lightning-thunder/issues/1732
+def test_symbolic_shape_for_backward_issue_1732():
+    @partial(thunder.jit, cache="symbolic values")
+    def f(a, b):
+        return a * b
+
+    a = make_tensor((1, 32, 232, 232), device="cpu", dtype=torch.float32, requires_grad=True)
+    b = make_tensor((1, 1, 232, 232), device="cpu", dtype=torch.float32, requires_grad=False)
+    out = f(a, b)
+    out.backward(torch.ones_like(out))
+
+
 @pytest.mark.parametrize("device", ("cuda", "cpu"))
 def test_backward_recomputation_decomposed_ops(device):
     if device == "cuda" and not torch.cuda.is_available():


### PR DESCRIPTION
**Base PR: https://github.com/Lightning-AI/lightning-thunder/pull/1754, I'm keeping this PR in Draft for stacking PRs**

The current code assumes that the first output of all BoundSymbols will be a Proxy with a `.name` attribute. It's not always the case when DCE might replace unused outputs with `None` or some other objects are returned from Symbols.

The important changes are:

* skipping symbols with no proxies in the output to attach additional metadata for propagation (using is_literal, the approach is similar to the attempt in https://github.com/Lightning-AI/lightning-thunder/pull/1712)
* instead of specialing on the assumption that the first output of bound symbols is always a proxy object we actually find the first output, if all outputs are non-proxies they should have been skipped due to changes from the previous bullet point

I added the test from the issue description of https://github.com/Lightning-AI/lightning-thunder/issues/1732.

Fixes https://github.com/Lightning-AI/lightning-thunder/issues/1732.

