### PR TITLE
add option of `_force_disable_execution_callback_file`

### DIFF
--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -709,6 +709,7 @@ def _convert_pytorchfunc_to_thundertrace(
         return wrapped_func_result, None
 
     trace = TraceCtx()
+    trace._force_disable_execution_callback_file = True
     bsyms = active_jit_ctx.computation_trace.pop_scope()
     trace.bound_symbols.extend(bsyms)
     func_result = unwrap(wrapped_func_result)
@@ -784,6 +785,7 @@ def _general_jit_torch_autograd_function_apply_lookaside(obj: Any, *args, **kwar
         ctx_proxy.saved_tensors,
     )
     trace_of_augmented_fwd = TraceCtx()
+    trace_of_augmented_fwd._force_disable_execution_callback_file = True
     trace_of_augmented_fwd.bound_symbols.extend(trace_of_fwd.bound_symbols[:-1])
     with tracectx(trace_of_augmented_fwd):
         prims.python_return(augmented_bsym_output)
@@ -812,6 +814,7 @@ def _general_jit_torch_autograd_function_apply_lookaside(obj: Any, *args, **kwar
     trace_of_backward.bound_symbols = bwd_unpack_bsyms + trace_of_backward.bound_symbols
 
     bwd_trace_impl = TraceCtx()
+    bwd_trace_impl._force_disable_execution_callback_file = True
     bwd_trace_impl.bound_symbols.extend(trace_of_backward.bound_symbols)
     bwd_trace_impl._siginfo = SigInfo.from_name_and_args(
         "backward_impl",
@@ -897,6 +900,7 @@ def _general_jit_torch_ops_higher_order_autograd_function_apply(fwd, bwd, *fwd_a
     )
 
     trace_of_forward = from_trace(aug_fwd_trace)
+    trace_of_forward._force_disable_execution_callback_file = True
     for bsym in aug_fwd_trace.bound_symbols:
         if bsym.sym.id == prims.PrimIDs.RETURN:
             continue

--- a/thunder/core/trace.py
+++ b/thunder/core/trace.py
@@ -131,6 +131,11 @@ class TraceCtx:
         # We only want the forward function to be called with ctx manager.
         self._include_te_fp8_autocast = False
 
+        # Disable :func:`thunder.set_execution_callback_file`
+        # mainly for traces generated inside lookasides for custom `torch.autograd.Function`
+        # and `torch.ops.higher_order.autograd_function_apply`
+        self._force_disable_execution_callback_file = False
+
     @property
     def bound_symbols(self) -> list[BoundSymbolInterface]:
         return self._bound_symbols
@@ -497,7 +502,7 @@ class TraceCtx:
 
         # Writes the program to allow it to be edited before execution
         path: None | str = _get_execution_file()
-        if path is not None:
+        if path is not None and not self._force_disable_execution_callback_file:
             f = open(path, "w")
             f.write(self.python(**kwargs))
             f.close()


### PR DESCRIPTION
## What does this PR do?

Add option `TraceCtx._force_disable_execution_callback_file` so that we do not need to see files of traces  of custom torch.autograd.Function and torch.ops.higher_order.autograd_function_apply.