### PR TITLE
Update thunderfx benchmarks to use new UX

### DIFF
--- a/thunder/benchmarks/__init__.py
+++ b/thunder/benchmarks/__init__.py
@@ -712,9 +712,9 @@ def torch_compile_executor(fn: Callable) -> Callable:
 
 def thunderfx_executor(fn: Callable) -> Callable:
     torch.backends.cuda.matmul.allow_tf32 = True
-    backend = thunder.dynamo.ThunderCompiler()
+    backend = thunder.dynamo.thunderfx
     torch._dynamo.reset()
-    return torch.compile(fn, backend=backend)
+    return backend(fn)
 
 
 def thunder_torch_executor(fn: Callable) -> Callable:


### PR DESCRIPTION
With this PR it's easier to inspect last_traces from a benchmark run thanks to the ThunderFX wrapper.