### PR TITLE
benchmark_litgpt - update `low_precision_mode` accepted values

### DIFF
--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -83,7 +83,7 @@ def check_fp8_compute_capability() -> None:
 
 
 def is_transformer_engine(low_precision_mode: str) -> bool:
-    return low_precision_mode in ["fp8-delayed-te", "fp8-delayed-te-wo_layernorm"]
+    return low_precision_mode in ["fp8-default-te", "fp8-default-te-wo_layernorm"]
 
 
 def check_and_update_config_for_te_if_needed(config: Config) -> None:
@@ -430,7 +430,7 @@ class Benchmark_litGPT:
         # Handle fp8 related Linear layer swapping (for torchao or TransformerEngine)
         model = self._torchao_fp8_handler.convert_model_to_fp8(model)
         if self.use_te_fp8_autocast:
-            is_wo_layernorm = self.low_precision_mode == "fp8-delayed-te-wo_layernorm"
+            is_wo_layernorm = self.low_precision_mode == "fp8-default-te-wo_layernorm"
             swap_linear_layers_for_te(model, init_device, swap_layernorm=not is_wo_layernorm)
 
         model.to(dtype=torch.bfloat16)


### PR DESCRIPTION
With TE 2.0, the default recipe is chosen based on the platform

https://github.com/NVIDIA/TransformerEngine/blob/b39397c541292f336c5964dd1661d80c08dc4c78/transformer_engine/pytorch/fp8.py#L46-L51

For B200, it is MXFP8BlockScaling
For H100 and others, it is DelayedScaling

This PR updates `benchmark_litgpt.py` script to update the accepted value for `--low-precision-mode` from `fp8-delayed-te` and `fp8-delayed-te-wo_layernorm` to `fp8-default-te` and `fp8-default-te-wo_layernorm` to hint at this.
