### PR TITLE
Report bug

### DIFF
--- a/thunder/dynamo/utils.py
+++ b/thunder/dynamo/utils.py
@@ -723,13 +723,18 @@ def _readable(
 
 
 def get_env() -> tuple[str, str]:
-    """Retrieve detailed environment information using `torch.utils.collect_env.get_pretty_env_info()`.
+    """Retrieve detailed environment information using `torch.utils.collect_env.get_pip_packages()`.
     Additionally, include the installed versions of Thunder and NvFuser (if available via pip).
     """
 
-    from torch.utils.collect_env import run, get_pretty_env_info, get_pip_packages
+    from torch.utils.collect_env import run, get_pip_packages
 
-    torch_env = get_pretty_env_info()
+    torch_env = "CUDA devices:\n"
+    for i in range(torch.cuda.device_count()):
+        torch_env += f"  {i}: {torch.cuda.get_device_name(i)}\n"
+    torch_env += f"CUDA version: {torch.version.cuda}\n"
+    _, packages = get_pip_packages(run)
+    torch_env += packages
     _, thunder_packages = get_pip_packages(run, {"lightning-thunder", "nvfuser"})
     return torch_env, thunder_packages
 

--- a/thunder/dynamo/utils.py
+++ b/thunder/dynamo/utils.py
@@ -665,9 +665,12 @@ def arg_like(arg: Any):
     """Creates a new argument that is similar to the given arg."""
     if isinstance(arg, (torch.Tensor, ExampleInputMetaData)):
         return arg_like_tensor(arg)
-    else:
-        # Assume it's a literal that we can just print directly.
+    elif isinstance(arg, Sequence):
+        return "[" + "".join(arg_like(a) for a in arg) + "],"
+    elif isinstance(arg, (int, bool, float)):
         return f"{arg},"
+    else:
+        raise TypeError(f"Unsupported input type: {type(arg)}")
 
 
 def _readable(


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Many thanks to @crcrpar for the debugging and helpful suggestions.
This PR fixes the bugs found when using on DeepSeek-R1
- Fixes handling of nested tensor inputs when generating input strings.
- Resolves issues with contiguous input tensors that have a storage offset.
- Uses shorter env information:
```
Environment information get from `torch.utils.collect_env.get_pretty_env_info()`:
CUDA devices:
  0: NVIDIA RTX 6000 Ada Generation
  1: NVIDIA RTX 6000 Ada Generation
 cuda version: 12.8
numpy==1.26.4
nvidia-cudnn-frontend==1.10.0
optree==0.14.0
optree==0.14.0
pytorch-lightning==2.5.0.post0
pytorch-triton==3.2.0+git0d4682f0b.nvinternal
torch==2.7.0a0+ecf3bae40a.nvinternal
torchmetrics==1.6.1
torchvision==0.22.0a0

Versions of Thunder related libraries:
lightning-thunder==0.2.2.dev0
nvfuser==0.2.26+git94ec5b3
```

