### PR TITLE
Use THUNDER_ANNOTATE_TRACES for enabling NVTX annotations with annotate_for_profile

### DIFF
--- a/thunder/core/profile.py
+++ b/thunder/core/profile.py
@@ -13,8 +13,6 @@ _ENABLED = os.getenv("THUNDER_ANNOTATE_TRACES") in ("1", "y", "Y")
 # environment variable.
 try:
     import nvtx
-
-    _ENABLED = True
 except ImportError:
     if _ENABLED:
         msg = "Requested nvtx but the package is not available."


### PR DESCRIPTION
Summary: This PR stops adding NVTX markers through `annotate_for_profile` when THUNDER_ANNOTATE_TRACES is not set.

Adding NVTX markers in Python has a cost of ~1 μs. This should be done only when profiling, not during regular execution. 
We have (what I thought optional) NVTX markers available through `annotate_for_profile`:
https://github.com/Lightning-AI/lightning-thunder/blob/69ae4d66e45be68115b260f5ad7af07a75dd8a5c/thunder/core/profile.py#L49-L51
but they were not optional because the `_ENABLED` variable was overwritten in the file and the `THUNDER_ANNOTATE_TRACES` environment variable was ignored.

After this PR, the markers will be added if the special environment variable is set to 1 `THUNDER_ANNOTATE_TRACES=1`:
https://github.com/Lightning-AI/lightning-thunder/blob/69ae4d66e45be68115b260f5ad7af07a75dd8a5c/thunder/core/profile.py#L10

Before this PR:
```py
In [1]: from thunder.core.profile import annotate_for_profile

In [2]: %%timeit
   ...: with annotate_for_profile("test"):
   ...:     pass
   ...: 
1.14 µs ± 9.82 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```
After this PR:
```py
In [1]: from thunder.core.profile import annotate_for_profile

In [2]: %%timeit
   ...: with annotate_for_profile("test"):
   ...:     pass
   ...: 
347 ns ± 3.34 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```

cc @riccardofelluga