### PR TITLE
[reporting] Adds utility to save failing repros for a FXGraphReport (…

### DIFF
--- a/thunder/dynamo/report.py
+++ b/thunder/dynamo/report.py
@@ -1218,7 +1218,9 @@ def thunderfx_benchmark_report(
     )
 
 
-def save_failing_repros(reports: list[FXGraphReport], compile_fn: CompileSpecificationInterface, repros_folder: str | PathLike):
+def save_failing_repros(
+    reports: list[FXGraphReport], compile_fn: CompileSpecificationInterface, repros_folder: str | PathLike
+):
     """
     Saves the repros for the failing reports. The failing reason is saved as comment in the repro file.
     example usage:

--- a/thunder/dynamo/report.py
+++ b/thunder/dynamo/report.py
@@ -1216,3 +1216,24 @@ def thunderfx_benchmark_report(
     thunderfx_benchmark_report_from_splits(
         thunder_fxgraph_reports, folder_path, thunder_compile_kwargs, compare_fusion, rtol, atol
     )
+
+
+def save_failing_repros(reports: list[FXGraphReport], compile_fn: CompileSpecificationInterface, repros_folder: str | PathLike):
+    """
+    Saves the repros for the failing reports. The failing reason is saved as comment in the repro file.
+    example usage:
+    ```python
+    # Gets the Dynamo FX Graph reports
+    report = fx_report(model, x)
+    # Saves the repros for the failing reports using TorchCompile
+    save_failing_repros(report.fx_graph_reports, TorchCompileSpecification(), "repros")
+    ```
+    """
+    repros_folder = Path(repros_folder)
+    repros_folder.mkdir(exist_ok=True, parents=True)
+    for report in reports:
+        try:
+            report.run_repro(compile_fn)
+        except Exception as e:
+            comment = f"Failed to run the function using {compile_fn.name} with exception: {e}"
+            report.write_repro(repros_folder, compile_fn, extra_comment_str=comment)

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -29,7 +29,13 @@ from thunder.tests.framework import (
     version_between,
 )
 from thunder.tests.make_tensor import make_tensor
-from thunder.dynamo.report import thunderfx_pytest_benchmark_report, fx_report, analyze_thunder_splits, save_failing_repros, get_thunder_fxgraph_reports
+from thunder.dynamo.report import (
+    thunderfx_pytest_benchmark_report,
+    fx_report,
+    analyze_thunder_splits,
+    save_failing_repros,
+    get_thunder_fxgraph_reports,
+)
 from thunder.dynamo.benchmark_utils import (
     ThunderCompileSpecification,
     TorchCompileSpecification,

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -29,7 +29,7 @@ from thunder.tests.framework import (
     version_between,
 )
 from thunder.tests.make_tensor import make_tensor
-from thunder.dynamo.report import thunderfx_pytest_benchmark_report, fx_report, analyze_thunder_splits
+from thunder.dynamo.report import thunderfx_pytest_benchmark_report, fx_report, analyze_thunder_splits, save_failing_repros, get_thunder_fxgraph_reports
 from thunder.dynamo.benchmark_utils import (
     ThunderCompileSpecification,
     TorchCompileSpecification,
@@ -1411,3 +1411,24 @@ def test_TorchInductorSpecification(tmp_path):
     assert len(py_files) == 2
     for file in py_files:
         run_script(file, cmd)
+
+
+@requiresCUDA
+def test_save_failing_repros(tmp_path):
+    x = torch.ones(2, 2, device="cuda", requires_grad=True)
+
+    def foo(x):
+        return torch.sin(x) + torch.cos(x)
+
+    # Tests for dynamo fx graphreports
+    results = fx_report(foo, x)
+    with patch("thunder.dynamo.report.FXGraphReport.run_repro", side_effect=Exception("run_Repro raises exception")):
+        save_failing_repros(results.fx_graph_reports, TorchCompileSpecification(), tmp_path)
+    assert os.path.exists(tmp_path / "graph0.py")
+
+    # Tests for thunder split reports
+    thunder_fxgraph_reports = get_thunder_fxgraph_reports(foo, x)
+    assert len(thunder_fxgraph_reports) == 1
+    with patch("thunder.dynamo.report.FXGraphReport.run_repro", side_effect=Exception("run_Repro raises exception")):
+        save_failing_repros(thunder_fxgraph_reports[0].subgraph_reports, ThunderCompileSpecification(), tmp_path)
+    assert os.path.exists(tmp_path / "graph0_thunder_0.py")


### PR DESCRIPTION
…#1856)

<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes #1856

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
