### PR TITLE
Fixes test_TorchInductorSpecification: uses retain_graph in run_benchmark

### DIFF
--- a/thunder/dynamo/report.py
+++ b/thunder/dynamo/report.py
@@ -475,13 +475,10 @@ class FXGraphReport:
         )
         bwd_measurement = None
         if not forward_only:
-            backward_fn, backward_setup = backward_only(
-                compiled_fn, *example_inputs, setup_graph_on_each_invocation=True
-            )
+            backward_fn, backward_setup = backward_only(compiled_fn, *example_inputs)
+            backward_args = backward_setup()
             bwd_measurement = time_fn.time(
-                "backward_fn(*backward_args)",
-                setup="backward_args=backward_setup()",
-                globals={"backward_fn": backward_fn, "backward_setup": backward_setup},
+                "backward_fn(*backward_args)", globals={"backward_fn": backward_fn, "backward_args": backward_args}
             )
         return fwd_measurement, bwd_measurement
 


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes the CI failure: 
```
FAILED thunder/tests/test_dynamo.py::test_TorchInductorSpecification - RuntimeError: Trying to backward through the graph a second time (or directly access saved tensors after they have already been freed). Saved intermediate values of the graph are freed when you call .backward() or autograd.grad(). Specify retain_graph=True if you need to backward through the graph a second time or if you need to access saved tensors after calling backward.
```

In `FXGraphReport.run_benchmark`, I used the `setup` argument of `torch.utils.benchmark.Timer`, which is only called once before the loop of `stmt` (unlike `setup` in pytest's `benchmark.pedantic`, which runs before every iteration). As a result, without `retain_graph=True`, multiple backward passes raise an error due to the computation graph being freed after the first backward pass.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
