### PR TITLE
Fix tensor.to

### DIFF
--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -3092,21 +3092,40 @@ def to_sample_generator(op, device, dtype, requires_grad, **kwargs):
     # None
     yield SampleInput(make(4, 4))
 
+    # None - copy
+    yield SampleInput(make(4, 4), copy=True)
+
     # device
     yield SampleInput(make(4, 4), device)
     yield SampleInput(make(4, 4), "cpu")
     yield SampleInput(make(4, 4), "cpu", dtype=to_dtype)
 
+    # device - copy
+    yield SampleInput(make(4, 4), device, copy=True)
+    yield SampleInput(make(4, 4), "cpu", copy=True)
+    yield SampleInput(make(4, 4), "cpu", dtype=to_dtype, copy=True)
+
     # dtype
     yield SampleInput(make(4, 4), dtype)
+
+    # dtype - copy
+    yield SampleInput(make(4, 4), dtype, copy=True)
 
     # device and dtype
     yield SampleInput(make(4, 4), device, dtype)
     yield SampleInput(make(4, 4), "cpu", to_dtype)
 
+    # device and dtype - copy
+    yield SampleInput(make(4, 4), device, dtype, copy=True)
+    yield SampleInput(make(4, 4), "cpu", to_dtype, copy=True)
+
     # tensor
     yield SampleInput(make(4, 4), make(2, 2))
     yield SampleInput(make(4, 4), make(2, 2, device="cpu", dtype=to_dtype))
+
+    # tensor - copy
+    yield SampleInput(make(4, 4), make(2, 2), copy=True)
+    yield SampleInput(make(4, 4), make(2, 2, device="cpu", dtype=to_dtype), copy=True)
 
 
 to_opinfo = OpInfo(

--- a/thunder/tests/test_core.py
+++ b/thunder/tests/test_core.py
@@ -1865,20 +1865,6 @@ def test_torch_tensor_to_memory_format(executor: TestExecutor, device: str, _):
         assert_close(torch_result, thunder_result, check_stride=True)
 
 
-def test_torch_tensor_to_return_type():
-    a = torch.randn(2, 4, 5, 3)
-
-    def torch_to(a):
-        return a.to(copy=True)
-
-    jfoo = thunder.jit(torch_to)
-    thunder_result = jfoo(a)
-    torch_result = torch_to(a)
-
-    assert thunder_result is not a
-    assert_close(torch_result, thunder_result)
-
-
 # TODO See issue "Add contiguous and clang.stride_order OpInfos that check stride
 # consistency with PyTorch"
 @instantiate(

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -477,19 +477,7 @@ def to(
     )
 
     if copy:
-        if device is not None:
-            device = to_device(device)
-            a = prims.device_put(a, device)
-        if dtype is not None:
-            dtype = to_dtype(dtype)
-            a = prims.convert_element_type(a, dtype)
-        if memory_format is not None:
-            # NOTE not sure if we need to handle torch.preserve_format explicitly
-            if memory_format == torch.channels_last:
-                a = prims.stride_order(a, (3, 0, 2, 1))
-            elif memory_format == torch.channels_last_3d:
-                a = prims.stride_order(a, (4, 0, 3, 2, 1))
-        return a
+        a = prims.clone(a)
 
     # NOTE copy == False
     # NOTE to() returns the tensor unmodified if the device and dtype requested are the same

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -472,13 +472,6 @@ def to(
     copy: bool = False,
     memory_format: None | torch.memory_format = None,
 ) -> TensorLike:
-
-    input_device = a.device
-    input_dtype = a.dtype
-    if copy and not _will_to_return_self(input_device, input_dtype, device, dtype, memory_format, copy):
-        b = prims.empty(a.shape, device=input_device, dtype=input_dtype)
-        return _copy_(b, a)
-
     device, dtype = _parse_to_device_and_dtype(
         tensor_dtype_or_device, optional_positional_dtype, device=device, dtype=dtype
     )


### PR DESCRIPTION
#1775 wrongly uses `_copy_` while we need to register a clone op to have a copy of the tensor. Moved the tests to thunder's opinfos suite as per all the rest of the torch ops. 

This PR reverts #1775 and, together with #1292, fixes #1291


cc @mruberry