### PR TITLE
remove redundant assert

### DIFF
--- a/thunder/core/symbol.py
+++ b/thunder/core/symbol.py
@@ -345,7 +345,6 @@ class Symbol:
             lambda: f"A symbol {self} was called while processing a primitive",
             exception_type=AssertionError,
         )
-        assert symbols_list is not None
 
         symbols_list.append(bsym)
         return result


### PR DESCRIPTION
This check above this assert does the same.

https://github.com/Lightning-AI/lightning-thunder/blob/7fd5686b571eda868f5b8ea02aea231f60518a5c/thunder/core/symbol.py#L343-L347