### PR TITLE
`f.write(...)` <- `print(..., file=f)`

### DIFF
--- a/thunder/dynamo/report.py
+++ b/thunder/dynamo/report.py
@@ -472,7 +472,7 @@ class FXGraphReport:
         if file_name is None:
             file_name = f"{self.graph_name}.py"
         with open(folder / file_name, "w") as f:
-            print(code_str, file=f)
+            f.write(code_str)
 
     def run_benchmark(self, compile_fn: CompileSpecificationInterface, time_fn: TimerInterface):
         # From torch.compile docs - https://pytorch.org/docs/stable/generated/torch.compile.html


### PR DESCRIPTION
## What does this PR do?

`code_str` seems to be guaranteed to be a string at https://github.com/Lightning-AI/lightning-thunder/blob/ff74bef8f31ae2624ae7a78a9cafa37755eb2cf2/thunder/dynamo/report.py#L470, thus it'd be reasonable to use `f.write` instead.