### PR TITLE
Add softmin op

### DIFF
--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -8174,6 +8174,25 @@ softmax_opinfo = OpInfo(
 nn_ops.append(softmax_opinfo)
 
 
+softmin_opinfo = OpInfo(
+    ltorch.softmin,
+    supports_grad=True,
+    sample_input_generator=softmax_sample_generator,
+    torch_reference=torch.nn.functional.softmin,
+    dtypes=(datatypes.floating,),
+    test_directives=(
+        # torch.softmin doesn't support float16 on CPU
+        # RuntimeError: "softmax_lastdim_kernel_impl" not implemented for 'Half'
+        DecorateInfo(
+            pytest.mark.xfail,
+            dtypes=(datatypes.float16,),
+            devicetypes=(devices.DeviceType.CPU,),
+        ),
+    ),
+)
+nn_ops.append(softmin_opinfo)
+
+
 log_softmax_opinfo = OpInfo(
     ltorch.log_softmax,
     sample_input_generator=softmax_sample_generator,

--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -8161,15 +8161,6 @@ softmax_opinfo = OpInfo(
     sample_input_generator=softmax_sample_generator,
     torch_reference=torch.softmax,
     dtypes=(datatypes.floating,),
-    test_directives=(
-        # torch.softmax doesn't support float16 on CPU
-        # RuntimeError: "softmax_lastdim_kernel_impl" not implemented for 'Half'
-        DecorateInfo(
-            pytest.mark.xfail,
-            dtypes=(datatypes.float16,),
-            devicetypes=(devices.DeviceType.CPU,),
-        ),
-    ),
 )
 nn_ops.append(softmax_opinfo)
 
@@ -8180,15 +8171,6 @@ softmin_opinfo = OpInfo(
     sample_input_generator=softmax_sample_generator,
     torch_reference=torch.nn.functional.softmin,
     dtypes=(datatypes.floating,),
-    test_directives=(
-        # torch.softmin doesn't support float16 on CPU
-        # RuntimeError: "softmax_lastdim_kernel_impl" not implemented for 'Half'
-        DecorateInfo(
-            pytest.mark.xfail,
-            dtypes=(datatypes.float16,),
-            devicetypes=(devices.DeviceType.CPU,),
-        ),
-    ),
 )
 nn_ops.append(softmin_opinfo)
 
@@ -8199,14 +8181,6 @@ log_softmax_opinfo = OpInfo(
     torch_reference=None if LooseVersion(torch.__version__) < "1.13" else torch._refs.log_softmax,
     dtypes=(datatypes.floating,),
     test_directives=(
-        # torch.log_softmax doesn't support float16 on CPU
-        # RuntimeError: "log_softmax_lastdim_kernel_impl" not implemented for 'Half'
-        DecorateInfo(
-            pytest.mark.xfail,
-            "test_core_vs_torch_consistency",
-            dtypes=(datatypes.float16,),
-            devicetypes=(devices.DeviceType.CPU,),
-        ),
         # Sets more permissive atol and rtol precisions for bfloat16 than assert_close's defaults
         #   (which are 1.6e-2 and 1e-5)
         DecorateInfo(

--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -8185,7 +8185,10 @@ log_softmax_opinfo = OpInfo(
         #   (which are 1.6e-2 and 1e-5)
         DecorateInfo(
             custom_comparator(partial(assert_close, atol=1e-2, rtol=1e-2)),
-            dtypes=(datatypes.bfloat16,),
+            dtypes=(
+                datatypes.float16,
+                datatypes.bfloat16,
+            ),
         ),
     ),
 )

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -5344,6 +5344,17 @@ def softmax(a: TensorLike, dim: int, dtype: None | dtypeLike = None, _stacklevel
     return _softmax(a, dim=dim, dtype=dtype)
 
 
+@torchsymbol(torch.nn.functional.softmin, is_method=False, id="torch.nn.functional.softmin")
+def _softmin(a: TensorLike, /, dim: int, *, dtype: None | dtypeLike = None) -> TensorLike:
+    return softmax(-a, dim, dtype)
+
+
+# A wrapper to support `torch.nn.Softmin` whose `forward` passes the kwarg of `_stacklevel=5` to `torch.nn.functional.softmin`.
+# ref: https://github.com/pytorch/pytorch/blob/8d12ba9acfa20ed7df438a8892c9bf8e6bef5775/torch/nn/modules/activation.py#L1487
+def softmin(a: TensorLike, dim: int, dtype: None | dtypeLike = None, _stacklevel: int = 3) -> TensorLike:
+    return _softmin(a, dim=dim, dtype=dtype)
+
+
 def torch_device(type: DeviceLike, index: int | None = None) -> devices.Device:
     if isinstance(type, (devices.Device, torch.device)):
         # PyTorch behavior:

--- a/thunder/torch/default_torch_ops.py
+++ b/thunder/torch/default_torch_ops.py
@@ -379,7 +379,6 @@ torch_auto_registered_ops = {
         torch.nn.functional.rrelu,
         torch.nn.functional.smooth_l1_loss,
         torch.nn.functional.soft_margin_loss,
-        torch.nn.functional.softmin,
         torch.nn.functional.softplus,
         torch.nn.functional.softsign,
         torch.nn.functional.triplet_margin_loss,


### PR DESCRIPTION
Adds support for the `softmin` op, which is nearly identical to the `softmax` op.  However, unlike for `softmax` there is no `torch.softmin`  nor `torch.Tensor.softmin`.  

Also, it looks like `softmax` is supported on CPU for float16 now.