### PR TITLE
restore nvfuser take_along_axis support

### DIFF
--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -1355,10 +1355,13 @@ def squeeze(a: TensorProxy, /, dims: Sequence[int], *, fd: FusionDefinition, lc_
 
 register_supported(PrimIDs.SQUEEZE, squeeze, _squeeze_check)
 
-# TAKE is currently disabled
-# def _take_check(a: TensorProxy, /, index: TensorProxy, dim: int) -> bool:
-#     return are_supported_tensors(a, index)
+def _take_check(a: TensorProxy, /, index: TensorProxy, dim: int) -> bool:
+    enable_indexing: None | bool = get_compile_option("nv_enable_indexing", "Enable nvFuser indexing operations.")
+    if not enable_indexing or not are_supported_tensors(a, index)
+        return False
+    return True
 
+# NOTE: TAKE is currently disabled
 # def take(a: TensorProxy, /, index: TensorProxy, dim: int, *, fd: FusionDefinition, lc_to_nv_map: dict) -> Any:
 #     nv_a = getnv(a, fd, lc_to_nv_map)
 #     nv_index = getnv(index, fd, lc_to_nv_map)
@@ -1366,16 +1369,12 @@ register_supported(PrimIDs.SQUEEZE, squeeze, _squeeze_check)
 #     return fd.ops.index_select(nv_a, nv_index, dim)
 # register_supported(PrimIDs.TAKE, take, _take_check)
 
-# TAKE_ALONG_AXIS is currently disabled
-# There was an nvFuser bug that prevented this which is now fixed; we should
-# investigate re-enabling take_along_axis.
-# # TODO Check that the nvFuser version is >= 0.0.10 when this operator was added
-# def take_along_axis(a: TensorProxy, /, index: TensorProxy, dim: int, *, fd: FusionDefinition, lc_to_nv_map: dict) -> Any:
-#     nv_a = getnv(a, fd, lc_to_nv_map)
-#     nv_index = getnv(index, fd, lc_to_nv_map)
+def take_along_axis(a: TensorProxy, /, index: TensorProxy, dim: int, *, fd: FusionDefinition, lc_to_nv_map: dict) -> Any:
+    nv_a = getnv(a, fd, lc_to_nv_map)
+    nv_index = getnv(index, fd, lc_to_nv_map)
 
-#     return fd.ops.take_along_axis(nv_a, nv_index, dim)
-# register_supported(PrimIDs.TAKE_ALONG_AXIS, take_along_axis, _take_check)
+    return fd.ops.take_along_axis(nv_a, nv_index, dim)
+register_supported(PrimIDs.TAKE_ALONG_AXIS, take_along_axis, _take_check)
 
 
 def _transpose_check(a: TensorProxy, /, permutation: Sequence[int]) -> bool:


### PR DESCRIPTION
Two things are done here:
1. adding back nvfuser take_along_axis support
2. adding an compile flag `