### PR TITLE
Update vjp implementation to attach residuals to all outputs

### DIFF
--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -56,6 +56,7 @@ from thunder.core.utils import (
     OrderedSet,
     ProxyDict,
 )
+from thunder.core.codeutils import is_literal
 import thunder.clang as clang
 from thunder.clang import (
     empty,
@@ -2285,6 +2286,8 @@ def iter_bound_symbols(bound_symbols):
     """
     for symbol in bound_symbols:
         if symbol.sym.id in trace_interpreter_skip_list:
+            continue
+        elif all(is_literal(sym_out) for sym_out in symbol.flat_outs):
             continue
         elif symbol.output is None:
             continue


### PR DESCRIPTION
This PR fixes the residuals/saved_for_backward saving and retrieving so that that backward function generation works correctly in the case when the first output of a bound symbol is unused.