### PR TITLE
add torch.optim._functional.sgd benchmark

### DIFF
--- a/thunder/benchmarks/__init__.py
+++ b/thunder/benchmarks/__init__.py
@@ -3227,11 +3227,12 @@ class SGDBenchmark(Benchmark, metaclass=UserFacingBenchmarkMeta):
 
     def fn(self) -> Callable:
         params_tensor = [
-            make_tensor(shape, device=self.device, dtype=self.tdtype, requires_grad=False)
-            for shape in self.params
+            make_tensor(shape, device=self.device, dtype=self.tdtype, requires_grad=False) for shape in self.params
         ]
         d_p_list = [make_tensor(d_p, device=self.device, dtype=self.tdtype, requires_grad=False) for d_p in self.params]
-        momentum_buffer_list = [make_tensor(mbl, device=self.device, dtype=self.tdtype, requires_grad=False) for mbl in self.params]
+        momentum_buffer_list = [
+            make_tensor(mbl, device=self.device, dtype=self.tdtype, requires_grad=False) for mbl in self.params
+        ]
 
         @torch.no_grad()
         def foo(params_tensor, d_p_list):
@@ -3246,6 +3247,7 @@ class SGDBenchmark(Benchmark, metaclass=UserFacingBenchmarkMeta):
                 nesterov=0.001,
                 maximize=False,
             )
+
         return lambda *args, **kwargs: foo(params_tensor, d_p_list)
 
 

--- a/thunder/benchmarks/__init__.py
+++ b/thunder/benchmarks/__init__.py
@@ -3216,8 +3216,8 @@ class SGDBenchmark(Benchmark, metaclass=UserFacingBenchmarkMeta):
     def __init__(
         self,
         params: Sequence[int],
-        foreach: Optional[bool],
-        fused: Optional[bool],
+        foreach: bool | None,
+        fused: bool | None,
         device: str = "cuda",
         dtype: dtypes.dtype = thunder.float32,
         requires_grad: bool = False,
@@ -3225,8 +3225,8 @@ class SGDBenchmark(Benchmark, metaclass=UserFacingBenchmarkMeta):
         super().__init__()
 
         self.params: Sequence[int] = params
-        self.foreach: Optional[bool] = foreach
-        self.fused: Optional[bool] = fused
+        self.foreach: bool | None = foreach
+        self.fused: bool | None = fused
         self.device: str = device
         self.dtype: dtypes.dtype = dtype
         self.tdtype: torch.dtype = ltorch.to_torch_dtype(self.dtype)

--- a/thunder/benchmarks/__init__.py
+++ b/thunder/benchmarks/__init__.py
@@ -3170,6 +3170,85 @@ class LinearLoRABenchmark(Benchmark, metaclass=UserFacingBenchmarkMeta):
         return self.lora_cls(self.model)
 
 
+class SGDBenchmark(Benchmark, metaclass=UserFacingBenchmarkMeta):
+    _args = (
+        BenchmarkArg(
+            name="params",
+            description="An iterable of parameters.",
+        ),
+        BenchmarkArg(
+            name="device",
+            description="A string representing the device to run on. Default is 'cuda'.",
+        ),
+        BenchmarkArg(
+            name="dtype",
+            description="The dtype of the tensors. Default is thunder.float32.",
+        ),
+        BenchmarkArg(
+            name="requires_grad",
+            description="Whether the input tensors require grad. Default is False.",
+        ),
+    )
+
+    @classmethod
+    @property
+    def name(cls) -> str:
+        return "litgpt-sgd"
+
+    @classmethod
+    @property
+    def description(cls) -> str:
+        return "LitGPT's 'SGD' optimizer"
+
+    @classmethod
+    @property
+    def args(cls) -> tuple[BenchmarkArg, ...]:
+        return cls._args
+
+    def __init__(
+        self,
+        params: Sequence[int],
+        device: str = "cuda",
+        dtype: dtypes.dtype = thunder.float32,
+        requires_grad: bool = False,
+    ) -> None:
+        super().__init__()
+
+        self.params: Sequence[int] = params
+        self.device: str = device
+        self.dtype: dtypes.dtype = dtype
+        self.tdtype: torch.dtype = ltorch.to_torch_dtype(self.dtype)
+        self.requires_grad: bool = requires_grad
+
+        self.devices: list[str] = [device]
+
+    def make_batch(self) -> tuple[list, dict]:
+        return (make_tensor(self.params, device=self.device, dtype=self.tdtype, requires_grad=False),), {}
+
+    def fn(self) -> Callable:
+        params_tensor = [
+            make_tensor(shape, device=self.device, dtype=self.tdtype, requires_grad=False)
+            for shape in self.params
+        ]
+        d_p_list = [make_tensor(d_p, device=self.device, dtype=self.tdtype, requires_grad=False) for d_p in self.params]
+        momentum_buffer_list = [make_tensor(mbl, device=self.device, dtype=self.tdtype, requires_grad=False) for mbl in self.params]
+
+        @torch.no_grad()
+        def foo(params_tensor, d_p_list):
+            return torch.optim._functional.sgd(
+                params_tensor,
+                d_p_list,
+                momentum_buffer_list,
+                lr=0.001,
+                momentum=0,
+                weight_decay=0,
+                dampening=0.01,
+                nesterov=0.001,
+                maximize=False,
+            )
+        return lambda *args, **kwargs: foo(params_tensor, d_p_list)
+
+
 # TODO Add descriptions to the executors when listed, and list them alphabetically
 # TODO Allow querying benchmark for details
 # TODO Allow specifying benchmark arguments

--- a/thunder/benchmarks/__init__.py
+++ b/thunder/benchmarks/__init__.py
@@ -3178,11 +3178,11 @@ class SGDBenchmark(Benchmark, metaclass=UserFacingBenchmarkMeta):
         ),
         BenchmarkArg(
             name="foreach",
-            description="An optional boolean parameter to enable multi-tensor adam (horizontal fusion).",
+            description="An optional boolean parameter to enable multi-tensor sgd (horizontal fusion).",
         ),
         BenchmarkArg(
             name="fused",
-            description="An optional boolean parameter to enable fused adam (vertical fusion).",
+            description="An optional boolean parameter to enable fused sgd (vertical fusion).",
         ),
         BenchmarkArg(
             name="device",

--- a/thunder/benchmarks/__init__.py
+++ b/thunder/benchmarks/__init__.py
@@ -3193,12 +3193,12 @@ class SGDBenchmark(Benchmark, metaclass=UserFacingBenchmarkMeta):
     @classmethod
     @property
     def name(cls) -> str:
-        return "litgpt-sgd"
+        return "optim-functional-sgd"
 
     @classmethod
     @property
     def description(cls) -> str:
-        return "LitGPT's 'SGD' optimizer"
+        return "Benchmark 'torch.optim._functional.sgd' optimizer"
 
     @classmethod
     @property
@@ -3223,7 +3223,7 @@ class SGDBenchmark(Benchmark, metaclass=UserFacingBenchmarkMeta):
         self.devices: list[str] = [device]
 
     def make_batch(self) -> tuple[list, dict]:
-        pt = partial(make_tensor, device=self.device, dtype=self.tdtype, requires_grad=False)
+        pt = partial(make_tensor, device=self.device, dtype=self.tdtype, requires_grad=self.requires_grad)
         params = [pt(shape) for shape in self.params]
         d_p_list = [pt(d_p) for d_p in self.params]
         momentum_buffer_list = [pt(mbl) for mbl in self.params]

--- a/thunder/benchmarks/targets.py
+++ b/thunder/benchmarks/targets.py
@@ -955,7 +955,7 @@ PARAM_SHAPES = [
         torch_compile_executor,
         torch_executor,
     ],
-    ids=["thunderfx", "inductor", "eager"]
+    ids=["thunderfx", "inductor", "eager"],
 )
 @parametrize_compute_type_without_backward
 @pytest.mark.parametrize(

--- a/thunder/benchmarks/targets.py
+++ b/thunder/benchmarks/targets.py
@@ -5,7 +5,6 @@ from collections.abc import Callable
 from enum import auto, Enum
 from collections.abc import Sequence
 from contextlib import nullcontext
-from typing import Any, Optional
 
 import pytest
 import torch
@@ -959,27 +958,24 @@ def test_lora_linear(benchmark, executor, compute_type, implementation):
     ids=("64x64", "128x64"),
 )
 @pytest.mark.parametrize(
-    "foreach,",
-    [True, False],
-    ids=["foreach-true", "foreach-false"],
-)
-@pytest.mark.parametrize(
-    "fused,",
-    [True, False],
-    ids=["fused-true", "fused-false"],
+    "config,",
+    [
+        ("single_tensor", False, False),
+        ("multi_tensor", True, False),
+        ("fused", False, True),
+    ],
+    ids=["single_tensor", "multi_tensor(foreach)", "fused"],
 )
 def test_optim_functional_sgd(
     benchmark,
     executor: None | Callable,
+    config: tuple[str, bool, bool],
     params: Sequence[int],
-    foreach: bool | None,
-    fused: bool | None,
     compute_type: ComputeType,
 ):
     bench: Benchmark = SGDBenchmark(
+        config=config,
         params=params,
-        foreach=foreach,
-        fused=fused,
         device="cuda:0",
         dtype=thunder.float32,
         requires_grad=is_requires_grad(compute_type),

--- a/thunder/benchmarks/targets.py
+++ b/thunder/benchmarks/targets.py
@@ -968,7 +968,14 @@ def test_lora_linear(benchmark, executor, compute_type, implementation):
     [True, False],
     ids=["fused-true", "fused-false"],
 )
-def test_optim_functional_sgd(benchmark, executor: None | Callable, params: Sequence[int], foreach: Optional[bool], fused: Optional[bool], compute_type: ComputeType):
+def test_optim_functional_sgd(
+    benchmark,
+    executor: None | Callable,
+    params: Sequence[int],
+    foreach: bool | None,
+    fused: bool | None,
+    compute_type: ComputeType,
+):
     bench: Benchmark = SGDBenchmark(
         params=params,
         foreach=foreach,

--- a/thunder/benchmarks/targets.py
+++ b/thunder/benchmarks/targets.py
@@ -942,12 +942,6 @@ def test_lora_linear(benchmark, executor, compute_type, implementation):
     benchmark_for_compute_type(compute_type, benchmark, fn, args, kwargs)
 
 
-PARAM_SHAPES = [
-    (64, 64),
-    (128, 64),
-]
-
-
 @pytest.mark.parametrize(
     "executor",
     [
@@ -960,10 +954,10 @@ PARAM_SHAPES = [
 @parametrize_compute_type_without_backward
 @pytest.mark.parametrize(
     "params",
-    PARAM_SHAPES,
-    ids=("x".join(map(str, shape)) for shape in PARAM_SHAPES),
+    [(64, 64), (128, 64)],
+    ids=("64x64", "128x64"),
 )
-def test_litgpt_sgd(benchmark, executor: None | Callable, params: Sequence[int], compute_type: ComputeType):
+def test_optim_functional_sgd(benchmark, executor: None | Callable, params: Sequence[int], compute_type: ComputeType):
     bench: Benchmark = SGDBenchmark(
         params=params,
         device="cuda:0",
@@ -973,6 +967,5 @@ def test_litgpt_sgd(benchmark, executor: None | Callable, params: Sequence[int],
 
     jfn = executor(bench.fn())
     args, kwargs = bench.make_batch()
-    args = [args]
 
     benchmark_for_compute_type(compute_type, benchmark, jfn, args, kwargs)


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes a part of #1213

Hi!! The PR adds the benchmarking suite for the `torch.optim._functional.sgd` in Thunder.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃

### Benchmarking Result
```python
-------------------------------------------------------------------------------------- benchmark 'params=(128, 64) compute_type=ComputeType.INFERENCE': 9 tests -------------------------------------------------------------------------------------
Name (time in us)                                                                   Min                 Max               Mean            StdDev             Median               IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_optim_functional_sgd[single_tensor-128x64-inference-eager]                  5.0233 (1.0)       25.9809 (2.28)      5.9910 (1.0)      1.0657 (1.79)      5.8905 (1.0)      0.7361 (1.89)        92;72      166.9173 (1.0)        1722         100
test_optim_functional_sgd[multi_tensor(foreach)-128x64-inference-eager]          7.4700 (1.49)      11.3921 (1.0)       8.1289 (1.36)     0.5968 (1.0)       7.8498 (1.33)     0.7170 (1.84)       185;58      123.0173 (0.74)       1442         100
test_optim_functional_sgd[fused-128x64-inference-eager]                          9.3390 (1.86)      18.8165 (1.65)     12.8410 (2.14)     0.8267 (1.39)     12.7973 (2.17)     0.3899 (1.0)       131;138       77.8755 (0.47)       1066         100
test_optim_functional_sgd[fused-128x64-inference-inductor]                      15.5461 (3.09)      25.1313 (2.21)     18.8863 (3.15)     1.1786 (1.97)     18.4863 (3.14)     1.0474 (2.69)        65;31       52.9484 (0.32)        494         100
test_optim_functional_sgd[fused-128x64-inference-thunderfx]                     18.5124 (3.69)      33.5932 (2.95)     20.6712 (3.45)     2.1152 (3.54)     19.8755 (3.37)     1.5047 (3.86)      168;131       48.3764 (0.29)       2089          26
test_optim_functional_sgd[multi_tensor(foreach)-128x64-inference-inductor]      22.6249 (4.50)      40.6630 (3.57)     24.8530 (4.15)     2.5861 (4.33)     24.1216 (4.10)     0.8473 (2.17)      125;235       40.2366 (0.24)       2022          22
test_optim_functional_sgd[multi_tensor(foreach)-128x64-inference-thunderfx]     22.7923 (4.54)      36.0619 (3.17)     24.5947 (4.11)     2.2432 (3.76)     23.8925 (4.06)     0.6388 (1.64)      110;212       40.6592 (0.24)       1618          27
test_optim_functional_sgd[single_tensor-128x64-inference-inductor]              24.2358 (4.82)      63.6654 (5.59)     28.3064 (4.72)     3.3781 (5.66)     26.9985 (4.58)     2.0334 (5.21)      260;258       35.3277 (0.21)       2415          17
test_optim_functional_sgd[single_tensor-128x64-inference-thunderfx]             75.3719 (15.00)    147.2263 (12.92)    87.1044 (14.54)    8.6950 (14.57)    83.5975 (14.19)    8.1656 (20.94)      164;96       11.4805 (0.07)       1354          10
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

-------------------------------------------------------------------------------------- benchmark 'params=(64, 64) compute_type=ComputeType.INFERENCE': 9 tests --------------------------------------------------------------------------------------
Name (time in us)                                                                  Min                 Max               Mean             StdDev             Median               IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_optim_functional_sgd[single_tensor-64x64-inference-eager]                  5.6589 (1.0)        9.4847 (1.0)       6.0785 (1.0)       0.5006 (1.0)       5.9257 (1.0)      0.1675 (1.0)       204;267      164.5137 (1.0)        1794         100
test_optim_functional_sgd[multi_tensor(foreach)-64x64-inference-eager]          7.0648 (1.25)      18.8885 (1.99)      9.0705 (1.49)      0.7011 (1.40)      8.8928 (1.50)     0.3341 (1.99)       95;109      110.2469 (0.67)       1195         100
test_optim_functional_sgd[fused-64x64-inference-eager]                          9.2662 (1.64)      19.2645 (2.03)     11.4388 (1.88)      0.9412 (1.88)     11.2141 (1.89)     1.1552 (6.90)       172;19       87.4216 (0.53)        828         100
test_optim_functional_sgd[fused-64x64-inference-inductor]                      16.8737 (2.98)      48.6152 (5.13)     21.7999 (3.59)      2.8798 (5.75)     21.7884 (3.68)     2.8691 (17.13)     217;110       45.8717 (0.28)       2067          26
test_optim_functional_sgd[multi_tensor(foreach)-64x64-inference-inductor]      18.4864 (3.27)      96.7337 (10.20)    24.2810 (3.99)      3.7556 (7.50)     24.3454 (4.11)     1.2862 (7.68)      565;674       41.1845 (0.25)       2429          18
test_optim_functional_sgd[fused-64x64-inference-thunderfx]                     18.6402 (3.29)      36.4307 (3.84)     20.8482 (3.43)      2.3891 (4.77)     19.9423 (3.37)     1.5263 (9.11)      183;163       47.9657 (0.29)       2301          23
test_optim_functional_sgd[multi_tensor(foreach)-64x64-inference-thunderfx]     18.6514 (3.30)      40.7179 (4.29)     24.4146 (4.02)      3.3061 (6.60)     24.0946 (4.07)     0.7456 (4.45)      358;659       40.9591 (0.25)       2159          20
test_optim_functional_sgd[single_tensor-64x64-inference-inductor]              24.6182 (4.35)      74.3911 (7.84)     30.7613 (5.06)      3.6651 (7.32)     29.7588 (5.02)     0.9298 (5.55)      179;369       32.5083 (0.20)       2544          16
test_optim_functional_sgd[single_tensor-64x64-inference-thunderfx]             77.8082 (13.75)    281.9272 (29.72)    91.0393 (14.98)    10.4559 (20.89)    87.6901 (14.80)    4.4791 (26.74)     130;160       10.9843 (0.07)       1225          10
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
```
#### Command to run the benchmarks
```python
pytest thunder/benchmarks/targets.py -k "test_optim_functional_sgd" --benchmark-group-by='param:params,param:compute_type'
```