### PR TITLE
Inplace dtype mismatch

### DIFF
--- a/thunder/tests/test_inplace_copy.py
+++ b/thunder/tests/test_inplace_copy.py
@@ -191,3 +191,15 @@ def test_inplace_copy_of_leaf_requiring_grad_fails(executor, device, dtype):
     a = make_tensor((4, 4), device=device, dtype=tdtype, requires_grad=True)
     with pytest.raises(RuntimeError):
         jitted_fn(a)
+
+@instantiate(executors=(TorchExecutor,), dtypes=datatypes.float_math_dtypes)
+def test_inplace_copy_dtype_mismatch(executor, device, dtype):
+    def fn(x, y):
+        x.add_(y)
+
+    jitted_fn = executor.make_callable(fn)
+    tdtype = ttorch.to_torch_dtype(dtype)
+    a = make_tensor((4, 4), device=device, dtype=tdtype, requires_grad=True)
+    y = make_tensor((4, 4), device=device, dtype=torch.float32, requires_grad=False)
+    with pytest.raises(RuntimeError):
+        jitted_fn(a)

--- a/thunder/tests/test_inplace_copy.py
+++ b/thunder/tests/test_inplace_copy.py
@@ -192,6 +192,7 @@ def test_inplace_copy_of_leaf_requiring_grad_fails(executor, device, dtype):
     with pytest.raises(RuntimeError):
         jitted_fn(a)
 
+
 @instantiate(executors=(TorchExecutor,), dtypes=datatypes.float_math_dtypes)
 def test_inplace_copy_dtype_mismatch(executor, device, dtype):
     def fn(x, y):

--- a/thunder/tests/test_inplace_copy.py
+++ b/thunder/tests/test_inplace_copy.py
@@ -200,6 +200,6 @@ def test_inplace_copy_dtype_mismatch(executor, device, dtype):
     jitted_fn = executor.make_callable(fn)
     tdtype = ttorch.to_torch_dtype(dtype)
     a = make_tensor((4, 4), device=device, dtype=tdtype, requires_grad=True)
-    y = make_tensor((4, 4), device=device, dtype=torch.float32, requires_grad=False)
+    b = make_tensor((4, 4), device=device, dtype=torch.float32, requires_grad=False)
     with pytest.raises(RuntimeError):
-        jitted_fn(a)
+        jitted_fn(a, b)

--- a/thunder/tests/test_inplace_copy.py
+++ b/thunder/tests/test_inplace_copy.py
@@ -199,7 +199,6 @@ def test_inplace_copy_dtype_mismatch(executor, device, dtype):
 
     jitted_fn = executor.make_callable(fn)
     tdtype = ttorch.to_torch_dtype(dtype)
-    a = make_tensor((4, 4), device=device, dtype=tdtype, requires_grad=True)
+    a = make_tensor((4, 4), device=device, dtype=tdtype, requires_grad=False)
     b = make_tensor((4, 4), device=device, dtype=torch.float32, requires_grad=False)
-    with pytest.raises(RuntimeError):
-        jitted_fn(a, b)
+    jitted_fn(a, b)

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -227,6 +227,7 @@ def register_function(torchfn, thunderfn_impl):
 
 def _copy_(a, b, /):
     cd = get_compile_data()
+    b = clang.maybe_convert_to_dtype(b, a.dtype)
     return prims.copy_(b, a, grad_enabled=cd.is_grad_enabled if cd is not None else False)
 
 


### PR DESCRIPTION
We could have a.add_(b), where a and b have different dtypes.

Type promotion would ended up having us trying to trigger inplace copy with mismatching dtypes.