### PR TITLE
added custom logsigmoid grad for torchex

### DIFF
--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -1430,20 +1430,11 @@ register_grad(pids.COPY_WITH_SETITEM, _copy_with_setitem_grad)
 def _log_sigmoid_grad(
     a: TensorProxy,
 ) -> TensorProxy:
-    from thunder.torch import abs, exp, log_sigmoid_backward, logsigmoid
+    from thunder.torch import where, exp, logsigmoid
 
     fwd = logsigmoid(a)
-
     g = get_grad(fwd)
-    if a.device.type == "cpu":
-        # NOTE PyTorch's CPU computation for logsigmoid's grad uses an additional "buffer" tensor, see
-        # https://github.com/pytorch/pytorch/blob/7667235a23e2ffca4d32e6e16aa60a683418e159/torch/_decomp/decompositions.py#L332
-        buffer = exp(-abs(a))
-        a_grad = log_sigmoid_backward(g, a, buffer)
-    else:
-        # Here a placeholder tensor is provided.
-        placeholder_buffer = empty((0,), device=a.device, dtype=a.dtype)
-        a_grad = log_sigmoid_backward(g, a, placeholder_buffer)
+    a_grad =  g * where(a > 0, exp(-a) / (1 + exp(-a)), 1 - exp(a) / (1 + exp(a)))
     put_grad(a, a_grad)
 
     return fwd

--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -1434,7 +1434,7 @@ def _log_sigmoid_grad(
 
     fwd = logsigmoid(a)
     g = get_grad(fwd)
-    a_grad =  g * where(a > 0, exp(-a) / (1 + exp(-a)), 1 - exp(a) / (1 + exp(a)))
+    a_grad = g * where(a > 0, exp(-a) / (1 + exp(-a)), 1 - exp(a) / (1 + exp(a)))
     put_grad(a, a_grad)
 
     return fwd

--- a/thunder/executors/torchex.py
+++ b/thunder/executors/torchex.py
@@ -1795,6 +1795,7 @@ ex.register_implementation(
     ltorch.max_pool3d, max_pool3d, checker=_always_executable, grad_transform=max_pool3d_bwd_wrapper
 )
 
+
 def log_sigmoid_backward_meta(
     g: TensorProxy,
     a: TensorProxy,
@@ -1802,11 +1803,13 @@ def log_sigmoid_backward_meta(
 ) -> TensorProxy:
     return TensorProxy(like=a)
 
+
 log_sigmoid_backward = ex.register_operator(
     "torch.ops.aten.log_sigmoid_backward",
     meta=log_sigmoid_backward_meta,
     fn=torch.ops.aten.log_sigmoid_backward,
 )
+
 
 def log_sigmoid_backward_wrapper(
     a: TensorProxy,
@@ -1825,6 +1828,7 @@ def log_sigmoid_backward_wrapper(
         a_grad = log_sigmoid_backward(g, a, placeholder_buffer)
     put_grad(a, a_grad)
     return fwd
+
 
 ex.register_implementation(
     ltorch.logsigmoid,

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -1836,14 +1836,6 @@ def logsigmoid(a: TensorProxy, /) -> TensorLike:
     return where(a > 0, -log1p(exp(-a)), a - log1p(exp(a)))
 
 
-@torchsymbol("log_sigmoid_backward", id="log_sigmoid_backward")
-def log_sigmoid_backward(g: TensorProxy, a: TensorProxy, buffer: TensorProxy) -> TensorLike:
-    # buffer is used by PyTorch in cpu-based calculations.  See
-    # https://github.com/pytorch/pytorch/blob/7667235a23e2ffca4d32e6e16aa60a683418e159/torch/_decomp/decompositions.py#L332
-    # This is addressed in the custom grad fn thunder.core.transforms._log_sigmoid_grad.
-    return g * where(a > 0, exp(-a) / (1 + exp(-a)), 1 - exp(a) / (1 + exp(a)))
-
-
 # TODO Should this use clamp? -- Would that propagate NaNs properly?
 @torchsymbol(torch.relu, torch.nn.functional.relu, id="torch.relu", is_method=True)
 def relu(a: TensorLike, /, inplace: bool = False) -> TensorLike:


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

## What does this PR do?

Avoids adding the extra creation of the CUDA buffer tensor by implementing a thunder grad formula without it, then adding a special grad formula for logsigmoid when it's being executed by the PyTorch executor that has the buffer tensor.

Fixes # (issue). #1555

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

YES!
