### PR TITLE
Bump Jupyter CI to testing with PyTorch 2.5.1

### DIFF
--- a/.azure/notebook-runs.yml
+++ b/.azure/notebook-runs.yml
@@ -15,8 +15,8 @@ jobs:
   - job: jupyter
     strategy:
       matrix:
-        "ubuntu22.04 | cuda 12.1 | torch 2.4.0":
-          docker-image: "ubuntu22.04-cuda12.1.1-cudnn-fe1.5.2-py3.10-pt_2.4.0-dev"
+        "ubuntu22.04 | cuda 12.1 | torch 2.5.1":
+          docker-image: "ubuntu22.04-cuda12.1.1-cudnn-fe1.5.2-py3.10-pt_2.5.1-dev"
           CUDA_VERSION_MM: "121"
         "ubuntu22.04 | cuda 12.1 | torch-nightly":
           docker-image: "ubuntu22.04-cuda12.1.1-cudnn-fe1.5.2-py3.10-pt_main-dev"


### PR DESCRIPTION
All other CI jobs are already at PyTorch 2.5.1

cc @borda