### PR TITLE
[fix] `ltorch.to` to return a copy, when `copy=True`

### DIFF
--- a/thunder/tests/test_core.py
+++ b/thunder/tests/test_core.py
@@ -1865,6 +1865,18 @@ def test_torch_tensor_to_memory_format(executor: TestExecutor, device: str, _):
         assert_close(torch_result, thunder_result, check_stride=True)
 
 
+def test_torch_tensor_to_return_type():
+    a = torch.randn(2, 4, 5, 3)
+
+    def torch_to(a):
+        return a.to(copy=True)
+
+    jfoo = thunder.jit(torch_to)
+    result = jfoo(a)
+
+    assert result is not a
+
+
 # TODO See issue "Add contiguous and clang.stride_order OpInfos that check stride
 # consistency with PyTorch"
 @instantiate(

--- a/thunder/tests/test_core.py
+++ b/thunder/tests/test_core.py
@@ -1872,9 +1872,11 @@ def test_torch_tensor_to_return_type():
         return a.to(copy=True)
 
     jfoo = thunder.jit(torch_to)
-    result = jfoo(a)
+    thunder_result = jfoo(a)
+    torch_result = torch_to(a)
 
-    assert result is not a
+    assert thunder_result is not a
+    assert_close(torch_result, thunder_result)
 
 
 # TODO See issue "Add contiguous and clang.stride_order OpInfos that check stride

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -472,6 +472,13 @@ def to(
     copy: bool = False,
     memory_format: None | torch.memory_format = None,
 ) -> TensorLike:
+
+    input_device = a.device
+    input_dtype = a.dtype
+    if copy and not _will_to_return_self(input_device, input_dtype, device, dtype, memory_format, copy):
+        b = prims.empty(a.shape, device=input_device, dtype=input_dtype)
+        return _copy_(a, b)
+
     device, dtype = _parse_to_device_and_dtype(
         tensor_dtype_or_device, optional_positional_dtype, device=device, dtype=dtype
     )

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -477,7 +477,7 @@ def to(
     input_dtype = a.dtype
     if copy and not _will_to_return_self(input_device, input_dtype, device, dtype, memory_format, copy):
         b = prims.empty(a.shape, device=input_device, dtype=input_dtype)
-        return _copy_(a, b)
+        return _copy_(b, a)
 
     device, dtype = _parse_to_device_and_dtype(
         tensor_dtype_or_device, optional_positional_dtype, device=device, dtype=dtype


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes #1291

#### Earlier
```python
>>> import torch
>>> import thunder
>>> from thunder.torch import to
>>> a = torch.tensor([1.0, 2.0, 3.0])
>>> def foo(a):
...     return a.to(copy=True)
... 
>>> jfoo = thunder.jit(foo)
>>> result = jfoo(a)
>>> assert result is not a
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AssertionError
>>> 
```

#### Now
```python
>>> import torch
>>> import thunder
>>> from thunder.torch import to
>>> a = torch.tensor([1.0, 2.0, 3.0])
>>> def foo(a):
...     return a.to(copy=True)
... 
>>> jfoo = thunder.jit(foo)
>>> result = jfoo(a)
>>> assert result is not a
>>> 
```

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

:tada: :tada: 