### PR TITLE
Optionally use shared memory pool in CUDAGraphs Transform

### DIFF
--- a/thunder/tests/test_transforms.py
+++ b/thunder/tests/test_transforms.py
@@ -530,6 +530,41 @@ def test_cudagraph_empty_inputs():
     assert any(("CUDAGraph" in bsym.sym.name) for bsym in thunder.last_traces(jfn)[-1].bound_symbols)
 
 
+@pytest.mark.skip(
+    reason="Pools in CUDAGraphTransform are not sharing properly. ",
+)
+@requiresCUDA
+def test_cudagraph_pools():
+    def workload(a):
+        with torch.no_grad():
+            inter = [a * i for i in range(50)]
+            b = inter.pop()
+            while inter:
+                b = b + inter.pop()
+            return b
+
+    from thunder.transforms.cudagraph import CUDAGraphTransform
+
+    def run_cg(share_mem_pool=False):
+        jfn = thunder.jit(workload, transforms=(CUDAGraphTransform(share_mem_pool=share_mem_pool),), executors=())
+        n = 512
+        m = 256
+
+        a = torch.randn(n, n, device="cuda")
+        jfn(a)
+        b = torch.randn(m, m, device="cuda")
+        jfn(b)
+
+    run_cg()
+    reserved_memory_without_pool = torch.cuda.memory_reserved()
+
+    run_cg(True)
+    reserved_memory_with_pool = torch.cuda.memory_reserved()
+
+    assert reserved_memory_with_pool < reserved_memory_without_pool
+
+
+
 def test_disable_params_and_buffer_check():
     from thunder.tests.litgpt_model import Config
     from litgpt.model import GPT

--- a/thunder/tests/test_transforms.py
+++ b/thunder/tests/test_transforms.py
@@ -545,7 +545,7 @@ def test_cudagraph_pools():
 
     from thunder.transforms.cudagraph import CUDAGraphTransform
 
-    def run_cg(n , m, share_mem_pool=False):
+    def run_cg(n, m, share_mem_pool=False):
         jfn = thunder.jit(workload, transforms=(CUDAGraphTransform(share_mem_pool=share_mem_pool),), executors=())
 
         a = torch.randn(n, n, device="cuda")
@@ -553,7 +553,7 @@ def test_cudagraph_pools():
         b = torch.randn(m, m, device="cuda")
         jfn(b)
 
-    def run_graphs(n ,m):
+    def run_graphs(n, m):
         run_cg(n, m)
         reserved_memory_without_pool = torch.cuda.memory_reserved()
         run_cg(n, m, True)

--- a/thunder/tests/test_transforms.py
+++ b/thunder/tests/test_transforms.py
@@ -531,7 +531,7 @@ def test_cudagraph_empty_inputs():
 
 
 @pytest.mark.skip(
-    reason="Pools in CUDAGraphTransform are not sharing properly. ",
+    reason="Pools in CUDAGraphTransform are not sharing properly. https://github.com/Lightning-AI/lightning-thunder/issues/1792",
 )
 @requiresCUDA
 def test_cudagraph_pools():

--- a/thunder/transforms/cudagraph.py
+++ b/thunder/transforms/cudagraph.py
@@ -99,7 +99,7 @@ class CUDAGraphRunner:
 
         # Record
         # NOTE: we are (optionally) using a global memory pool
-        # which is shared across all graphs here. However, we havent observed any memeory 
+        # which is shared across all graphs here. However, we havent observed any memeory
         # saving from this, so it is not enabled by default.
         graph = torch.cuda.CUDAGraph()
         with torch.cuda.graph(graph, stream=stream, pool=self.mem_pool):

--- a/thunder/transforms/cudagraph.py
+++ b/thunder/transforms/cudagraph.py
@@ -96,10 +96,9 @@ class CUDAGraphRunner:
         torch.cuda.synchronize()
 
         # Record
-        # NOTE: We are using default private pool here, but it is possibly better to
-        # use a custom pool for better memory management. See CUDA Graphs Tree in
-        # PyTorch's Inductor: torch/_inductor/cudagraph_trees.py
-        # Design doc: https://docs.google.com/document/d/1ZrxLGWz7T45MSX6gPsL6Ln4t0eZCSfWewtJ_qLd_D0E/view
+        # NOTE: we are (optionally) using a global memory pool
+        # which is shared across all graphs here. However, we havent observed any memeory 
+        # saving from this, so it is not enabled by default.
         graph = torch.cuda.CUDAGraph()
         with torch.cuda.graph(graph, stream=stream, pool=self.global_mem_pool):
             static_outputs = fn(*static_inputs)

--- a/thunder/transforms/cudagraph.py
+++ b/thunder/transforms/cudagraph.py
@@ -213,7 +213,7 @@ class CUDAGraphTransform(Transform):
 
     def __init__(self, *, share_mem_pool: bool = False):
         super().__init__()
-        self.cuda_graph_runner = CUDAGraphRunner(share_mem_pool)
+        self.cuda_graph_runner = CUDAGraphRunner(share_mem_pool=share_mem_pool)
 
     def fuse(self, region: Region, fusion_counter: int) -> BoundSymbol:
         inputs = [unvariableify(inp) for inp in region.inputs]


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

- Adds an option to reuse memory pools in CUDAGraphs, as described [here](https://pytorch.org/docs/stable/notes/cuda.html#graph-memory-management)
- We note that using pools seems to have no effect on reserved memory increasing across captures

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
