### PR TITLE
Fix: corrects gradient calculation in benchmark (#1827)

### DIFF
--- a/thunder/benchmarks/utils.py
+++ b/thunder/benchmarks/utils.py
@@ -69,7 +69,7 @@ def backward_only_setup_graph_once(fn: Callable, *args, **kwargs):
         for i in forward_inputs:
             i.grad = None
 
-        torch.autograd.backward(result, output_grads, retain_graph=True)
+        torch.autograd.backward(backwardable_tensor_result, output_grads, retain_graph=True)
 
     return backward_fn, backward_setup
 

--- a/thunder/dynamo/report.py
+++ b/thunder/dynamo/report.py
@@ -83,7 +83,7 @@ def run_forward_backward(fn, *args, **kwargs):
     for i in inputs_requires_grad:
         i.grad = None
 
-    torch.autograd.backward(result, output_grads, inputs=inputs_requires_grad)
+    torch.autograd.backward(differentiable_tensor_result, output_grads, inputs=inputs_requires_grad)
     return result, [t.grad for t in inputs_requires_grad]
 
 

--- a/thunder/tests/test_grad.py
+++ b/thunder/tests/test_grad.py
@@ -1956,3 +1956,28 @@ def test_backward_recomputation_decomposed_ops(device):
             "unpack_sequence",
             "unpack_trivial",
         }
+
+
+@requiresCUDA
+def test_benchmark_grad():
+    from thunder.benchmarks.utils import backward_only
+    from thunder.dynamo.report import run_forward_backward
+
+    # Workaround for "RuntimeError: Triton Error [CUDA]: an illegal memory access was encountered"
+    # https://github.com/pytorch/pytorch/issues/124565
+    torch.empty(1, device="cuda", requires_grad=True).backward()
+
+    def func(x):
+        arange = torch.arange(0, 96, 2, dtype=torch.int64, device="cuda").float()
+        return x.exp(), arange
+
+    jfunc = thunder.jit(func)
+    tfunc = torch.compile(func)
+    x = torch.randn(2, 2, device="cuda", requires_grad=True)
+    out1 = run_forward_backward(jfunc, x)
+    out2 = run_forward_backward(tfunc, x)
+    torch.testing.assert_close(out1, out2)
+
+    backward_fn, backward_setup = backward_only(tfunc, x)
+    backward_args = backward_setup()
+    backward_fn(*backward_args)


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes #1827.
Thanks to the debugging by @IvanYashchuk , it fixes the bug when calculating grads in benchmark

