### PR TITLE
Only unsqueeze attn_mask in cudnnex if required

### DIFF
--- a/thunder/executors/cudnnex.py
+++ b/thunder/executors/cudnnex.py
@@ -282,7 +282,8 @@ def _cudnn_sdpa_fwd_impl(
     value = _sdpa_enforce_input_tensor_contiguity(value)
 
     if attn_mask is not None:
-        attn_mask = attn_mask.view((1,) * (query.ndim - attn_mask.ndim), *attn_mask.shape)
+        if query.ndim > attn_mask.ndim:
+            attn_mask = attn_mask.view((1,) * (query.ndim - attn_mask.ndim), *attn_mask.shape)
         # As cudnn does not support boolean attn_mask, convert these to additive mask with -inf
         if attn_mask.dtype == torch.bool:
             attn_bias = torch.zeros_like(attn_mask, dtype=query.dtype)
@@ -640,7 +641,8 @@ def _cudnn_sdpa_bwd_impl(
         grad_value = torch.empty_like(value)
 
     if attn_mask is not None:
-        attn_mask = attn_mask.view((1,) * (query.ndim - attn_mask.ndim), *attn_mask.shape)
+        if query.ndim > attn_mask.ndim:
+            attn_mask = attn_mask.view((1,) * (query.ndim - attn_mask.ndim), *attn_mask.shape)
         if attn_mask.dtype == torch.bool:
             attn_bias = torch.zeros_like(attn_mask, dtype=query.dtype)
             attn_bias.masked_fill_(attn_mask.logical_not(), float("-inf"))

--- a/thunder/executors/cudnnex.py
+++ b/thunder/executors/cudnnex.py
@@ -283,7 +283,7 @@ def _cudnn_sdpa_fwd_impl(
 
     if attn_mask is not None:
         if query.ndim > attn_mask.ndim:
-            attn_mask = attn_mask.view((1,) * (query.ndim - attn_mask.ndim), *attn_mask.shape)
+            attn_mask = attn_mask.view(*((1,) * (query.ndim - attn_mask.ndim)), *attn_mask.shape)
         # As cudnn does not support boolean attn_mask, convert these to additive mask with -inf
         if attn_mask.dtype == torch.bool:
             attn_bias = torch.zeros_like(attn_mask, dtype=query.dtype)
@@ -642,7 +642,7 @@ def _cudnn_sdpa_bwd_impl(
 
     if attn_mask is not None:
         if query.ndim > attn_mask.ndim:
-            attn_mask = attn_mask.view((1,) * (query.ndim - attn_mask.ndim), *attn_mask.shape)
+            attn_mask = attn_mask.view(*((1,) * (query.ndim - attn_mask.ndim)), *attn_mask.shape)
         if attn_mask.dtype == torch.bool:
             attn_bias = torch.zeros_like(attn_mask, dtype=query.dtype)
             attn_bias.masked_fill_(attn_mask.logical_not(), float("-inf"))

--- a/thunder/tests/test_sdpaex_executor.py
+++ b/thunder/tests/test_sdpaex_executor.py
@@ -201,7 +201,7 @@ def test_sdpa_attn_mask(attn_mask_requires_grad, device: str, dtype: torch.dtype
     output = expected.mean()
     output.backward()
 
-    jfun = thunder.jit(func)
+    jfun = thunder.jit(func, executors=[sdpa_ex])
     actual = jfun(query1, key1, value1, attn_mask1)
     output = actual.mean()
     output.backward()


### PR DESCRIPTION
- today if fails when query.ndim == attn_mask.ndim

<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes #1722.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
