### PR TITLE
[ThunderFX report] Adds TimerWithCUDAMemoryUsage to track CUDA memory usage alongside timing measurements

### DIFF
--- a/thunder/dynamo/benchmark_utils.py
+++ b/thunder/dynamo/benchmark_utils.py
@@ -444,8 +444,9 @@ def check_metrics(
         except Exception as e:
             msg = f"Benchmark {timer_fn.name} on {graph_name} using {compile_fn.name} failed with exception {e}, benchmark script failed_{filename} is saved"
             stream.write(msg)
+            failed_folder = folder_path / "failed"
             report.write_benchmark(
-                folder_path, compile_fn, timer_fn, file_name=f"failed_{filename1}", extra_comment_str=msg
+                failed_folder, compile_fn, timer_fn, file_name=f"failed_{filename1}", extra_comment_str=msg
             )
             return None
 

--- a/thunder/dynamo/benchmark_utils.py
+++ b/thunder/dynamo/benchmark_utils.py
@@ -428,6 +428,12 @@ def check_timing(
         if m1 is None:
             assert m2 is None
             continue
+
+        if timer_fn.name == "WallTimeWithMemoryUsage":
+            print(
+                f"Max_allocated_memory: [{graph_name} {name}] {compile_fn1.name}({m1.max_allocated_memory}MB); {compile_fn2.name}({m2.max_allocated_memory}MB)"
+            )
+
         ret = check_threshold_log(
             m1.median, m2.median, compile_fn1.name, compile_fn2.name, f"{graph_name} {name}", timer_name, rtol, atol
         )

--- a/thunder/dynamo/benchmark_utils.py
+++ b/thunder/dynamo/benchmark_utils.py
@@ -224,6 +224,34 @@ class TorchProfileTimer:
             pass
 
 
+class TimerWithCUDAMemoryUsage:
+    """
+    A timer wrapper that tracks CUDA memory usage alongside timing measurements.
+
+    Example usage:
+        t = TimerWithCUDAMemoryUsage(TimerInterface.time)
+        t0 = t()  # Records initial memory and time
+        # ... code to measure ...
+        t1 = t()  # Records final memory and time
+        duration = t1 - t0  # Get elapsed time
+        memory_mb = t.max_allocated_memory  # Get peak memory usage in MB
+
+    Note:
+        The memory tracking adds some overhead to the timing measurements.
+        Memory usage is recorded in megabytes (MB).
+    """
+
+    def __init__(self, timer):
+        self.max_allocated_memory = 0.0
+        self.timer = timer
+
+    def __call__(self):
+        # Max allocated memory is recorded in MB
+        self.max_allocated_memory = torch.cuda.max_memory_allocated() / (1024 * 1024.0)
+        torch.cuda.reset_peak_memory_stats()
+        return self.timer()
+
+
 class TimerInterface:
     """
     Defines an interface for specifying how to timing a callable and generate a statistic object.

--- a/thunder/dynamo/benchmark_utils.py
+++ b/thunder/dynamo/benchmark_utils.py
@@ -237,7 +237,7 @@ class TimerWithCUDAMemoryUsage:
         # ... code to measure ...
         t1 = t()  # Records final memory and time
         duration = t1 - t0  # Get elapsed time
-        memory_mb = t.max_allocated_memory  # Get peak memory usage in MB
+        memory_mb = t.max_allocated_memory  # Get peak memory usage in B
 
     Note:
         The memory tracking adds some overhead to the timing measurements.
@@ -469,7 +469,7 @@ def check_metrics(
                 memory_usage_rtol,
                 memory_usage_atol,
             )
-            if memory_ret[0]:
+            if not memory_ret[0]:
                 memory_record = True
             log_strs += memory_ret[1]
 

--- a/thunder/dynamo/report.py
+++ b/thunder/dynamo/report.py
@@ -42,6 +42,7 @@ from thunder.dynamo.benchmark_utils import (
     TorchInductorSpecification,
     WallTime,
     KernelTime,
+    WallTimeWithMemoryUsage,
     check_timing,
     check_timing_bsym,
 )
@@ -546,6 +547,8 @@ class FXGraphReport:
     # forward
     fwd_measurement = {fwd_timing_str}
     print("fwd_measurement=", fwd_measurement)
+    if hasattr(fwd_measurement, "max_allocated_memory"):
+        print(f"fwd_measurement.max_allocated_memory={{fwd_measurement.max_allocated_memory}}MB")
 """
         if not forward_only:
             code_str = f"""{code_str}
@@ -555,6 +558,8 @@ class FXGraphReport:
     backward_args = backward_setup()
     bwd_measurement = {bwd_timing_str}
     print("bwd_measurement=", bwd_measurement)
+    if hasattr(bwd_measurement, "max_allocated_memory"):
+        print(f"bwd_measurement.max_allocated_memory={{bwd_measurement.max_allocated_memory}}MB")
 """
 
         code_str += f"test_{self.graph_name}()"
@@ -1144,7 +1149,7 @@ def thunderfx_benchmark_report_from_splits(
         graph_folder = folder_path / thunder_fxgraph_report.graph_name
         graph_folder.mkdir()
         for split_report in thunder_fxgraph_report.subgraph_reports:
-            check_timing(graph_folder, split_report, torchinductor, thunderjit, WallTime, "walltime", rtol, atol)
+            check_timing(graph_folder, split_report, torchinductor, thunderjit, WallTimeWithMemoryUsage, "walltime", rtol, atol)
             check_timing(graph_folder, split_report, torchinductor, thunderjit, KernelTime, "kerneltime", rtol, atol)
             runnable_split_reports.append(split_report)
     if not compare_fusion:

--- a/thunder/dynamo/report.py
+++ b/thunder/dynamo/report.py
@@ -1132,10 +1132,15 @@ def thunderfx_benchmark_report_from_splits(
     """
     A utility function that analyzes the runnability and performance benchmarks of each Thunder-split FX graph and nvFusion regions(optional).
     It prints out the performance metrics and saves the benchmark script in `folder_path` if the difference exceeds
-    the tolerance (`perf_rtol`, `perf_atol` in seconds).
+    the tolerance (`perf_rtol`, `perf_atol` in seconds; `memory_usage_rtol`, `memory_usage_atol` in Bytes).
     the function will create the following folder structure:
     folder_path
     └── graph0
+        ├── failed
+        │   └── failed_graph0_thunder_1_thunder_WallTime.py
+        └── memory_issue
+            ├── graph0_thunder_0_inductor_backend_WallTimeWithMemoryUsage.py
+            └── graph0_thunder_0_thunder_WallTimeWithMemoryUsage.py
         ├── graph0_thunder_0_thunder_walltime.py
         └── nvfusion_reports
             └── graph0_thunder_0_nvfusion0_forward_nvfuser_kerneltime.py
@@ -1217,12 +1222,13 @@ def thunderfx_benchmark_report(
 
     3. For each subgraph:
     - Compares wall time and kernel time between `torch.compile` and Thunder.
-    - Reports performance metrics and saves the benchmark script in `folder_path` if the difference exceeds the tolerance (`rtol`, `atol` in seconds).
+    - Reports performance metrics and saves the benchmark script in `folder_path/graph_name/` if the difference exceeds the tolerance (`perf_rtol`, `perf_atol` in seconds)
+    - Reports memory usage and saves the benchmark script in `folder_path/graph_name/memory_issue` if the difference exceeds the tolerance (`memory_usage_rtol`, `memory_usage_atol` in Bytes).
     - Uses `math.isclose` for tolerance checks.
 
     4. If `compare_fusion` is `True`:
     - Also compares the wall time and kernel time of each nvFusion region.
-    - Saves the benchmark script when necessary, following the same criteria as above.
+    - Saves the benchmark script when necessary in `folder_path/graph_name/nvfusion_reports`, following the same criteria as above.
 
     Note:
     - This function may run out of memory (OOM) as it allocates random tensors when executing

--- a/thunder/dynamo/report.py
+++ b/thunder/dynamo/report.py
@@ -1149,7 +1149,9 @@ def thunderfx_benchmark_report_from_splits(
         graph_folder = folder_path / thunder_fxgraph_report.graph_name
         graph_folder.mkdir()
         for split_report in thunder_fxgraph_report.subgraph_reports:
-            check_timing(graph_folder, split_report, torchinductor, thunderjit, WallTimeWithMemoryUsage, "walltime", rtol, atol)
+            check_timing(
+                graph_folder, split_report, torchinductor, thunderjit, WallTimeWithMemoryUsage, "walltime", rtol, atol
+            )
             check_timing(graph_folder, split_report, torchinductor, thunderjit, KernelTime, "kerneltime", rtol, atol)
             runnable_split_reports.append(split_report)
     if not compare_fusion:

--- a/thunder/dynamo/report.py
+++ b/thunder/dynamo/report.py
@@ -549,7 +549,8 @@ class FXGraphReport:
     fwd_measurement = {fwd_timing_str}
     print("fwd_measurement=", fwd_measurement)
     if hasattr(fwd_measurement, "max_allocated_memory"):
-        print(f"fwd_measurement.max_allocated_memory={{fwd_measurement.max_allocated_memory}}MB")
+        from thunder.dynamo.benchmark_utils import get_pretty_memory_str
+        print(f"fwd_measurement.max_allocated_memory={{get_pretty_memory_str(fwd_measurement.max_allocated_memory)}}")
 """
         if not forward_only:
             code_str = f"""{code_str}
@@ -560,7 +561,7 @@ class FXGraphReport:
     bwd_measurement = {bwd_timing_str}
     print("bwd_measurement=", bwd_measurement)
     if hasattr(bwd_measurement, "max_allocated_memory"):
-        print(f"bwd_measurement.max_allocated_memory={{bwd_measurement.max_allocated_memory}}MB")
+        print(f"bwd_measurement.max_allocated_memory={{get_pretty_memory_str(bwd_measurement.max_allocated_memory)}}")
 """
 
         code_str += f"test_{self.graph_name}()"

--- a/thunder/dynamo/report.py
+++ b/thunder/dynamo/report.py
@@ -198,7 +198,7 @@ class FXGraphReport:
         self.graph = graph
         self.graph_name = graph_name
         self.example_input_meta = example_input_meta
-        self.ops = [node.target for node in self.graph.graph.nodes if node.op in ("call_function", "call_method")]
+        self.ops = {node.target for node in self.graph.graph.nodes if node.op in ("call_function", "call_method")}
 
     def __str__(self):
         output = f"Graph Name: {self.graph_name}\n"

--- a/thunder/dynamo/report.py
+++ b/thunder/dynamo/report.py
@@ -1123,8 +1123,8 @@ def thunderfx_benchmark_report_from_splits(
     folder_path: str | PathLike,
     thunder_compile_kwargs: dict = None,
     compare_fusion: bool = False,
-    perf_rtol=0.5,
-    perf_atol=0.0,
+    time_rtol=0.5,
+    time_atol=0.0,
     memory_usage_rtol=0.5,
     memory_usage_atol=0.0,
     stream: TextIO = sys.stdout,
@@ -1132,7 +1132,7 @@ def thunderfx_benchmark_report_from_splits(
     """
     A utility function that analyzes the runnability and performance benchmarks of each Thunder-split FX graph and nvFusion regions(optional).
     It prints out the performance metrics and saves the benchmark script in `folder_path` if the difference exceeds
-    the tolerance (`perf_rtol`, `perf_atol` in seconds; `memory_usage_rtol`, `memory_usage_atol` in Bytes).
+    the tolerance (`time_rtol`, `time_atol` in seconds; `memory_usage_rtol`, `memory_usage_atol` in Bytes).
     the function will create the following folder structure:
     folder_path
     └── graph0
@@ -1164,8 +1164,8 @@ def thunderfx_benchmark_report_from_splits(
                 torchinductor,
                 thunderjit,
                 WallTimeWithMemoryUsage,
-                perf_rtol,
-                perf_atol,
+                time_rtol,
+                time_atol,
                 memory_usage_rtol,
                 memory_usage_atol,
                 stream,
@@ -1176,8 +1176,8 @@ def thunderfx_benchmark_report_from_splits(
                 torchinductor,
                 thunderjit,
                 KernelTime,
-                perf_rtol,
-                perf_atol,
+                time_rtol,
+                time_atol,
                 memory_usage_rtol,
                 memory_usage_atol,
                 stream,
@@ -1192,8 +1192,8 @@ def thunderfx_benchmark_report_from_splits(
         graph_nvfusion_folder = folder_path / graph_report.graph_name / "nvfusion_reports"
         for split_report in graph_report.subgraph_reports:
             for nvfusion_report in split_report.fusion_reports:
-                check_nvfusion_timing(graph_nvfusion_folder, nvfusion_report, WallTime, perf_rtol, perf_atol, stream)
-                check_nvfusion_timing(graph_nvfusion_folder, nvfusion_report, KernelTime, perf_rtol, perf_atol, stream)
+                check_nvfusion_timing(graph_nvfusion_folder, nvfusion_report, WallTime, time_rtol, time_atol, stream)
+                check_nvfusion_timing(graph_nvfusion_folder, nvfusion_report, KernelTime, time_rtol, time_atol, stream)
 
 
 def thunderfx_benchmark_report(
@@ -1202,8 +1202,8 @@ def thunderfx_benchmark_report(
     folder_path: str | PathLike,
     thunder_compile_kwargs: dict = None,
     check_torch_runnablility: bool = True,
-    perf_rtol=0.5,
-    perf_atol=0.0,
+    time_rtol=0.5,
+    time_atol=0.0,
     memory_usage_rtol=0.5,
     memory_usage_atol=0.0,
     compare_fusion: bool = False,
@@ -1222,7 +1222,7 @@ def thunderfx_benchmark_report(
 
     3. For each subgraph:
     - Compares wall time and kernel time between `torch.compile` and Thunder.
-    - Reports performance metrics and saves the benchmark script in `folder_path/graph_name/` if the difference exceeds the tolerance (`perf_rtol`, `perf_atol` in seconds)
+    - Reports performance metrics and saves the benchmark script in `folder_path/graph_name/` if the difference exceeds the tolerance (`time_rtol`, `time_atol` in seconds)
     - Reports memory usage and saves the benchmark script in `folder_path/graph_name/memory_issue` if the difference exceeds the tolerance (`memory_usage_rtol`, `memory_usage_atol` in Bytes).
     - Uses `math.isclose` for tolerance checks.
 
@@ -1261,8 +1261,8 @@ def thunderfx_benchmark_report(
         folder_path,
         thunder_compile_kwargs,
         compare_fusion,
-        perf_rtol,
-        perf_atol,
+        time_rtol,
+        time_atol,
         memory_usage_rtol,
         memory_usage_atol,
         stream,

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -36,6 +36,7 @@ from thunder.dynamo.benchmark_utils import (
     TorchEagerSpecification,
     WallTime,
     KernelTime,
+    WallTimeWithMemoryUsage,
     BoundSymbolNvfuserSpecification,
     BoundSymbolTorchCompileSpecification,
 )
@@ -1269,6 +1270,8 @@ def test_WallTime_KernelTime():
 
     WallTime.time(stmt="fd.execute(inputs)", globals={"fd": fd, "inputs": inputs})
     KernelTime.time(stmt="fd.execute(inputs)", globals={"fd": fd, "inputs": inputs})
+    m = WallTimeWithMemoryUsage.time(stmt="fd.execute(inputs)", globals={"fd": fd, "inputs": inputs})
+    assert m.max_allocated_memory > 0
 
 
 @requiresCUDA

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -1270,8 +1270,12 @@ def test_WallTime_KernelTime():
 
     WallTime.time(stmt="fd.execute(inputs)", globals={"fd": fd, "inputs": inputs})
     KernelTime.time(stmt="fd.execute(inputs)", globals={"fd": fd, "inputs": inputs})
+
     m = WallTimeWithMemoryUsage.time(stmt="fd.execute(inputs)", globals={"fd": fd, "inputs": inputs})
-    assert m.max_allocated_memory > 0
+    torch.cuda.reset_peak_memory_stats()
+    fd.execute(inputs)
+    max_mem = torch.cuda.max_memory_allocated()
+    assert max_mem == m.max_allocated_memory
 
 
 @requiresCUDA


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

- Adds TimerWithCUDAMemoryUsage to track CUDA memory usage alongside timing measurements
- Reorganizes the TimerSpecification classes
- Uses the WallTimeWithMemoryUsage as default and saves script in `path/graph_name/memory_issue/` folder when the memory usage exceeds `rtol,atol`
- Note that if using `thunderfx_benchmark_report` directly, i.e. the original model and inputs are not freed, the peak memory reported in the log (which gets from `run_benchmark`) will be larger than the number reported by running the saved script (there's only single graph in the script)