### PR TITLE
Mark `test_vjp_correctness_sdpa_manual` with non-strict xfail instead of version check

### DIFF
--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -8463,6 +8463,15 @@ grad_sdpa_opinfo = OpInfo(
     # NOTE: NotImplementedError: Could not run 'aten::_scaled_dot_product_efficient_attention' with arguments from the 'CPU' backend.
     # NOTE: NotImplementedError: Could not run 'aten::_scaled_dot_product_efficient_attention_backward' with arguments from the 'CPU' backend
     devicetypes=(devices.DeviceType.CUDA,),
+    test_directives=(
+        # The test might fail due to numerical issues with bfloat16
+        # https://github.com/Lightning-AI/lightning-thunder/issues/703
+        DecorateInfo(
+            pytest.mark.xfail(strict=False),
+            "test_vjp_correctness_sdpa_manual",
+            dtypes=(datatypes.bfloat16,),
+        ),
+    )
 )
 nn_ops.append(grad_sdpa_opinfo)
 

--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -8467,7 +8467,7 @@ grad_sdpa_opinfo = OpInfo(
         # The test might fail due to numerical issues with bfloat16
         # https://github.com/Lightning-AI/lightning-thunder/issues/703
         DecorateInfo(
-            pytest.mark.xfail(strict=False),
+            pytest.mark.xfail(strict=False, raises=AssertionError),
             "test_vjp_correctness_sdpa_manual",
             dtypes=(datatypes.bfloat16,),
         ),

--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -8471,7 +8471,7 @@ grad_sdpa_opinfo = OpInfo(
             "test_vjp_correctness_sdpa_manual",
             dtypes=(datatypes.bfloat16,),
         ),
-    )
+    ),
 )
 nn_ops.append(grad_sdpa_opinfo)
 

--- a/thunder/tests/test_grad.py
+++ b/thunder/tests/test_grad.py
@@ -556,11 +556,6 @@ def test_vjp_correctness_sdpa_manual(op, device, dtype, executor, comp):
     from thunder.common import CompileData
     from thunder.core.compile_data import compile_data_and_stats
 
-    if version_between(torch.__version__, min_ver="2.5.0a0", max_ver="2.6.0a99"):
-        raise pytest.skip(
-            "https://github.com/Lightning-AI/lightning-thunder/issues/703",
-        )
-
     for sample in op.sample_inputs(device, dtype, requires_grad=True):
         from thunder.executors.sdpaex import sdpa_ex
 


### PR DESCRIPTION
Mark `test_vjp_correctness_sdpa_manual` with non-strict xfail instead of version check. The current nightly PyTorch version is 2.7 and the flakiness may re-emerge as seen in https://github.com/NVIDIA/Fuser/issues/3905.

The numerical flakiness of this test is tracked in https://github.com/Lightning-AI/lightning-thunder/issues/703.

cc @borda