### PR TITLE
Cast grad_chooser_backward output to match input

### DIFF
--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -1841,6 +1841,7 @@ def grad_chooser_backward(primal, x, x_shape, reduced_dims, g):
     argmax_locations = x == primal_repeated
     argmax_sum = keepdim_reduction(prims.sum, argmax_locations, reduced_dims)
     out = g_repeated * argmax_locations / argmax_sum
+    out = prims.convert_element_type(out, g.dtype)
     return out
 
 


### PR DESCRIPTION
In #1857, an error was encountered when calculating the backward trace of a function that uses `max` with integer input.  The error was coming from a check in `pad_meta` where a float was found when an integer was expected.  The backward implementation of `max` involves a division operation, that when applied to integers results in a float.  This pr converts the result of that division to match the dtype of the input.  
