### PR TITLE
[TEST] specify device_id in init_process_group

### DIFF
--- a/thunder/tests/distributed/helper.py
+++ b/thunder/tests/distributed/helper.py
@@ -181,16 +181,17 @@ if torch.distributed.is_available():
             self.rank = rank
             self.file_name = file_name
 
+            local_rank = self.rank % torch.cuda.device_count()
+            torch.cuda.set_device(local_rank)
+            os.environ["LOCAL_RANK"] = str(local_rank)
+
             torch.distributed.init_process_group(
                 init_method=self.init_method,
                 backend=self.DISTRIBUTED_BACKEND,
                 world_size=self.world_size,
                 rank=self.rank,
+                device_id=torch.device("cuda", local_rank),
             )
-
-            local_rank = self.rank % torch.cuda.device_count()
-            torch.cuda.set_device(local_rank)
-            os.environ["LOCAL_RANK"] = str(local_rank)
 
             torch.distributed.barrier()
             try:
@@ -215,7 +216,15 @@ if torch.distributed.is_available():
         else:
             raise ValueError(f"Unknown devicetype {devicetype}")
 
-        torch.distributed.init_process_group(init_method=init_method, backend=backend, world_size=world_size, rank=rank)
+        local_rank = rank % torch.cuda.device_count()
+        torch.cuda.set_device(local_rank)
+
+        torch.distributed.init_process_group(
+            init_method=init_method, backend=backend,
+            world_size=world_size,
+            rank=rank,
+            device_id=torch.device("cuda", local_rank),
+        )
 
         # NOTE _get_default_group is not a public PyTorch function, but there is no
         #   public mechanism to acquire the default process group, which is specified


### PR DESCRIPTION
## What does this PR do?
This PR enhances the test helper for distributed by setting `device_id` in `init_process_group`. Form more info please see [PyTorch Documentation](https://pytorch.org/docs/main/distributed.html#torch.distributed.init_process_group).