### PR TITLE
Upcast fp8 to fp32 in get_example_input_tensor_metadata for computing aminmax

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ For **performance experts**, Thunder is the most ergonomic framework for underst
 <div align='center'>
 
 <pre>
-✅ Run PyTorch 40% faster   ✅ Quantization                ✅ Kernel fusion        
-✅ Training recipes         ✅ FP4/FP6/FP8 precision       ✅ Distributed TP/PP/DP 
-✅ Inference recipes        ✅ Ready for NVIDIA Blackwell  ✅ CUDA Graphs          
+✅ Run PyTorch 40% faster   ✅ Quantization                ✅ Kernel fusion
+✅ Training recipes         ✅ FP4/FP6/FP8 precision       ✅ Distributed TP/PP/DP
+✅ Inference recipes        ✅ Ready for NVIDIA Blackwell  ✅ CUDA Graphs
 ✅ LLMs, non LLMs and more  ✅ Custom Triton kernels       ✅ Compose all the above
 </pre>
 

--- a/thunder/dynamo/utils.py
+++ b/thunder/dynamo/utils.py
@@ -17,6 +17,7 @@ from thunder.torch.langctx import torchctx
 from thunder.core.utils import check
 
 if TYPE_CHECKING:
+    from numbers import Number
     from thunder.core.symbol import Symbol
     import os
     from typing import Any
@@ -458,15 +459,19 @@ def _get_storage_shape(t: torch.Tensor):
     return (storage_size,)
 
 
+def _get_min_and_val(t: torch.Tensor) -> tuple[Number | None, Number | None]:
+    if isinstance(t, FakeTensor) or t.device.type == "meta" or t.numel() == 0:
+        return None, None
+    if t.dtype in (torch.float8_e4m3fn, torch.float8_e4m3fnuz, torch.float8_e5m2, torch.float8_e5m2fnuz):
+        t = t.to(torch.float32)
+    minmax: tuple[torch.Tensor, torch.Tensor] = torch.aminmax(t)
+    min_val = minmax[0].cpu().item()
+    max_val = minmax[1].cpu().item()
+    return min_val, max_val
+
+
 def _get_example_input_tensor_metadata(t: torch.Tensor) -> ExampleInputMetaData:
-    min_val = None
-    max_val = None
-    if not isinstance(t, FakeTensor) and t.device.type != "meta" and t.numel() != 0:
-        if t.dtype in (torch.float8_e4m3fn, torch.float8_e4m3fnuz, torch.float8_e5m2, torch.float8_e5m2fnuz):
-            t = t.to(torch.float32)
-        minmax: tuple[torch.Tensor, torch.Tensor] = torch.aminmax(t)
-        min_val = minmax[0].cpu().item()
-        max_val = minmax[1].cpu().item()
+    min_val, max_val = _get_min_and_val(t)
     meta_ev = ExampleInputMetaData(
         t.requires_grad,
         t.layout,

--- a/thunder/dynamo/utils.py
+++ b/thunder/dynamo/utils.py
@@ -462,6 +462,8 @@ def _get_example_input_tensor_metadata(t: torch.Tensor) -> ExampleInputMetaData:
     min_val = None
     max_val = None
     if not isinstance(t, FakeTensor) and t.device.type != "meta" and t.numel() != 0:
+        if t.dtype in (torch.float8_e4m3fn, torch.float8_e4m3fnuz, torch.float8_e5m2, torch.float8_e5m2fnuz):
+            t = t.to(torch.flot32)
         minmax: tuple[torch.Tensor, torch.Tensor] = torch.aminmax(t)
         min_val = minmax[0].cpu().item()
         max_val = minmax[1].cpu().item()

--- a/thunder/dynamo/utils.py
+++ b/thunder/dynamo/utils.py
@@ -463,7 +463,7 @@ def _get_example_input_tensor_metadata(t: torch.Tensor) -> ExampleInputMetaData:
     max_val = None
     if not isinstance(t, FakeTensor) and t.device.type != "meta" and t.numel() != 0:
         if t.dtype in (torch.float8_e4m3fn, torch.float8_e4m3fnuz, torch.float8_e5m2, torch.float8_e5m2fnuz):
-            t = t.to(torch.flot32)
+            t = t.to(torch.float32)
         minmax: tuple[torch.Tensor, torch.Tensor] = torch.aminmax(t)
         min_val = minmax[0].cpu().item()
         max_val = minmax[1].cpu().item()


### PR DESCRIPTION
## What does this PR do?

While trying to identify the root cause of `thunder.jit(torchao_float8_linears)` backward fails to correctly convert matrices of `torch._scaled_mm` inputs, I found that `thunder.jit(..., nv_store_fusion_inputs=True, nv_store_fusion_inputs_meta=True)` when I tried it on a whim as `aminmax` does not support any fp8 dtypes.
However, the function this PR changes aims at getting max and min of `t: torch.Tensor`, it'd be fair to upcsat it to `torch.float32`.