### PR TITLE
Improve cache lookup overheads in FusionDefinitionWrapper

### DIFF
--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -402,29 +402,6 @@ def compute_contiguity(
     return tuple(tuple(x) for x in nv_compute_td(shape, stride))
 
 
-@lru_cache(maxsize=2048)
-def compute_tensor_descriptor(
-    proxy_shape: Sequence[int | NumberProxy], shape: torch.Size | Sequence[int], stride: Sequence[int]
-) -> tuple[tuple[int, ...], tuple[bool, ...], tuple[int, ...]]:
-    """
-    Computes the symbolic shape, contiguity and stride_order of a tensor using
-    nvFuser's notion. See compute_symbolic_shape and compute_contiguity for
-    more details.
-
-    This function is caching the results of compute_symbolic_shape and
-    compute_contiguity to speed up the computation.
-
-    Args:
-        shape (Union[torch.Size, Sequence[int]]): The shape of the tensor.
-        stride (Sequence[int]): The stride of the tensor.
-
-    Returns:
-        Tuple[Tuple[int, ...], Tuple[bool, ...], Tuple[int, ...]]: The symbolic
-        shape, contiguity and stride_order of the tensor.
-    """
-    return compute_symbolic_shape(proxy_shape, shape), *compute_contiguity(shape, stride)
-
-
 def to_runtime_descriptors(args) -> tuple:
     def to_descriptor(arg):
         if isinstance(arg, Tensor):


### PR DESCRIPTION
Inspired by the changes from https://github.com/Lightning-AI/lightning-thunder/pull/1096, the next step is to utilize only the necessary information to construct contiguity and stride order information from runtime tensors. Therefore, the shape and dtype are now always derived from ProxyTensors and this information is available at the trace construction time.

Here are the results of measuring CPU time for the `to_descriptors` function which is used to build the cache key:
![image](https://github.com/user-attachments/assets/01564a91-3722-46c1-865a-9df28e52d677)

Here's the breakdown for different components of the call method for the current PR:
![image](https://github.com/user-attachments/assets/6b5f1772-32da-4512-a0d0-39b1951d06c8)

"Other" is something that is not `to_descriptors`, `get_fd`, `fd.execute`. For example, version check, which is being removed in https://github.com/Lightning-AI/lightning-thunder/pull/1840.

cc @tfogal