### PR TITLE
add custom grad function for softplus

### DIFF
--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -1443,6 +1443,20 @@ def _log_sigmoid_grad(
 register_grad("torch.nn.functional.logsigmoid", _log_sigmoid_grad)
 
 
+def _softplus_grad(a: TensorProxy, /, beta: float = 1.0, threshold: float = 20.0):
+    from thunder.torch import sigmoid, softplus, where
+
+    fwd = softplus(a, beta, threshold)
+    g = get_grad(fwd)
+    scaled_a = a * beta
+    rhs = sigmoid(scaled_a)
+    a_grad = g * where(scaled_a > threshold, 1.0, rhs)
+    put_grad(a, a_grad)
+    return fwd
+
+
+register_grad("torch.nn.functional.softplus", _softplus_grad)
+
 #
 # Phantom grad transform helpers
 #

--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -1783,7 +1783,7 @@ softplus_opinfo = OpInfo(
     ltorch.softplus,
     dtypes=(datatypes.floating,),
     sample_input_generator=get_elementwise_unary_with_kwargs_generator(
-        [{}, {"beta": 0.5}, {"beta": 2.0}, {"threshold": 5.0}, {"beta": 0.5, "threshold": 10.0}]
+        [{}, {"beta": 0.5}, {"beta": 2.0, "threshold": 10.0}]
     ),
     torch_reference=_elementwise_unary_torch(torch.nn.functional.softplus),
     singularity_fn_producer=soft_plus_singularity_fn_producer,


### PR DESCRIPTION
As noted [here](https://github.com/Lightning-AI/lightning-thunder/pull/1842#issuecomment-2718078365) test_vjp_correctness for softplus takes a long time, and even times out.  The custom grad speeds things up a bit, but the real difference is made by reducing the number of samples by 2/5. 
