### PR TITLE
[ThunderFX report]: Improve the interfaces

### DIFF
--- a/thunder/dynamo/benchmark_utils.py
+++ b/thunder/dynamo/benchmark_utils.py
@@ -53,7 +53,7 @@ class ThunderCompileSpecification(CompileSpecificationInterface):
         self.name = specification_name
         self.thunder_options: dict = kwargs
 
-    def compile(self, fn):
+    def compile(self, fn, *args):
         from thunder import jit
 
         return jit(fn, **self.thunder_options)
@@ -75,7 +75,7 @@ class TorchCompileSpecification(CompileSpecificationInterface):
         self.name = specification_name
         self.torch_compile_options: dict = kwargs
 
-    def compile(self, fn):
+    def compile(self, fn, *args):
         return torch.compile(fn, **self.torch_compile_options)
 
     def to_source(self, fn_name):
@@ -97,7 +97,7 @@ class TorchEagerSpecification(CompileSpecificationInterface):
     def __init__(self, specification_name="torcheager"):
         self.name = specification_name
 
-    def compile(self, fn):
+    def compile(self, fn, *args):
         return fn
 
     def to_source(self, fn_name):
@@ -111,9 +111,8 @@ class TorchInductorSpecification(CompileSpecificationInterface):
     https://github.com/Lightning-AI/lightning-thunder/issues/1521
     """
 
-    def __init__(self, inputs, specification_name="inductor_backend"):
+    def __init__(self, specification_name="inductor_backend"):
         self.name: str = specification_name
-        self.inputs: list = inputs
 
     @staticmethod
     def torch_inductor(fn, inputs):
@@ -123,8 +122,8 @@ class TorchInductorSpecification(CompileSpecificationInterface):
         fx_graph = symbolic_trace(fn)
         return inductor_compile(fx_graph, inputs)
 
-    def compile(self, fn):
-        return self.torch_inductor(fn, self.inputs)
+    def compile(self, fn, inputs):
+        return self.torch_inductor(fn, inputs)
 
     def to_source(self, fn_name):
         return f"TorchInductorSpecification.torch_inductor({fn_name}, inputs)"

--- a/thunder/dynamo/benchmark_utils.py
+++ b/thunder/dynamo/benchmark_utils.py
@@ -122,9 +122,8 @@ class TorchInductorSpecification(CompileSpecificationInterface):
         fx_graph = symbolic_trace(fn)
         return inductor_compile(fx_graph, inputs)
 
-    def compile(self, fn, **kwargs):
-        assert "inputs" in kwargs, "inputs is required for TorchInductorSpecification"
-        return self.torch_inductor(fn, kwargs["inputs"])
+    def compile(self, fn, *, inputs, **kwargs):
+        return self.torch_inductor(fn, inputs)
 
     def to_source(self, fn_name):
         return f"TorchInductorSpecification.torch_inductor({fn_name}, inputs)"

--- a/thunder/dynamo/report.py
+++ b/thunder/dynamo/report.py
@@ -1076,7 +1076,18 @@ def thunderfx_benchmark_report_from_splits(
     atol=0.0,
 ):
     """
-    A utility function that analyzes the runnability and performance benchmarks of each Thunder-split FX graph and nvFusion regions(optional). It prints out the performance metrics and saves the benchmark script in `folder_path` if the difference exceeds the tolerance (`rtol`, `atol` in seconds).
+    A utility function that analyzes the runnability and performance benchmarks of each Thunder-split FX graph and nvFusion regions(optional).
+    It prints out the performance metrics and saves the benchmark script in `folder_path` if the difference exceeds
+    the tolerance (`rtol`, `atol` in seconds).
+    the function will create the following folder structure:
+    folder_path
+    └── graph0
+        ├── graph0_thunder_0_thunder_walltime.py
+        └── nvfusion_reports
+            └── graph0_thunder_0_nvfusion0_forward_nvfuser_kerneltime.py
+    It separates subfolders for each `graph[index]` and `nvfusion_report`.
+    The script for each FX graph is named as `graph[index]_[thunder_split_name]_[executor_name]_[timer_name].py`.
+    The script for each nvfusion region is named as `graph[index]_[thunder_split_name]_[nvfusion_name]_[forward/backward]_[executor_name]_[timer_name].py`.
     """
     folder_path = Path(folder_path)
     folder_path.mkdir(exist_ok=True, parents=True)
@@ -1146,8 +1157,9 @@ def thunderfx_benchmark_report(
     Note:
     - This function may run out of memory (OOM) as it allocates random tensors when executing
     the graph module in each Report. To prevent OOM issues, users must manually free the
-    input model and arguments to free up memory for `get_nvfusion_reports`, `check_timing`,
+    input model and arguments to free up memory for `make_nvfusion_reports`, `check_timing`,
     and `check_timing_bsym`.
+    - See `thunderfx_benchmark_report_from_splits` for details on the generated folders and scripts.
 
     Here is an example:
 

--- a/thunder/dynamo/report.py
+++ b/thunder/dynamo/report.py
@@ -414,7 +414,7 @@ class FXGraphReport:
         check_consistency=False,
     ):
         example_inputs = self.make_example_inputs()
-        compiled_model = compile_fn.compile(self.graph, example_inputs)
+        compiled_model = compile_fn.compile(self.graph, inputs=example_inputs)
         result = run_forward_backward(compiled_model, *example_inputs)
 
         if check_consistency:
@@ -475,7 +475,7 @@ class FXGraphReport:
 
     def run_benchmark(self, compile_fn: CompileSpecificationInterface, time_fn: TimerInterface):
         example_inputs = self.make_example_inputs()
-        compiled_fn = compile_fn.compile(self.graph, example_inputs)
+        compiled_fn = compile_fn.compile(self.graph, inputs=example_inputs)
 
         forward_only = not any(hasattr(arg, "requires_grad") and arg.requires_grad for arg in example_inputs)
         fwd_measurement = time_fn.time(

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -1367,8 +1367,7 @@ def test_TorchInductorSpecification(tmp_path):
     assert len(thunder_fx_graph_report.subgraph_reports) == 1  # cos
     thunder_split_report = thunder_fx_graph_report.subgraph_reports[0]
 
-    ex_inputs = thunder_split_report.make_example_inputs()
-    torchinductor = TorchInductorSpecification(ex_inputs)
+    torchinductor = TorchInductorSpecification()
     thunder_split_report.run_benchmark(torchinductor, WallTime)
     thunder_split_report.run_repro(torchinductor)
     thunder_split_report.write_benchmark(tmp_path, torchinductor, WallTime)


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

This PR
1. Reorganizes the `thunderfx_benchmark_reports`, so that users can use:
```
thunder_fxgraph_reports = get_thunder_fxgraph_reports(model, x)

# Frees the parameters and inputs to make room for the reports
del model
del x

thunderfx_benchmark_report_from_splits(thunder_fxgraph_reports, folder_path, compare_fusion=True)
```
(or if there's no OOM, we can use `thunderfx_benchmark_report` directly)
2. Fixes `run_forward_backward` so that it can take both function and module as input
3. Uses TorchInductor without TorchDynamo by default when benchmarking each FX graph to avoid  https://github.com/Lightning-AI/lightning-thunder/issues/1521


