### PR TITLE
[CUDAGraphs] reuse saved for backward buffers from forward to backward

### DIFF
--- a/thunder/tests/test_transforms.py
+++ b/thunder/tests/test_transforms.py
@@ -554,7 +554,7 @@ def test_cudagraph_fw_bw():
 
     o = m(x)
     o.sum().backward()
-    
+
     # Ensure all saved for backwards tensors are marked as static inputs
     assert all(cg_transform.cuda_graph_runner.python_callables["CUDAGraph2"][1][1:-2])
 

--- a/thunder/transforms/cudagraph.py
+++ b/thunder/transforms/cudagraph.py
@@ -6,10 +6,10 @@ from typing import Any
 import torch
 
 from thunder.core.transform_common import Transform
-from thunder.core import utils, prims
+from thunder.core import utils, prims, vjp_utils
 from thunder.core.proxies import Proxy, ProxyTag, unvariableify
 from thunder.core.symbol import BoundSymbol, Symbol
-from thunder.core.trace import TraceCtx, from_trace, TraceProvenance, get_tracectx, set_tracectx, reset_tracectx
+from thunder.core.trace import TraceCtx, from_trace, TraceProvenance, get_tracectx, set_tracectx, reset_tracectx, TraceTag
 from thunder.executors.utils import Region
 from thunder.executors.data_dependent_partition import fuse_bound_symbols, Node
 
@@ -214,6 +214,7 @@ class CUDAGraphTransform(Transform):
     def __init__(self, *, share_mem_pool: bool = False):
         super().__init__()
         self.cuda_graph_runner = CUDAGraphRunner(share_mem_pool=share_mem_pool)
+        self.outputs_from_forward = None
 
     def fuse(self, region: Region, fusion_counter: int) -> BoundSymbol:
         inputs = [unvariableify(inp) for inp in region.inputs]
@@ -274,7 +275,7 @@ class CUDAGraphTransform(Transform):
 
         return True
 
-    def transform_trace_post_optimization(self, trace: TraceCtx, **kwargs) -> TraceCtx:
+    def generate_fused_trace(self, trace: TraceCtx, **kwargs) -> TraceCtx:
         start_time_ns: int = time.perf_counter_ns()
 
         def _should_fuse(a: Node, b: Node):
@@ -327,3 +328,31 @@ class CUDAGraphTransform(Transform):
         fused_trace.set_provenance(TraceProvenance(f"CUDAGraph fusion (took {elapsed_time_ms} milliseconds)"))
 
         return fused_trace
+
+    def transform_trace_post_optimization(self, trace, **kwargs):
+        if trace.siginfo().name == 'backward_fn':
+            # TODO: Backward TraceTag
+            assert self.outputs_from_forward is not None, "called on backward without forward before"
+            assert len(trace.bound_symbols[2].args) == 2 and trace.bound_symbols[2].args[0].name == 'saved_for_backward'
+            assert trace.bound_symbols[8].sym.name == 'unpack_sequence' and trace.bound_symbols[8].args[0] is trace.bound_symbols[2].output[0]
+
+            saved_for_backwards_unpacked = trace.bound_symbols[8].output
+            assert len(saved_for_backwards_unpacked) == len(self.outputs_from_forward)
+            for is_static, p_bw in zip(self.outputs_from_forward, saved_for_backwards_unpacked):
+                if is_static:
+                    p_bw.tags.add(ProxyTag.STATIC_MEMORY_LOCATION)
+            self.outputs_from_forward = None
+
+        new_trace = self.generate_fused_trace(trace, **kwargs)
+
+        if TraceTag.AUGMENTED_FORWARD in new_trace.tags:
+            assert self.outputs_from_forward is None, "called on augmented forward twice without backward in between"
+            cudagraph_output_names = set()
+            for bsym in new_trace.bound_symbols:
+                if bsym.sym.name.startswith('CUDAGraph'):
+                    for o in bsym.flat_proxy_outs:
+                        cudagraph_output_names.add(o.name)
+            saved_for_backward = vjp_utils.get_saved_for_backward_tensors(new_trace)
+            self.outputs_from_forward = [o.name in cudagraph_output_names or ProxyTag.STATIC_MEMORY_LOCATION in o.tags for o in saved_for_backward]
+
+        return new_trace


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Partially solves # ([1533](https://github.com/Lightning-AI/lightning-thunder/issues/1533)).

On the repro linked above with L40s on Lightning studios:
```
with this PR and cg: 25578.62656
before with cg: 34087.020032
no cg: 14395.375104
```
## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
