### PR TITLE
Fix implementation of strides computation in cuDNN executor

### DIFF
--- a/thunder/executors/cudnnex.py
+++ b/thunder/executors/cudnnex.py
@@ -218,6 +218,7 @@ def torch_to_cudnn_dtype(lc_dtype: dtypes.dtype):
     }
     return _torch_to_cudnn_dtype_map[lc_dtype]
 
+
 def _compute_row_major_strides(shape):
     """
     Compute contiguous strides for a row-major layout tensor of the given shape.

--- a/thunder/executors/cudnnex.py
+++ b/thunder/executors/cudnnex.py
@@ -95,6 +95,7 @@ register_executor(cudnn_ex)
 
 
 from collections import OrderedDict
+from itertools import accumulate
 
 
 # Cache already built cudnn graphs to save on runtime compilation overhead
@@ -217,12 +218,18 @@ def torch_to_cudnn_dtype(lc_dtype: dtypes.dtype):
     }
     return _torch_to_cudnn_dtype_map[lc_dtype]
 
-
 def _compute_row_major_strides(shape):
-    strides = [1]
-    for dim in reversed(shape[:-1]):
-        strides.append(strides[-1] * dim)
-    return tuple(reversed(strides))
+    """
+    Compute contiguous strides for a row-major layout tensor of the given shape.
+
+    Args:
+        shape: The shape of the tensor.
+
+    Returns:
+        A tuple of strides for the tensor.
+    """
+    initial = 1 if shape else None
+    return tuple(accumulate(reversed(shape[1:]), lambda x, y: x * y, initial=initial))[::-1]
 
 
 # sdpa requires that the embedding dim stride be one.

--- a/thunder/tests/test_cudnn_executor.py
+++ b/thunder/tests/test_cudnn_executor.py
@@ -276,3 +276,32 @@ def test_vjp_correctness_cudnn_sdpa(dtype, may_cat_grad_qkv):
         # compare gradients of query, key, value, and attn_mask
         for eg, ag in zip(expected_grad, actual_grad):
             torch.testing.assert_close(eg, ag, atol=2e-1, rtol=2e-2)
+
+
+def test_compute_row_major_strides():
+    from thunder.executors.cudnnex import _compute_row_major_strides
+
+    # Test case 1: 2D tensor
+    shape = (3, 4)
+    expected_strides = (4, 1)
+    assert _compute_row_major_strides(shape) == expected_strides
+
+    # Test case 2: 3D tensor
+    shape = (2, 3, 4)
+    expected_strides = (12, 4, 1)
+    assert _compute_row_major_strides(shape) == expected_strides
+
+    # Test case 3: 1D tensor
+    shape = (5,)
+    expected_strides = (1,)
+    assert _compute_row_major_strides(shape) == expected_strides
+
+    # Test case 4: 4D tensor
+    shape = (2, 3, 4, 5)
+    expected_strides = (60, 20, 5, 1)
+    assert _compute_row_major_strides(shape) == expected_strides
+
+    # Test case 5: Empty shape
+    shape = ()
+    expected_strides = ()
+    assert _compute_row_major_strides(shape) == expected_strides


### PR DESCRIPTION
There was a bug in the cuDNN executor code when computing the contiguous strides for a given shape. For example for a shape of (3, 4) the previous implementation was returning (3, 1) instead of correct (4, 1) strides.

The bug was benign because we were not executing/testing masked SDPA with the cuDNN executor (and the executor's checker was rightfully failing).


cc @mruberry, @vedaanta 