### PR TITLE
TE may raise a TypeError with retain_grad

### DIFF
--- a/thunder/tests/test_transformer_engine_executor.py
+++ b/thunder/tests/test_transformer_engine_executor.py
@@ -197,7 +197,7 @@ def test_te_with_autocast():
 
 
 # NOTE: strict=False as it passes on Blackwell.
-@pytest.mark.xfail(strict=False, raises=RuntimeError, reason="Retain graph is not supported by TE")
+@pytest.mark.xfail(strict=False, raises=(RuntimeError, TypeError), reason="Retain graph is not supported by TE")
 @requiresCUDA
 def test_te_with_retain_graph():
     def foo(x, w):


### PR DESCRIPTION
TransformerEngine started to raise a new error type for the tested scenario (see https://github.com/NVIDIA/TransformerEngine/issues/990#issuecomment-2693701737).

This PR updates the xfail decorator to xpass on TypeErrors.

cc @kshitij12345 