### PR TITLE
[ThunderFX report] Adds `thunderfx_benchmark_report` to do some automatic performance analysis on the FX graph

### DIFF
--- a/thunder/dynamo/benchmark_utils.py
+++ b/thunder/dynamo/benchmark_utils.py
@@ -105,7 +105,9 @@ class TorchEagerSpecification(CompileSpecificationInterface):
 
 class TorchInductorSpecification(CompileSpecificationInterface):
     """
-    A compile specification for :func:`torch.compile`.
+    A compilation specification for using TorchInductor without TorchDynamo.
+    For details on why compilation without TorchDynamo is needed, see:
+    https://github.com/Lightning-AI/lightning-thunder/issues/1521
     """
 
     def __init__(self, inputs, specification_name="inductor_backend"):

--- a/thunder/dynamo/benchmark_utils.py
+++ b/thunder/dynamo/benchmark_utils.py
@@ -131,7 +131,7 @@ class TorchInductorSpecification(CompileSpecificationInterface):
 
 
 class BoundSymbolNvfuserSpecification(CompileSpecificationInterface):
-    def __init__(self, specification_name="nvfusersymbol_nvfuser"):
+    def __init__(self, specification_name="nvfuser"):
         self.name: str = specification_name
 
     # Returns the nvFuser callable from the nvFuser bound symbol.
@@ -141,7 +141,7 @@ class BoundSymbolNvfuserSpecification(CompileSpecificationInterface):
 
 
 class BoundSymbolTorchCompileSpecification(CompileSpecificationInterface):
-    def __init__(self, specification_name="nvfusersymbol_torchcompile"):
+    def __init__(self, specification_name="torchcompile"):
         self.name: str = specification_name
 
     # Returns the torch compile callable from the nvFuser bound symbol.

--- a/thunder/dynamo/benchmark_utils.py
+++ b/thunder/dynamo/benchmark_utils.py
@@ -48,7 +48,8 @@ class ThunderCompileSpecification(CompileSpecificationInterface):
         compiled_fn = spec.compile(my_function)
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, specification_name="thunder", **kwargs):
+        self.name = specification_name
         self.thunder_options: dict = kwargs
 
     def compile(self, fn):
@@ -69,7 +70,8 @@ class TorchCompileSpecification(CompileSpecificationInterface):
     A compile specification for :func:`torch.compile`.
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, specification_name="torchcompile", **kwargs):
+        self.name = specification_name
         self.torch_compile_options: dict = kwargs
 
     def compile(self, fn):
@@ -91,6 +93,9 @@ class TorchEagerSpecification(CompileSpecificationInterface):
     A compile specification for Torch eager mode, which returns the callable unchanged.
     """
 
+    def __init__(self, specification_name="torcheager"):
+        self.name = specification_name
+
     def compile(self, fn):
         return fn
 
@@ -103,7 +108,8 @@ class TorchInductorSpecification(CompileSpecificationInterface):
     A compile specification for :func:`torch.compile`.
     """
 
-    def __init__(self, inputs):
+    def __init__(self, inputs, specification_name="inductor_backend"):
+        self.name: str = specification_name
         self.inputs: list = inputs
 
     @staticmethod
@@ -125,6 +131,9 @@ class TorchInductorSpecification(CompileSpecificationInterface):
 
 
 class BoundSymbolNvfuserSpecification(CompileSpecificationInterface):
+    def __init__(self, specification_name="nvfusersymbol_nvfuser"):
+        self.name: str = specification_name
+
     # Returns the nvFuser callable from the nvFuser bound symbol.
     # See the TODO in :class:`thunder.dynamo.report.ThunderFusionReport` for more details.
     def compile(self, nvfusion_bsym):
@@ -132,6 +141,9 @@ class BoundSymbolNvfuserSpecification(CompileSpecificationInterface):
 
 
 class BoundSymbolTorchCompileSpecification(CompileSpecificationInterface):
+    def __init__(self, specification_name="nvfusersymbol_torchcompile"):
+        self.name: str = specification_name
+
     # Returns the torch compile callable from the nvFuser bound symbol.
     # See the TODO in :class:`thunder.dynamo.report.ThunderFusionReport` for more details.
     def compile(self, bsym):

--- a/thunder/dynamo/benchmark_utils.py
+++ b/thunder/dynamo/benchmark_utils.py
@@ -247,7 +247,7 @@ class WallTime(TimerInterface):
         return ["from thunder.dynamo.benchmark_utils import WallTime"]
 
     @staticmethod
-    def to_source(fn_name="compiled_model", inputs_name="inputs"):
+    def to_source(fn_name, inputs_name):
         return f'WallTime.time("{fn_name}(*{inputs_name})", globals={{"{fn_name}":{fn_name}, "{inputs_name}": {inputs_name}}})'
 
 
@@ -271,5 +271,5 @@ class KernelTime(TimerInterface):
         return ["from thunder.dynamo.benchmark_utils import KernelTime"]
 
     @staticmethod
-    def to_source(fn_name="compiled_model", inputs_name="inputs"):
+    def to_source(fn_name, inputs_name):
         return f'KernelTime.time("{fn_name}(*{inputs_name})", globals={{"{fn_name}":{fn_name}, "{inputs_name}": {inputs_name}}})'

--- a/thunder/dynamo/compiler.py
+++ b/thunder/dynamo/compiler.py
@@ -139,7 +139,7 @@ class ThunderCompiler:
 
                 compile_fn = ThunderCompileSpecification(**self.thunder_options)
                 if not use_pytest_benchmark:
-                    report.write_repro_v2(
+                    report.write_repro(
                         reproducer_folder,
                         file_name=f"{report.graph_name}_repro.py",
                         compile_fn=compile_fn,

--- a/thunder/dynamo/report.py
+++ b/thunder/dynamo/report.py
@@ -993,6 +993,25 @@ def thunderfx_benchmark_report(
     atol=0.0,
     **kwargs,
 ):
+    """
+    A utility function that analyzes the runnability and performance benchmarks of each FX graph.
+
+    1. Checks if the callable can be executed with `torch.compile`.
+    - If it fails, attempts to run it eagerly.
+    - If eager execution also fails, an error is printed, and the function returns.
+    - If eager execution succeeds, the analysis continues.
+
+    2. Collects all ThunderFX subgraphs and verifies whether each subgraph can be successfully executed by Thunder.
+
+    3. For each subgraph:
+    - Compares wall time and kernel time between `torch.compile` and Thunder.
+    - Reports performance metrics and saves the benchmark script in `folder_path` if the difference exceeds the tolerance (`rtol`, `atol`).
+    - Uses `math.isclose` for tolerance checks.
+
+    4. If `compare_fusion` is `True`:
+    - Also compares the wall time and kernel time of each nvFusion region.
+    - Saves the benchmark script when necessary, following the same criteria as above.
+    """
     torch_compile_success = True
     try:
         torch_compiled = torch.compile(fn)

--- a/thunder/dynamo/repro_script_template.py
+++ b/thunder/dynamo/repro_script_template.py
@@ -1,3 +1,8 @@
+FXGRAPH_CLASS_NAME = "DynamoModule"
+INPUTS_NAME = "inputs"
+CALLABLE_NAME = "model"
+COMPILED_CALLABLE_NAME = "compiled_model"
+
 repro_code_template = '''
 """
 Environment information get from `torch.utils.collect_env.get_pretty_env_info()`:
@@ -138,22 +143,22 @@ bsym = fusion_symbols[0]
 torch_compiled_callable = make_torch_compile_callable(bsym.subsymbols, bsym.flat_args, bsym.flat_outs)
 """
 
-repro_bench_code_template = '''
+repro_bench_code_template = f'''
 """
 Environment information get from `torch.utils.collect_env.get_pretty_env_info()`:
-{torch_env}
+{{torch_env}}
 
 Versions of Thunder related libraries:
-{thunder_pkgs}
+{{thunder_pkgs}}
 
-{extra_comment_str}
+{{extra_comment_str}}
 """
-{import_str}
+{{import_str}}
 
-def test_{graph_name}():
-{dynamo_module}
+def test_{{graph_name}}():
+{{dynamo_module}}
 
-{inputs}
+{{inputs}}
 
-    model = DynamoModule()
+    model = {FXGRAPH_CLASS_NAME}()
 '''

--- a/thunder/dynamo/repro_script_template.py
+++ b/thunder/dynamo/repro_script_template.py
@@ -120,7 +120,10 @@ def test_{graph_name}(benchmark, executor, compute_type):
 '''
 
 
-bsym_torch_compile_repro_template = """
+bsym_torch_compile_repro_template = '''
+"""
+{extra_comment_str}
+"""
 {python_func}
 
 from thunder.executors.torch_compile import make_compiled as make_torch_compile_callable
@@ -141,7 +144,7 @@ bsym = fusion_symbols[0]
 # Additionally, it's recommended to visually verify that `bsym` matches the
 # `nvFusion` function above by printing it using `print(bsym)`.
 torch_compiled_callable = make_torch_compile_callable(bsym.subsymbols, bsym.flat_args, bsym.flat_outs)
-"""
+'''
 
 repro_bench_code_template = f'''
 """

--- a/thunder/dynamo/utils.py
+++ b/thunder/dynamo/utils.py
@@ -100,6 +100,14 @@ class ExampleInputMetaData:
     def stride(self) -> list[int]:
         return self.strides
 
+    def is_contiguous(self) -> bool:
+        expected_stride = 1
+        for s, actual_stride in reversed(list(zip(self.shape, self.strides))):
+            if actual_stride != expected_stride:
+                return False
+            expected_stride *= s
+        return True
+
 
 @dataclasses.dataclass(frozen=True)
 class SubgraphInfo:
@@ -478,9 +486,11 @@ def _get_example_input_tensor_metadata(t: torch.Tensor) -> ExampleInputMetaData:
 def _create_random_tensor_from_tensor_metadata(t: ExampleInputMetaData) -> torch.Tensor:
     from thunder.tests.make_tensor import make_tensor
 
-    return make_tensor(t.storage_shape, dtype=t.dtype, device=t.device, requires_grad=t.requires_grad).as_strided(
-        t.shape, t.stride()
-    )
+    torch_tensor = make_tensor(t.storage_shape, dtype=t.dtype, device=t.device, requires_grad=t.requires_grad)
+    if t.is_contiguous():
+        return torch_tensor
+
+    return torch_tensor.as_strided(t.shape, t.stride())
 
 
 def _get_example_inputs_from_placeholder(
@@ -613,24 +623,44 @@ def remove_empty_autocast(graph_module: torch.fx.GraphModule) -> torch.fx.GraphM
     return empty_autocast_removed_graph_module
 
 
-def arg_like_tensor(arg: torch.Tensor | ExampleInputMetaData):
-    """Creates a new argument like the given tensor or tensor metadata"""
+def _get_example_input_tensor_metadata(t: torch.Tensor) -> ExampleInputMetaData:
     min_val = None
     max_val = None
+    if not isinstance(t, FakeTensor) and t.device.type != "meta" and t.numel() != 0:
+        minmax: tuple[torch.Tensor, torch.Tensor] = torch.aminmax(t)
+        min_val = minmax[0].cpu().item()
+        max_val = minmax[1].cpu().item()
+    meta_ev = ExampleInputMetaData(
+        t.requires_grad,
+        t.layout,
+        t.device,
+        t.dtype,
+        _concrete_value(t.shape),
+        _get_storage_shape(t),
+        _concrete_value(t.stride()),
+        min_val,
+        max_val,
+    )
+    return meta_ev
+
+
+def arg_like_tensor(arg: torch.Tensor | ExampleInputMetaData):
+    """Creates a new argument like the given tensor or tensor metadata"""
     if isinstance(arg, torch.Tensor):
-        if arg.numel() != 0:
-            min_val, max_val = torch.aminmax(arg)
-            min_val = min_val.cpu().item()
-            max_val = max_val.cpu().item()
-    else:
-        min_val, max_val = arg.min_val, arg.max_val
-    storage_shape = _get_storage_shape(arg) if isinstance(arg, torch.Tensor) else arg.storage_shape
+        arg = _get_example_input_tensor_metadata(arg)
+    min_val, max_val = arg.min_val, arg.max_val
+    storage_shape = arg.storage_shape
+    is_contiguous = arg.is_contiguous()
     if min_val is not None and min_val == max_val:
         meta = f"{storage_shape}, {min_val}, dtype={arg.dtype}, device='{arg.device}', requires_grad={arg.requires_grad}, layout={arg.layout}"
-        return f"torch.full({meta}).as_strided({arg.shape}, {arg.stride()}),"
-    meta = f"{storage_shape}, dtype={arg.dtype},  device='{arg.device}', requires_grad={arg.requires_grad},"
-    meta = f"{meta} low={min_val}, high={max_val},"
-    return f"torch.testing.make_tensor({meta}).as_strided({arg.shape}, {arg.stride()}),"
+        tensor_str = f"torch.full({meta})"
+    else:
+        meta = f"{storage_shape}, dtype={arg.dtype},  device='{arg.device}', requires_grad={arg.requires_grad},"
+        meta = f"{meta} low={min_val}, high={max_val},"
+        tensor_str = f"torch.testing.make_tensor({meta})"
+    if is_contiguous:
+        return f"{tensor_str},"
+    return f"{tensor_str}.as_strided({arg.shape}, {arg.stride()}),"
 
 
 def arg_like(arg: Any):

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -1368,17 +1368,16 @@ def test_TorchInductorSpecification(tmp_path):
 
 
 @requiresCUDA
-def test_autotest_report():
-    from thunder.dynamo.report import thunderfx_test_report
+def test_autotest_report(tmp_path):
+    from thunder.dynamo.report import thunderfx_benchmark_report
+
+    # Workaround for "RuntimeError: Triton Error [CUDA]: an illegal memory access was encountered"
+    # https://github.com/pytorch/pytorch/issues/124565
+    torch.empty(1, device="cuda", requires_grad=True).backward()
 
     x = torch.ones(2, 2, device="cuda", requires_grad=True)
 
     def foo(x):
-        # torch.sinc has automatic fallback registered,
-        # so that operation will be given to inductor.
-        # x = x.exp()
-        # torch._dynamo.graph_break()
-        y = torch.sinc(x) + torch.cos(x)
-        return y + 1
+        return x * x
 
-    thunderfx_test_report(foo, x, compare_fusion=True)
+    thunderfx_benchmark_report(foo, x, folder_path=tmp_path, compare_fusion=True, rtol=0.1)

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -1252,7 +1252,7 @@ def test_ThunderCompileSpecification():
 
 
 @requiresCUDA
-def test_reports_repro_v2(tmp_path):
+def test_reports_repro(tmp_path):
     x = torch.ones(2, 2, device="cuda", requires_grad=True)
 
     def foo(x):
@@ -1365,3 +1365,20 @@ def test_TorchInductorSpecification(tmp_path):
     assert len(py_files) == 2
     for file in py_files:
         run_script(file, cmd)
+
+
+@requiresCUDA
+def test_autotest_report():
+    from thunder.dynamo.report import thunderfx_test_report
+
+    x = torch.ones(2, 2, device="cuda", requires_grad=True)
+
+    def foo(x):
+        # torch.sinc has automatic fallback registered,
+        # so that operation will be given to inductor.
+        # x = x.exp()
+        # torch._dynamo.graph_break()
+        y = torch.sinc(x) + torch.cos(x)
+        return y + 1
+
+    thunderfx_test_report(foo, x, compare_fusion=True)


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

This PR:
1. Adds `thunderfx_benchmark_report` function that uses the previously implemented reporting APIs to analyze the the input callable, see the function comment for details
<details>
<summary>example outputs</summary>

```
The input callable can be successfully executed by torch.compile.

graph0: Split Information:
The original graph is not split, and is entirely run by Thunder.


graph0_thunder_0 can be successfully executed by Thunder

Benchmark walltime for **graph0_thunder_0 forward** requires investigation: thunder(132.469 us) and torchcompile(28.990 us) is not close (rtol=0.1, atol=0.0)
Benchmark walltime for **graph0_thunder_0 backward** requires investigation: thunder(98.921 us) and torchcompile(34.108 us) is not close (rtol=0.1, atol=0.0)
The scripts are saved: graph0_thunder_0_torchcompile_walltime.py, graph0_thunder_0_thunder_walltime.py


Benchmark kerneltime ran successfully on **graph0_thunder_0 forward**: thunder(955.523 ns) , torchcompile(1.002 us)
Benchmark kerneltime ran successfully on **graph0_thunder_0 backward**: thunder(965.957 ns) , torchcompile(1.012 us)


Benchmark walltime for **graph0_thunder_0_nvFusion0_forward** requires investigation: nvfuser(22.932 us) and torchcompile(20.361 us) is not close (rtol=0.1, atol=0.0)
The scripts are saved: graph0_thunder_0_nvFusion0_forward_torchcompile_walltime.py, graph0_thunder_0_nvFusion0_forward_nvfuser_walltime.py


Benchmark kerneltime ran successfully on **graph0_thunder_0_nvFusion0_forward**: nvfuser(952.301 ns) , torchcompile(998.566 ns)


Benchmark walltime for **graph0_thunder_0_nvFusion0_backward** requires investigation: nvfuser(26.004 us) and torchcompile(21.240 us) is not close (rtol=0.1, atol=0.0)
The scripts are saved: graph0_thunder_0_nvFusion0_backward_torchcompile_walltime.py, graph0_thunder_0_nvFusion0_backward_nvfuser_walltime.py


Benchmark kerneltime ran successfully on **graph0_thunder_0_nvFusion0_backward**: nvfuser(962.118 ns) , torchcompile(1.007 us)

```

</details>

2. Adds `TorchInductorSpecification` which uses only TorchInductor without TorchDynamo, the reason is mentioned here https://github.com/Lightning-AI/lightning-thunder/issues/1521
3. Removes the previous write_repro interface, keeping only the one that takes "CompileSpecification" and timer function as inputs
4. Makes some revisions according to the previous review comments
5. Adds the WAR for Triton error:
  <details>
  <summary>repro script</summary>
  
  ```
  import torch
  
  def test_graph0():
      class DynamoModule(torch.nn.Module):
          def forward(self, L_x_ : torch.Tensor):
              l_x_ = L_x_
              x = l_x_.exp();  l_x_ = None
              return (x,)
          
  
      inputs = [
          torch.testing.make_tensor((2, 2), dtype=torch.float32,  device='cuda:0', requires_grad=True),
      ]
  
      model = DynamoModule()
      compiled_model = torch.compile(model, )
      from thunder.dynamo.report import run_forward_backward
  
      result = compiled_model(*inputs)
  
      output_grads = [torch.ones_like(r) for r in result]
  
      torch.autograd.backward(result, output_grads)
      print(result)
  
  # the WAR: https://github.com/pytorch/pytorch/issues/124565
  # torch.empty(1, device='cuda', requires_grad=True).backward()
  test_graph0()
  ```
  
  <\details>
## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
