### PR TITLE
TE: don't compute wgrad when weights are frozen

### DIFF
--- a/thunder/distributed/prims.py
+++ b/thunder/distributed/prims.py
@@ -184,7 +184,14 @@ def synchronize_meta(
             # Assuming that the sharding is done on the first dimension
             # See [FSDP Sharding] in distributed/__init__.py
             unsharded_shape = a.shape[0] * group.size(), *a.shape[1:]
-            return TensorProxy(shape=unsharded_shape, like=a, distparallel_type=DistParallelType.REPLICATED)
+            # NOTE: We explicitly pass the `a.requires_grad` as we want to propogate the requires grad correctly on `nn.Parameter`'s
+            # as it maybe queried later.
+            return TensorProxy(
+                shape=unsharded_shape,
+                like=a,
+                distparallel_type=DistParallelType.REPLICATED,
+                requires_grad=a.requires_grad,
+            )
         case _:
             utils.check(False, lambda: f"Proxy {a} has unexpected {a.distparallel_type=}")
 

--- a/thunder/executors/transformer_engineex.py
+++ b/thunder/executors/transformer_engineex.py
@@ -180,7 +180,7 @@ class TELinear(TransformerEngineBaseModule):
         else:
             self.pg = None
 
-    def forward(self, inp, weight, bias, is_grad_enabled: bool = False):
+    def forward(self, inp, weight, bias, is_grad_enabled: bool = False, *, weight_requires_grad, bias_requires_grad):
         # NOTE: Backward FP8 metadata sync
         # TransformerEngine v1.6 onwards, we control the sync and update of FP8 metadata for FP8 tensors
         # tied to backward pass (i.e. the gradient tensors)
@@ -190,12 +190,19 @@ class TELinear(TransformerEngineBaseModule):
         # We consume the `is_first_fp8_module` so that the automatic sync for FP8 metadata is disabled.
         FP8GlobalStateManager.is_first_fp8_module()  # Consume first module token.
 
-        tensor_inputs = tuple(filter(lambda t: isinstance(t, torch.Tensor), (inp, weight, bias)))
+        enable_grad_inputs = (inp,)
+
+        # For PEFT scenarios, weights maybe frozen i.e. weight_requires_grad=False.
+        if weight_requires_grad:
+            enable_grad_inputs += (weight,)
+        if bias_requires_grad:
+            enable_grad_inputs += (bias,)
+
         # See [NOTE] Enable grad within context
-        # TE backward depends on `requires_grad` to compute grads.
+        # TE backward depends on `requires_grad` to compute grads but thunder wraps it's execution trace with `no_grad`,
         # so under grad mode we enable grad for input tensors
         # Ref: https://github.com/NVIDIA/TransformerEngine/blob/b957aa475bcbcf22405381d18bd7fefe4fb6b171/transformer_engine/pytorch/module/linear.py#L264
-        grad_ctx = enable_grad(*tensor_inputs) if is_grad_enabled else nullcontext()
+        grad_ctx = enable_grad(*enable_grad_inputs) if is_grad_enabled else nullcontext()
         with grad_ctx, self.prepare_forward(inp) as inp:
             assert (
                 self.fp8 or not self.primary_weights_in_fp8
@@ -345,6 +352,8 @@ def _te_functional_linear_backward_impl(
     a_shape: tuple,
     w_shape: tuple,
     b_shape: tuple | None,
+    weight_requires_grad: bool,
+    bias_requires_grad: bool,
     ctx: Context,
     saved_tensors: Sequence[torch.Tensor],
     g: torch.Tensor,
@@ -360,14 +369,16 @@ def _te_functional_linear_backward_meta(
     a_shape: tuple,
     w_shape: tuple,
     b_shape: tuple | None,
+    weight_requires_grad: bool,
+    bias_requires_grad: bool,
     ctx: Context,
     saved_tensors: Sequence[TensorProxy],
     g: TensorProxy,
 ) -> [TensorProxy, TensorProxy, None | TensorProxy]:
     return (
         TensorProxy(like=g, shape=a_shape),
-        TensorProxy(like=g, shape=w_shape),
-        TensorProxy(like=g, shape=b_shape) if b_shape else None,
+        TensorProxy(like=g, shape=w_shape) if weight_requires_grad else None,
+        TensorProxy(like=g, shape=b_shape) if bias_requires_grad else None,
     )
 
 
@@ -399,7 +410,12 @@ def get_recipe_from_options_or_default_recipe():
 def _create_fp8_linear_bound_symbol(
     a: TensorProxy, w: TensorProxy, b: TensorProxy, is_grad_enabled=False
 ) -> tuple[torch.Tensor, AnyProxy | None]:
-    linear_fn = partial(TELinear(w.shape[1], w.shape[0]), is_grad_enabled=is_grad_enabled)
+    linear_fn = partial(
+        TELinear(w.shape[1], w.shape[0]),
+        is_grad_enabled=is_grad_enabled,
+        weight_requires_grad=w.requires_grad,
+        bias_requires_grad=b.requires_grad if b is not None else False,
+    )
     global LINEAR_CALLS_COUNTER
     name = f"te_linear_{LINEAR_CALLS_COUNTER}"
 
@@ -486,7 +502,15 @@ def _linear_checker(
 def linear_forward_rule(a, w, bias):
     out, saved_tensors, ctx = _create_fp8_linear_bound_symbol(a, w, bias, is_grad_enabled=True)
     primal = out
-    saved_for_backward = (a.shape, w.shape, bias.shape if bias is not None else None, ctx, saved_tensors)
+    saved_for_backward = (
+        a.shape,
+        w.shape,
+        bias.shape if bias is not None else None,
+        w.requires_grad,
+        bias.requires_grad if bias is not None else False,
+        ctx,
+        saved_tensors,
+    )
     return primal, saved_for_backward
 
 
@@ -498,11 +522,13 @@ def _linear_transform(a: TensorProxy, w: TensorProxy, b: TensorProxy) -> torch.T
 @disable_caching_split_forward_and_backward
 def _linear_grad(a: TensorProxy, w: TensorProxy, b: TensorProxy) -> TensorProxy:
     out, saved_for_backward = linear_forward_rule(a, w, b)
+    _, _, _, weight_requires_grad, bias_requires_grad, *_ = saved_for_backward
     g = prims.get_grad(out)
     ga, gw, gb = te_functional_linear_backward(*saved_for_backward, g)
     prims.put_grad(a, ga)
-    prims.put_grad(w, gw)
-    if b is not None:
+    if weight_requires_grad:
+        prims.put_grad(w, gw)
+    if bias_requires_grad:
         prims.put_grad(b, gb)
     return out
 

--- a/thunder/tests/test_transformer_engine_executor.py
+++ b/thunder/tests/test_transformer_engine_executor.py
@@ -249,3 +249,45 @@ def test_te_trace_metadata_propagation():
 
     # Verify that we have `te_linear` in the trace.
     assert any(bsym.sym.name.startswith("te_linear") for bsym in fwd_traces[-1].bound_symbols)
+
+
+@requiresCUDA
+def test_te_frozen_weights():
+    # Test to verify that setting `requires_grad` on weights is respected by the TE executor
+    # and we don't compute gradients for the same.
+    with torch.device("cuda"):
+        model = torch.nn.Sequential(*(torch.nn.Linear(32, 32, bias=False) for _ in range(6)))
+        x = torch.randn(32, 32, requires_grad=True)
+
+    for idx, parameters in enumerate(model.parameters()):
+        # Every even linear layer's weight is frozen.
+        if idx % 2 == 0:
+            parameters.requires_grad = False
+
+    tmodel = thunder.jit(model, executors=[transformer_engine_ex])
+    o = tmodel(x)
+
+    bwd_trc = thunder.last_backward_traces(tmodel)[-1]
+    te_linear_cnt = 0
+    # NOTE - `reversed(bwd_trc.bound_symbols)` because we will compute gradients for last linear first and similarly
+    #        for the first linear at the end.
+    for bsym in reversed(bwd_trc.bound_symbols):
+        if bsym.sym.name.startswith("te_functional_linear"):
+            weight_requires_grad = bsym.args[3]
+            bias_requires_grad = bsym.args[4]
+            if te_linear_cnt % 2 == 0:
+                assert not weight_requires_grad
+                assert not bias_requires_grad
+            else:
+                assert weight_requires_grad
+                assert not bias_requires_grad
+
+            te_linear_cnt += 1
+
+    o.sum().backward()
+
+    for idx, parameters in enumerate(model.parameters()):
+        if idx % 2 != 0:
+            assert parameters.grad is not None and isinstance(parameters.grad, torch.Tensor)
+        else:
+            assert parameters.grad is None


### PR DESCRIPTION
Problem - Currently, TE executor just assumes that we will be computing gradients for both input and weight. This is true for full finetuning, but in PEFT scenario the weights are frozen i.e. requires_grad=False. This leads to poor performance as the TE executor ends up doing unnecessary work of computing gradients for weights.

Solution - Based on the `requires_grad` on TensorProxy for weight and bias, enable/disable the relevant gradient computation.

NOTE - Thunder doesn't reliable propagate the requires_grad on intermediate values (see https://github.com/Lightning-AI/lightning-thunder/issues/1768) so we just assume that requires_grad on `inp` is True. However, it should be safe to check the `requires_grad` on Parameters as they are inputs to the jitted function.

