### PR TITLE
thunderfx - disable split autograd.Function on thunderFX path

### DIFF
--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -746,6 +746,9 @@ def jit(
 
         return wrapped
 
+    # For more context see `NOTE: Split autograd.Function`
+    disable_split_autograd: bool = compile_options.get("disable_split_autograd", False)
+
     def maybe_connect_to_autograd(cache_entry, result):
         if cache_entry.backward_fn:
             # If the backward function is available, we need to connect the
@@ -760,6 +763,7 @@ def jit(
                 saved_tensors=saved_tensors,
                 saved_other=saved_other,
                 return_none_instead_of_grads=cache_entry.return_none_instead_of_grads,
+                disable_split_autograd=disable_split_autograd,
             )
             result = data_for_autograd["output"]
 

--- a/thunder/dynamo/compiler.py
+++ b/thunder/dynamo/compiler.py
@@ -29,6 +29,12 @@ if TYPE_CHECKING:
 
 _DEFAULT_THUNDER_FUSION_TYPE = "dataflow"
 
+# Split Autograd is disabled by default as
+# it can lead to race conditions when using thunderFX + TE + FSDP
+# leading to NCCL hang-up due to collective mismatch.
+# TODO(kshitij12345): Investiage more and understand if the bug is in PyTorch or elsewhere.
+_DEFAULT_THUNDERFX_DISABLE_SPLIT_AUTOGRAD = True
+
 
 def _add_prologue_pruning(options: dict):
     """
@@ -87,6 +93,9 @@ class ThunderCompiler:
         # NOTE: Dynamo already adds guards for modules by default (see flag `torch._dynamo.config.guard_nn_modules`), so thunder can avoid adding extra metadata checks for parameters
         #       in prologue.
         _add_prologue_pruning(thunder_options)
+        thunder_options["disable_split_autograd"] = thunder_options.get(
+            "disable_split_autograd", _DEFAULT_THUNDERFX_DISABLE_SPLIT_AUTOGRAD
+        )
         self.thunder_options = thunder_options
         self._thunder_jit = partial(jit, **thunder_options)
         self._torch_compile = torch.compile

--- a/thunder/executors/torch_autograd.py
+++ b/thunder/executors/torch_autograd.py
@@ -12,6 +12,7 @@ from thunder.core.trace import TraceCtx, from_trace, set_tracectx, reset_tracect
 from thunder.core.transform_common import replace_redundant_inputs
 from thunder.core.vjp_utils import get_saved_for_backward_tensors, set_saved_for_backward_tensors
 from .utils import is_cudagraph_capturing
+from thunder.core.compile_data import get_compile_option
 
 if TYPE_CHECKING:
     from thunder.core.trace import VariableInterface
@@ -61,6 +62,7 @@ def rename_bwd_trace_outputs(bwd_trace: TraceCtx, fwd_trace: TraceCtx) -> TraceC
     return renamed_bwd_trace
 
 
+# NOTE: Split autograd.Function
 # We split the autograd.Function into two parts because this allows
 # the args to the ThunderOutputFunction.backward to go out of scope
 # and the tensors (the grad_outs matching the flattened output) to be
@@ -189,13 +191,14 @@ def connect_to_autograd(
     saved_tensors,
     saved_other,
     return_none_instead_of_grads,
+    disable_split_autograd,
 ):
     # PyTorch seems to not like our side channel trick when capturing graphs
     # through dynamo and using cuda graphs.
     # Of course, the real trick is to use the CUDAGraphTransform instead
     # of having something else apply it while introducing funny additional
     # conditions for success.
-    if not is_cudagraph_capturing():
+    if not is_cudagraph_capturing() and not disable_split_autograd:
         side_channel = {}
     else:
         side_channel = None

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -78,7 +78,7 @@ def test_basic(executor, device: str, dtype: dtypes.dtype, dynamic: bool | None)
 
     # out should have grad_fn and its name should be ThunderFunctionBackward
     assert out.grad_fn is not None
-    assert out.grad_fn.name() == "ThunderOutputFunctionBackward"
+    assert out.grad_fn.name() == "ThunderFunctionBackward"
 
     # We record the GraphModules that was compiled by ThunderCompiler
     backend = compiled._backend
@@ -341,7 +341,7 @@ def test_force_skip_lazy_graph_module(executor, device: str, dtype: dtypes.dtype
 
         # out should have grad_fn and its name should be ThunderFunctionBackward
         assert out.grad_fn is not None
-        assert out.grad_fn.name() == "ThunderOutputFunctionBackward"
+        assert out.grad_fn.name() == "ThunderFunctionBackward"
 
         backend = cfunc._backend
         # We record the GraphModules that was compiled by ThunderCompiler


### PR DESCRIPTION
Adds an option to disable split autograd.Function and disables it by default on thunderFX path. Also, the original PR introducing the mechanism mentions (https://github.com/Lightning-AI/lightning-thunder/pull/1581#issuecomment-2565684698) - 

> This seems to collide with some dynamo trickery, so we should only use this for the direct jit invocation for now.


**Problem** - With split autograd.Function, we see hangup due to NCCL collective mismatch with thunderFX + TE + FSDP. These hang-ups are random and probably occur due to race condition (need to investigate the exact cause).

Here is a script to run a benchmark multiple times

<details>

```python
import subprocess

# Define the command you want to run
command = "nsys profile --cuda-flush-interval=500 torchrun --nproc-per-node=2 thunder/benchmarks/benchmark_litgpt.py --max_iters 10 --warmup_iters 5 --model_name pythia-12b --distributed_mode fsdp --shard_mode zero3 --compile dynamo_thunder --checkpoint_activations False --low_precision_mode fp8-delayed-te --micro_batch_size 1 --bucketing_mode block --use_sdpa False --n_layer 3"

# Loop 10 times to execute the command
for i in range(1, 11):
    # Define the log file name
    log_file = f"debug_{i}.log"

    # Open the log file in write mode
    with open(log_file, "w") as log:
        try:
            # Run the command, writing stdout and stderr directly to the log file
            process = subprocess.run(
                command,
                shell=True,  # Allows running shell commands
                stdout=log,  # Direct standard output to the log file
                stderr=log   # Direct standard error to the log file
            )
            
            # Check if the command ran successfully
            if process.returncode == 0:
                print(f"Command run #{i} succeeded.")
            else:
                print(f"Command run #{i} failed with return code {process.returncode}.")
        except Exception as e:
            # If an exception occurs, log it and print an error message
            log.write(f"Error occurred when running the command: {str(e)}\n")
            print(f"Command run #{i} encountered an error: {str(e)}")

print("All commands executed. Logs saved to files.")
```

</details>

Output before patch -
```
Command run #1 failed with return code 1.
Command run #2 failed with return code 1.
Command run #3 failed with return code 1.
Command run #4 failed with return code 1.
Command run #5 failed with return code 1.
Command run #6 succeeded.
Command run #7 failed with return code 1.
Command run #8 failed with return code 1.
Command run #9 failed with return code 1.
Command run #10 failed with return code 1.
All commands executed. Logs saved to files
```

Output after patch -
```
Command run #1 succeeded.
Command run #2 succeeded.
Command run #3 succeeded.
Command run #4 succeeded.
Command run #5 succeeded.
Command run #6 succeeded.
Command run #7 succeeded.
Command run #8 succeeded.
Command run #9 succeeded.
Command run #10 succeeded.
All commands executed. Logs saved to files.
```

Thanks @IvanYashchuk for pointing me in this direction!
