### PR TITLE
add torch.optim._functional.rmsprop benchmark

### DIFF
--- a/thunder/benchmarks/__init__.py
+++ b/thunder/benchmarks/__init__.py
@@ -3235,7 +3235,10 @@ class RMSpropBenchmark(Benchmark, metaclass=UserFacingBenchmarkMeta):
         square_avgs = [pt(sq_avgs, requires_grad=False) for sq_avgs in self.params]
         grad_avgs = [pt(g_avgs, requires_grad=False) for g_avgs in self.params]
         momentum_buffer_list = [pt(mbl, requires_grad=False) for mbl in self.params]
-        state_steps = [torch.tensor(0, device=self.device, dtype=self.tdtype, requires_grad=self.requires_grad) for _ in self.params]
+        state_steps = [
+            torch.tensor(0, device=self.device, dtype=self.tdtype, requires_grad=self.requires_grad)
+            for _ in self.params
+        ]
         return (params, grads, square_avgs, grad_avgs, momentum_buffer_list, state_steps), {}
 
     def fn(self) -> Callable:
@@ -3259,6 +3262,7 @@ class RMSpropBenchmark(Benchmark, metaclass=UserFacingBenchmarkMeta):
             )
 
         return foo
+
 
 # TODO Add descriptions to the executors when listed, and list them alphabetically
 # TODO Allow querying benchmark for details

--- a/thunder/benchmarks/targets.py
+++ b/thunder/benchmarks/targets.py
@@ -957,8 +957,17 @@ def test_lora_linear(benchmark, executor, compute_type, implementation):
     [(64, 64), (128, 64)],
     ids=["64x64", "128x64"],
 )
-def test_optim_functional_rmsprop(benchmark, executor: None | Callable, params: Sequence[int], compute_type: ComputeType):
+@pytest.mark.parametrize(
+    "config,",
+    [
+        ("single_tensor", False),
+        ("multi_tensor", True),
+    ],
+    ids=["single_tensor", "multi_tensor(foreach)"],
+)
+def test_optim_functional_rmsprop(benchmark, executor: None | Callable, config: tuple[str, bool], params: Sequence[int], compute_type: ComputeType):
     bench: Benchmark = RMSpropBenchmark(
+        config=config,
         params=params,
         device="cuda:0",
         dtype=thunder.float32,

--- a/thunder/benchmarks/targets.py
+++ b/thunder/benchmarks/targets.py
@@ -965,13 +965,15 @@ def test_lora_linear(benchmark, executor, compute_type, implementation):
     ],
     ids=["single_tensor", "multi_tensor(foreach)"],
 )
-def test_optim_functional_rmsprop(benchmark, executor: None | Callable, config: tuple[str, bool], params: Sequence[int], compute_type: ComputeType):
+def test_optim_functional_rmsprop(
+    benchmark, executor: None | Callable, config: tuple[str, bool], params: Sequence[int], compute_type: ComputeType
+):
     bench: Benchmark = RMSpropBenchmark(
         config=config,
         params=params,
         device="cuda:0",
         dtype=thunder.float32,
-        requires_grad=is_requires_grad(compute_type)
+        requires_grad=is_requires_grad(compute_type),
     )
 
     fn = executor(bench.fn())


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes a part of #1213.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃

### Benchmarking Results
```python
----------------------------------------------------------------------------------------- benchmark 'params=(128, 64) compute_type=ComputeType.INFERENCE': 6 tests -----------------------------------------------------------------------------------------
Name (time in us)                                                                        Min                 Max                Mean            StdDev              Median               IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_optim_functional_rmsprop[multi_tensor(foreach)-128x64-inference-inductor]       28.4865 (1.0)       48.8486 (1.0)       30.7993 (1.0)      2.9182 (1.0)       30.1198 (1.0)      0.7923 (1.0)       108;187       32.4683 (1.0)        2185          16
test_optim_functional_rmsprop[multi_tensor(foreach)-128x64-inference-eager]          29.2207 (1.03)     103.3148 (2.11)      36.0840 (1.17)     4.6862 (1.61)      35.9477 (1.19)     1.8761 (2.37)      171;322       27.7131 (0.85)       2162          15
test_optim_functional_rmsprop[single_tensor-128x64-inference-eager]                  45.5007 (1.60)      72.4588 (1.48)      48.5552 (1.58)     4.0031 (1.37)      47.6581 (1.58)     0.8330 (1.05)      100;204       20.5951 (0.63)       2000          11
test_optim_functional_rmsprop[single_tensor-128x64-inference-inductor]               46.1426 (1.62)      79.9051 (1.64)      49.2648 (1.60)     4.5752 (1.57)      48.2626 (1.60)     0.9438 (1.19)      117;211       20.2985 (0.63)       2452          10
test_optim_functional_rmsprop[multi_tensor(foreach)-128x64-inference-thunderfx]      94.7380 (3.33)     134.8365 (2.76)     102.2036 (3.32)     6.5855 (2.26)     100.3192 (3.33)     2.7771 (3.51)      103;111        9.7844 (0.30)       1045          10
test_optim_functional_rmsprop[single_tensor-128x64-inference-thunderfx]             155.6985 (5.47)     214.9621 (4.40)     166.5930 (5.41)     7.6461 (2.62)     164.3265 (5.46)     6.3656 (8.03)        80;56        6.0027 (0.18)        636          10
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

----------------------------------------------------------------------------------------- benchmark 'params=(64, 64) compute_type=ComputeType.INFERENCE': 6 tests -----------------------------------------------------------------------------------------
Name (time in us)                                                                       Min                 Max                Mean            StdDev              Median               IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_optim_functional_rmsprop[multi_tensor(foreach)-64x64-inference-eager]          30.2358 (1.0)       62.6024 (1.24)      33.4179 (1.0)      3.6577 (1.24)      32.3357 (1.0)      0.9650 (1.23)      146;276       29.9241 (1.0)        2474          13
test_optim_functional_rmsprop[multi_tensor(foreach)-64x64-inference-inductor]       31.7279 (1.05)      50.2832 (1.0)       34.0043 (1.02)     2.9584 (1.0)       33.3276 (1.03)     0.7846 (1.0)        98;143       29.4080 (0.98)       1879          17
test_optim_functional_rmsprop[single_tensor-64x64-inference-inductor]               37.1621 (1.23)      70.5163 (1.40)      43.7051 (1.31)     4.1755 (1.41)      42.2040 (1.31)     3.6865 (4.70)      152;113       22.8806 (0.76)       2309          11
test_optim_functional_rmsprop[single_tensor-64x64-inference-eager]                  39.3996 (1.30)      74.9190 (1.49)      44.0930 (1.32)     4.0302 (1.36)      42.9335 (1.33)     2.2582 (2.88)      165;170       22.6794 (0.76)       2047          11
test_optim_functional_rmsprop[multi_tensor(foreach)-64x64-inference-thunderfx]      95.3015 (3.15)     143.6794 (2.86)     102.2204 (3.06)     7.1208 (2.41)     100.1111 (3.10)     3.5213 (4.49)      110;117        9.7828 (0.33)       1129          10
test_optim_functional_rmsprop[single_tensor-64x64-inference-thunderfx]             148.2096 (4.90)     285.8687 (5.69)     163.7491 (4.90)     8.9987 (3.04)     162.1975 (5.02)     7.5630 (9.64)        98;44        6.1069 (0.20)        656          10
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
```

#### Command to run
```python
pytest thunder/benchmarks/targets.py -k "test_optim_functional_rmsprop" --benchmark-group-by='param:params,param:compute_type'
```