### PR TITLE
[ThunderFX report] Uses fd in `run_benchmark` instead of `FusionDefinitionWrapper`

### DIFF
--- a/thunder/dynamo/benchmark_utils.py
+++ b/thunder/dynamo/benchmark_utils.py
@@ -140,7 +140,7 @@ class BoundSymbolNvfuserSpecification(CompileSpecificationInterface):
     # See the TODO in :class:`thunder.dynamo.report.ThunderFusionReport` for more details.
     def compile(self, nvfusion_bsym):
         fd = nvfusion_bsym._call_ctx[nvfusion_bsym.sym.name].last_used
-        return fd.execute
+        return lambda *args: fd.execute(args)
 
 
 class BoundSymbolTorchCompileSpecification(CompileSpecificationInterface):

--- a/thunder/dynamo/benchmark_utils.py
+++ b/thunder/dynamo/benchmark_utils.py
@@ -139,7 +139,8 @@ class BoundSymbolNvfuserSpecification(CompileSpecificationInterface):
     # Returns the nvFuser callable from the nvFuser bound symbol.
     # See the TODO in :class:`thunder.dynamo.report.ThunderFusionReport` for more details.
     def compile(self, nvfusion_bsym):
-        return nvfusion_bsym._call_ctx[nvfusion_bsym.sym.name]
+        fd = nvfusion_bsym._call_ctx[nvfusion_bsym.sym.name].last_used
+        return fd.execute
 
 
 class BoundSymbolTorchCompileSpecification(CompileSpecificationInterface):

--- a/thunder/dynamo/report.py
+++ b/thunder/dynamo/report.py
@@ -796,6 +796,8 @@ class ThunderFusionReport:
     def run_benchmark(self, compile_fn: CompileSpecificationInterface, timer_fn: TimerInterface):
         compiled_fn = compile_fn.compile(self.nvfusion_bsym)
         inputs = self.make_example_inputs()
+        if compile_fn.name == "nvfuser":
+            inputs = [inputs]
         return timer_fn.time("compiled_fn(*inputs)", globals={"compiled_fn": compiled_fn, "inputs": inputs})
 
     def run_repro(

--- a/thunder/dynamo/report.py
+++ b/thunder/dynamo/report.py
@@ -796,8 +796,6 @@ class ThunderFusionReport:
     def run_benchmark(self, compile_fn: CompileSpecificationInterface, timer_fn: TimerInterface):
         compiled_fn = compile_fn.compile(self.nvfusion_bsym)
         inputs = self.make_example_inputs()
-        if compile_fn.name == "nvfuser":
-            inputs = [inputs]
         return timer_fn.time("compiled_fn(*inputs)", globals={"compiled_fn": compiled_fn, "inputs": inputs})
 
     def run_repro(
@@ -806,8 +804,6 @@ class ThunderFusionReport:
     ):
         compiled_fn = compile_fn.compile(self.nvfusion_bsym)
         inputs = self.make_example_inputs()
-        if compile_fn.name == "nvfuser":
-            return compiled_fn(inputs)
         return compiled_fn(*inputs)
 
     def _get_nvfuser_code(self):

--- a/thunder/dynamo/report.py
+++ b/thunder/dynamo/report.py
@@ -806,6 +806,8 @@ class ThunderFusionReport:
     ):
         compiled_fn = compile_fn.compile(self.nvfusion_bsym)
         inputs = self.make_example_inputs()
+        if compile_fn.name == "nvfuser":
+            return compiled_fn(inputs)
         return compiled_fn(*inputs)
 
     def _get_nvfuser_code(self):


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

The old `run_benchmark` for nvfusion symbol measures the callable `FusionDefinitionWrapper`, but saves the `fd.execute` in the benchmarking script. There's extra overhead of `FusionDefinitionWrapper`, so the wall time are different between `run_benchmark` and the saved script.
This PR makes their behavior uniform: both use `fd.execute` since it's hard to serialize `FusionDefinitionWrapper` into code string.
