### PR TITLE
fix signature of polygamma_

### DIFF
--- a/thunder/core/functionalization.py
+++ b/thunder/core/functionalization.py
@@ -316,7 +316,7 @@ def canonicalize_bsym_args(
 
 
 def create_functional_bsym_from(inplace_bsym: BoundSymbol) -> BoundSymbol:
-    from thunder.torch import _inplace_to_out_of_place, setitem_, setitem
+    from thunder.torch import _inplace_to_out_of_place, polygamma_, setitem_, setitem
 
     functional_sym, optional_inplace_arg_index = _inplace_to_out_of_place[inplace_bsym.sym]
     args, kwargs = inplace_bsym.args, inplace_bsym.kwargs
@@ -330,6 +330,15 @@ def create_functional_bsym_from(inplace_bsym: BoundSymbol) -> BoundSymbol:
         # setitem does not return a value, take the output of the setitem subsymbol
         assert inplace_bsym.subsymbols[0].sym is setitem
         functional_output = inplace_bsym.subsymbols[0].output
+    if inplace_bsym.sym is polygamma_:
+        # polygamma expects an int as its first argument and a tensor as its second but
+        # torch.Tensor.polygamma_ wants opposite; tensor first, int second.
+        # ref:
+        # - https://pytorch.org/docs/stable/special.html#torch.special.polygamma
+        # - https://pytorch.org/docs/stable/generated/torch.Tensor.polygamma_.html
+        flat_args, flat_args_spec = tree_flatten((args, kwargs))
+        flat_args[0], flat_args[1] = flat_args[1], flat_args[0]
+        args, kwargs = tree_unflatten(flat_args, flat_args_spec)
     functional_bsym = functional_sym.bind(
         *args,
         **kwargs,

--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -3038,7 +3038,7 @@ def type_error_generator_tensor(op, device, dtype=torch.float32, **kwargs):
 
 
 type_opinfo_tensor = OpInfo(
-    ltorch.type,
+    ltorch.torch_type,
     sample_input_generator=type_sample_generator_tensor,
     error_input_generator=type_error_generator_tensor,
     torch_reference=torch.Tensor.type,
@@ -3069,7 +3069,7 @@ def string_compare(actual, expected, **kwargs):
 
 
 type_opinfo_str = OpInfo(
-    ltorch.type,
+    ltorch.torch_type,
     sample_input_generator=type_sample_generator_str,
     error_input_generator=type_error_generator_str,
     torch_reference=torch.Tensor.type,

--- a/thunder/tests/test_inplace_functionalization.py
+++ b/thunder/tests/test_inplace_functionalization.py
@@ -84,34 +84,13 @@ for op in opinfos:
         _inplace_opinfos.append(inplace_opinfo)
 
 
-@dataclass(frozen=True)
-class InplaceOpWrapper:
-    torch_func: Callable
-    is_polygamma: bool
-    jitted: bool
-
-    def __call__(self, *args, **kwargs):
-        # polygamma expects an int as its first argument and a tensor as its second but
-        # torch.Tensor.polygamma_ wants opposite; tensor first, int second.
-        # ref:
-        # - https://pytorch.org/docs/stable/special.html#torch.special.polygamma
-        # - https://pytorch.org/docs/stable/generated/torch.Tensor.polygamma_.html
-        args = list(args)
-        idx = int(self.is_polygamma and self.jitted)
-        t = args[idx] + 1.0
-        args[idx] = t
-
-        self.torch_func(*args, **kwargs)
-        return t
-
-
 @ops(_inplace_opinfos, supported_dtypes=(dtypes.float32,))
 def test_functionalization(op: OpInfo, device: str, dtype: dtypes.dtype, executor, _):
     import thunder
 
     is_polygamma = op.name == "polygamma_"
-    inplace_op = InplaceOpWrapper(op.torch_reference, is_polygamma, False)
-    jitted_inplace_op = executor.make_callable(InplaceOpWrapper(op.torch_reference, is_polygamma, True))
+    inplace_op = op.torch_reference
+    jitted_inplace_op = executor.make_callable(op.torch_reference)
     sample: SampleInput
     for idx, sample in enumerate(op.sample_inputs(device, dtype)):
         if idx > 0:
@@ -119,11 +98,16 @@ def test_functionalization(op: OpInfo, device: str, dtype: dtypes.dtype, executo
 
         args = list(sample.args)
         if is_polygamma:
+            # polygamma expects an int as its first argument and a tensor as its second but
+            # torch.Tensor.polygamma_ wants opposite; tensor first, int second.
+            # ref:
+            # - https://pytorch.org/docs/stable/special.html#torch.special.polygamma
+            # - https://pytorch.org/docs/stable/generated/torch.Tensor.polygamma_.html
             tmp = args[0]
             args[0] = args[1]
             args[1] = tmp
         expected = inplace_op(*args, **sample.kwargs)
-        actual = jitted_inplace_op(*sample.args, **sample.kwargs)
+        actual = jitted_inplace_op(*args, **sample.kwargs)
         torch.testing.assert_close(actual, expected, equal_nan=True)
 
     # make sure `prims.copy_` does not exist in the trace thanks to functionalization

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -357,8 +357,9 @@ def _old_torch_typestring_to_devicetype_and_dtype(typestring: str) -> tuple[Devi
     return devicetype_str, dtype_str
 
 
-@torchsymbol(torch.Tensor.type, is_method=True)
-def type(a: TensorLike, /, dtype: None | str | dtypeLike = None, non_blocking: bool = False) -> str | TensorLike:
+# NOTE: Using name `torch_type` to avoid conflict with Python's `type`
+@torchsymbol(torch.Tensor.type, is_method=True, method_name="type", id="torch.Tensor.type")
+def torch_type(a: TensorLike, /, dtype: None | str | dtypeLike = None, non_blocking: bool = False) -> str | TensorLike:
     utils.check(
         not non_blocking,
         lambda: f"type(): `non_blocking==True` is currently not supported.",
@@ -386,7 +387,7 @@ def type(a: TensorLike, /, dtype: None | str | dtypeLike = None, non_blocking: b
     return to(a, dev, dtype)
 
 
-register_method("type", type)
+register_method("type", torch_type)
 
 #
 # Data movement and transformation operations
@@ -2209,7 +2210,7 @@ def polygamma(n: int, a: TensorLike, /) -> TensorLike:
 
 
 @torchsymbol(torch.Tensor.polygamma_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
-def polygamma_(n: int, a: TensorLike, /) -> TensorLike:
+def polygamma_(a: TensorLike, n: int, /) -> TensorLike:
     return _copy_(a, polygamma(n, a))
 
 


### PR DESCRIPTION
The signature of `polygamma_` should reflect that of `torch.Tensor.polygamma_`, meaning the first input should be a tensor.  It currently matches the signature of `torch.special.polygamma`, which take the same inputs, but in reversed order.  This change aims to make `polygamma_` consistent with `torch.Tensor.polygamma_`.

As an added bonus, this renames `ltorch.type` to `ltorch.torch_type` to avoid overriding python's `type`.