### PR TITLE
Trace Transform for Tensor Wrapper Subclasses

### DIFF
--- a/docs/source/reference/transforms/index.rst
+++ b/docs/source/reference/transforms/index.rst
@@ -8,3 +8,4 @@ thunder.transforms
 
     MaterializationTransform
     ConstantFolding
+    unroll_tensor_subclasses

--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -480,7 +480,7 @@ def jit(
 
             prologue_traces += transform_for_execution(
                 prologue_trc,
-                executors_list=(pythonex,),
+                executors_list=(pythonex, get_executor("torch")),
                 use_del_last_used=False,
             )
             prologue_trc = prologue_traces[-1]

--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -73,6 +73,7 @@ from thunder.core.proxies import (
 from thunder.core.interpreter import print_interpreter_log, print_to_log
 from thunder.core.jit_ext import thunder_general_jit
 from thunder.executors.torch_autograd import split_forward_backward, connect_to_autograd
+from thunder.transforms.tensor_wrapper_subclass import unroll_tensor_subclasses
 
 # NOTE This import is intentionally pytorch so that it thunder.torch doesn't import this
 import torch as pytorch
@@ -372,7 +373,7 @@ def jit(
         data_ptr_to_tensor_group_index = {}
         tensor_group_index_to_tensor_indices = defaultdict(list)
         for idx, t in enumerate(flat_args):
-            if pytorch.is_tensor(t) and t.layout == pytorch.strided:
+            if type(t) in {pytorch.Tensor, pytorch.nn.Parameter} and t.layout == pytorch.strided:
                 data_ptr = t.untyped_storage().data_ptr()
                 if data_ptr not in data_ptr_to_tensor_group_index:
                     data_ptr_to_tensor_group_index[data_ptr] = len(data_ptr_to_tensor_group_index)

--- a/thunder/clang/__init__.py
+++ b/thunder/clang/__init__.py
@@ -22,7 +22,9 @@ from thunder.core.proxies import (
     NumberLike,
     NumberProxy,
     Proxy,
+    SubclassTensorProxy,
     TensorProxy,
+    proxy,
     pytype,
     pyval,
 )
@@ -62,7 +64,7 @@ class clangop:
 
 # Checks a tensor's shape and metadata (for use with cache check)
 @clangop()
-def check_tensor_shape_and_metadata(t: TensorProxy, /) -> None:
+def check_tensor_shape_and_metadata(t: TensorProxy | SubclassTensorProxy, /) -> None:
     return prims.check_tensor_shape_and_metadata(
         t,
         # replace Proxy entries with `-1`s as wild card, as we any value is

--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -111,7 +111,9 @@ class JITSharpEdgeError(RuntimeError):
 def _general_jit_sharp_edge(desc: str, value: Any, /) -> Any | INTERPRETER_SIGNALS:
     sharp_edges: SHARP_EDGES_OPTIONS = get_jit_ctx().sharp_edges
 
-    s: str = f"{desc} This is currently considered a sharp edge even with interpretation=INTERPRETATION_OPTIONS.TRANSLATE_PYTHON. For cases in which we are overly strict, please file an issue. Thank you!"
+    s: str = (
+        f"{desc} This is currently considered a sharp edge even with interpretation=INTERPRETATION_OPTIONS.TRANSLATE_PYTHON. For cases in which we are overly strict, please file an issue. Thank you!"
+    )
 
     if sharp_edges is SHARP_EDGES_OPTIONS.ERROR:
         return do_raise(JITSharpEdgeError(s))

--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -743,6 +743,7 @@ def _general_jit_torch_autograd_function_apply_lookaside(obj: Any, *args, **kwar
     from thunder.core.trace_interpreter import interpret_trace
     from thunder.core.transforms import dce
     from thunder.core.pytree import tree_flatten, tree_unflatten
+    from thunder.extend import TemporaryExecutor
 
     custom_autograd_function_cls = unwrap(obj)
     custom_forward = custom_autograd_function_cls.forward
@@ -786,7 +787,8 @@ def _general_jit_torch_autograd_function_apply_lookaside(obj: Any, *args, **kwar
         flat_output, _ = tree_flatten(output)
         return tree_unflatten(flat_output, spec_of_fwd_output)
 
-    custom_fwd_sym = get_jit_ctx().ad_hoc_executor.register_operator(
+    temporary_executor: TemporaryExecutor = get_jit_ctx().ad_hoc_executor
+    custom_fwd_sym = temporary_executor.register_operator(
         custom_autograd_function_cls.__name__,
         like=core_of_forward,
     )

--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -4212,7 +4212,6 @@ def tensor_subclass_ctor_meta(
         requires_grad=requires_grad,
         tensors=tensors,
         non_tensors=non_tensors,
-        history=[t.history for t in tensors],
     )
     return s
 

--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -3688,8 +3688,9 @@ view = make_prim(PrimIDs.VIEW, "view", meta=reshape_meta, tags=(OpTags.SHAPE_OP,
 
 def shallow_copy_meta(a: TensorProxy | SubclassTensorProxy, /) -> TensorProxy:
     if isinstance(a, SubclassTensorProxy):
-        # SubclassTensorProxy(like=...) would not copy some attrs such as `_tensors` while replace does.
-        return a.replace()
+        shallow = SubclassTensorProxy(like=a)
+        shallow.copy_attributes_from(a)
+        return shallow
     return TensorProxy(like=a)
 
 

--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -284,6 +284,8 @@ class PrimIDs(Enum):
     SINK = auto()
     # Tensor Subclasses methods
     TENSOR_SUBCLASS_CTOR = auto()
+    FLATTEN_TENSOR_SUBCLASS = auto()
+    UNFLATTEN_TENSOR_SUBCLASS = auto()
 
 
 class OpTags(Enum):
@@ -4236,7 +4238,7 @@ def get_nested_types(collection):
     return tuple(types_set)
 
 
-def filter_types(types: tuple[Any, ...]) -> tuple[Any, ...]:
+def filter_types_for_tensor_wrapper_subclass(types: tuple[Any, ...]) -> tuple[Any, ...]:
     return tuple(
         filter(
             lambda t: (
@@ -4258,7 +4260,7 @@ def bind_postprocess_of_tensor_subclass_ctor(bsym: BoundSymbol) -> None:
     filtered_types: tuple[Any, ...] = (cls,)
     if non_tensors:
         types = get_nested_types(non_tensors)
-        filtered_types += filter_types(types)
+        filtered_types += filter_types_for_tensor_wrapper_subclass(types)
     new_imports = {t.__name__: t for t in filtered_types}
     bsym._import_ctx.update(new_imports)
 
@@ -4268,4 +4270,164 @@ tensor_subclass_ctor = make_prim(
     "tensor_subclass_ctor",
     meta=tensor_subclass_ctor_meta,
     _bind_postprocess=bind_postprocess_of_tensor_subclass_ctor,
+)
+
+
+def printer_of_tensor_subclass_flatten(
+    bsym: BoundSymbol,
+    out_printables: Any,
+    arg_printables: Sequence[Printable],
+    kwarg_printables: dict[str, Printable],
+) -> str | Iterable[str]:
+    from itertools import chain
+
+    arg_str = (
+        ""
+        if (arg_printables is None or len(arg_printables) == 0)
+        else ", ".join(codeutils.prettyprint(x) for x in arg_printables)
+    )
+
+    result_str: str
+    if bsym.output is None or (baseutils.is_collection(bsym.output) and len(bsym.output) == 0):
+        result_str = ""
+    else:
+        result_str = f"{codeutils.prettyprint(out_printables, literals_as_underscores=True)} = "
+
+    # Creates a comment describing the output
+    comment_str = ""
+    if isinstance(bsym.output, Proxy):
+        comment_str = f"  # {codeutils.prettyprint(out_printables, with_type=True)}"
+
+    s = f"{result_str}{arg_str}.__tensor_flatten__(){comment_str}"
+
+    if bsym.header:
+        header_lines = (
+            bsym.header
+            if isinstance(bsym.header, Sequence) and not isinstance(bsym.header, str)
+            else bsym.header.splitlines()
+        )
+        header_lines = (f"# {line}" for line in header_lines)
+        return chain(header_lines, [s])
+
+    return s
+
+
+# NOTE(crcrpar): The behavior is different from PyTorch `subclass_tensor.__tensor_flatten__()`
+# that returns a list of tensor attr names and a dict of const metadata. In Thunder traces,
+# const values could be obviated and actual tensor proxies would be more useful
+# than tensor attr names.
+def flatten_tensor_subclass_meta(t: SubclassTensorProxy) -> tuple[TensorProxy, ...]:
+    tensor_attr_names, metadata = t.__tensor_flatten__()
+    tensors = tuple(getattr(t, name) for name in tensor_attr_names)
+    return tensors
+
+
+flatten_tensor_subclass = make_prim(
+    PrimIDs.FLATTEN_TENSOR_SUBCLASS,
+    "flatten_tensor_subclass",
+    meta=flatten_tensor_subclass_meta,
+    python_printer=printer_of_tensor_subclass_flatten,
+)
+
+
+def printer_of_unflatten_tensor_subclass(
+    bsym: BoundSymbol,
+    out_printables: Any,
+    arg_printables: Sequence[Printable],
+    kwarg_printables: dict[str, Printable],
+) -> str | Iterable[str]:
+    from itertools import chain
+
+    wrapped_cls: ContextObject | torch._C._TensorMeta = arg_printables[0]
+    if isinstance(wrapped_cls, torch._C._TensorMeta):
+        cls = wrapped_cls
+    else:
+        cls: torch._C._TensorMeta = wrapped_cls.obj
+
+    arg_str = (
+        ""
+        if (arg_printables is None or len(arg_printables) == 0)
+        else ", ".join(codeutils.prettyprint(x) for x in arg_printables[1:])
+    )
+    kwarg_str: str
+
+    if len(kwarg_printables) == 0:
+        kwarg_str = ""
+    else:
+        kwarg_str = ", ".join(f"{k}={codeutils.prettyprint(v)}" for k, v in kwarg_printables.items())
+
+    result_str: str
+    if bsym.output is None or (baseutils.is_collection(bsym.output) and len(bsym.output) == 0):
+        result_str = ""
+    else:
+        result_str = f"{codeutils.prettyprint(out_printables, literals_as_underscores=True)} = "
+
+    # Creates a comment describing the output
+    comment_str = ""
+    if isinstance(bsym.output, Proxy):
+        comment_str = f"  # {codeutils.prettyprint(out_printables, with_type=True)}"
+
+    s = f"{result_str}{cls.__name__}.__tensor_unflatten__({arg_str}{', ' if (len(arg_str) > 0 and len(kwarg_str) > 0) else ''}{kwarg_str}){comment_str}"
+
+    if bsym.header:
+        header_lines = (
+            bsym.header
+            if isinstance(bsym.header, Sequence) and not isinstance(bsym.header, str)
+            else bsym.header.splitlines()
+        )
+        header_lines = (f"# {line}" for line in header_lines)
+        return chain(header_lines, [s])
+
+    return s
+
+
+def bind_postprocess_of_unflatten_tensor_subclass(bsym: BoundSymbol) -> None:
+    cls = bsym.args[0]
+    inner_tensors = bsym.args[1]
+    metadata = bsym.args[2]
+
+    filtered_types: tuple[Any, ...] = (cls,)
+    if metadata:
+        types = get_nested_types(list(metadata.values()))
+        filtered_types += filter_types_for_tensor_wrapper_subclass(types)
+    new_imports = {t.__name__: t for t in filtered_types}
+    bsym._import_ctx.update(new_imports)
+
+
+def unflatten_tensor_subclass_meta(
+    tensor_subclass_type,
+    inner_tensors: dict[str, TensorProxy],
+    metadata: dict[str, Any],
+) -> SubclassTensorProxy:
+    first_tensor: TensorProxy = list(inner_tensors.values())[0]
+    a = SubclassTensorProxy(
+        shape=first_tensor.shape,
+        device=first_tensor.device,
+        dtype=first_tensor.dtype,
+        requires_grad=first_tensor.requires_grad,
+        tensors=list(inner_tensors.values()),
+        non_tensors=list(metadata.values()),
+        subclass_type=tensor_subclass_type,
+    )
+    for name, value in inner_tensors.items():
+        setattr(a, name, value)
+    for name, value in metadata.items():
+        setattr(a, name, value)
+    return a
+
+
+def unflatten_tensor_subclass_python_impl(
+    tensor_subclass_type,
+    inner_tensors: dict[str, TensorProxy],
+    metadata: dict[str, Any],
+) -> torch.Tensor:
+    return tensor_subclass_type.__tensor_unflatten__(inner_tensors, metadata, -1, -1)
+
+
+unflatten_tensor_subclass = make_prim(
+    PrimIDs.UNFLATTEN_TENSOR_SUBCLASS,
+    "unflatten_tensor_subclass",
+    meta=unflatten_tensor_subclass_meta,
+    python_printer=printer_of_unflatten_tensor_subclass,
+    _bind_postprocess=bind_postprocess_of_unflatten_tensor_subclass,
 )

--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -4273,45 +4273,6 @@ tensor_subclass_ctor = make_prim(
 )
 
 
-def printer_of_tensor_subclass_flatten(
-    bsym: BoundSymbol,
-    out_printables: Any,
-    arg_printables: Sequence[Printable],
-    kwarg_printables: dict[str, Printable],
-) -> str | Iterable[str]:
-    from itertools import chain
-
-    arg_str = (
-        ""
-        if (arg_printables is None or len(arg_printables) == 0)
-        else ", ".join(codeutils.prettyprint(x) for x in arg_printables)
-    )
-
-    result_str: str
-    if bsym.output is None or (baseutils.is_collection(bsym.output) and len(bsym.output) == 0):
-        result_str = ""
-    else:
-        result_str = f"{codeutils.prettyprint(out_printables, literals_as_underscores=True)} = "
-
-    # Creates a comment describing the output
-    comment_str = ""
-    if isinstance(bsym.output, Proxy):
-        comment_str = f"  # {codeutils.prettyprint(out_printables, with_type=True)}"
-
-    s = f"{result_str}{arg_str}.__tensor_flatten__(){comment_str}"
-
-    if bsym.header:
-        header_lines = (
-            bsym.header
-            if isinstance(bsym.header, Sequence) and not isinstance(bsym.header, str)
-            else bsym.header.splitlines()
-        )
-        header_lines = (f"# {line}" for line in header_lines)
-        return chain(header_lines, [s])
-
-    return s
-
-
 # NOTE(crcrpar): The behavior is different from PyTorch `subclass_tensor.__tensor_flatten__()`
 # that returns a list of tensor attr names and a dict of const metadata. In Thunder traces,
 # const values could be obviated and actual tensor proxies would be more useful
@@ -4326,59 +4287,7 @@ flatten_tensor_subclass = make_prim(
     PrimIDs.FLATTEN_TENSOR_SUBCLASS,
     "flatten_tensor_subclass",
     meta=flatten_tensor_subclass_meta,
-    python_printer=printer_of_tensor_subclass_flatten,
 )
-
-
-def printer_of_unflatten_tensor_subclass(
-    bsym: BoundSymbol,
-    out_printables: Any,
-    arg_printables: Sequence[Printable],
-    kwarg_printables: dict[str, Printable],
-) -> str | Iterable[str]:
-    from itertools import chain
-
-    wrapped_cls: ContextObject | torch._C._TensorMeta = arg_printables[0]
-    if isinstance(wrapped_cls, torch._C._TensorMeta):
-        cls = wrapped_cls
-    else:
-        cls: torch._C._TensorMeta = wrapped_cls.obj
-
-    arg_str = (
-        ""
-        if (arg_printables is None or len(arg_printables) == 0)
-        else ", ".join(codeutils.prettyprint(x) for x in arg_printables[1:])
-    )
-    kwarg_str: str
-
-    if len(kwarg_printables) == 0:
-        kwarg_str = ""
-    else:
-        kwarg_str = ", ".join(f"{k}={codeutils.prettyprint(v)}" for k, v in kwarg_printables.items())
-
-    result_str: str
-    if bsym.output is None or (baseutils.is_collection(bsym.output) and len(bsym.output) == 0):
-        result_str = ""
-    else:
-        result_str = f"{codeutils.prettyprint(out_printables, literals_as_underscores=True)} = "
-
-    # Creates a comment describing the output
-    comment_str = ""
-    if isinstance(bsym.output, Proxy):
-        comment_str = f"  # {codeutils.prettyprint(out_printables, with_type=True)}"
-
-    s = f"{result_str}{cls.__name__}.__tensor_unflatten__({arg_str}{', ' if (len(arg_str) > 0 and len(kwarg_str) > 0) else ''}{kwarg_str}){comment_str}"
-
-    if bsym.header:
-        header_lines = (
-            bsym.header
-            if isinstance(bsym.header, Sequence) and not isinstance(bsym.header, str)
-            else bsym.header.splitlines()
-        )
-        header_lines = (f"# {line}" for line in header_lines)
-        return chain(header_lines, [s])
-
-    return s
 
 
 def bind_postprocess_of_unflatten_tensor_subclass(bsym: BoundSymbol) -> None:
@@ -4428,6 +4337,5 @@ unflatten_tensor_subclass = make_prim(
     PrimIDs.UNFLATTEN_TENSOR_SUBCLASS,
     "unflatten_tensor_subclass",
     meta=unflatten_tensor_subclass_meta,
-    python_printer=printer_of_unflatten_tensor_subclass,
     _bind_postprocess=bind_postprocess_of_unflatten_tensor_subclass,
 )

--- a/thunder/core/proxies.py
+++ b/thunder/core/proxies.py
@@ -2123,6 +2123,7 @@ _cls_to_number_proxy_map = {
 
 # TODO: move this function to jit_ext.py
 def tensorproxy(t: torch.Tensor, /, *, name: None | str, history: None | tuple = None) -> TensorProxy:
+    from torch._subclasses.fake_tensor import FakeTensor
     from thunder.core.interpreter import ProvenanceRecord, PseudoInst, wrap_const
 
     if hasattr(t, "_thunder_device"):
@@ -2157,8 +2158,8 @@ def tensorproxy(t: torch.Tensor, /, *, name: None | str, history: None | tuple =
     else:
         # NOTE Without tuple(t.shape) then the shape would be a torch.Size object
         shape = tuple(t.shape)
-    return TensorProxy(
-        name,
+    ctor_kwargs = dict(
+        name=name,
         shape=tuple(shape),
         device=device,
         dtype=dtype,
@@ -2168,6 +2169,39 @@ def tensorproxy(t: torch.Tensor, /, *, name: None | str, history: None | tuple =
         history=history,
         thunder_fsdp_padding_size=_thunder_fsdp_padding_size,
     )
+    # n.b.(crcrpar): :class:`thunder.dynamo.ThunderCompiler.__call__` takes torch.fx GraphModule
+    # where `FakeTensor` seems to be used, leading to failures observed in e.g.
+    # https://github.com/Lightning-AI/lightning-thunder/actions/runs/11689709564/job/32553053319#step:10:5747
+    # https://dev.azure.com/Lightning-AI/lightning/_build/results?buildId=219328&view=logs&jobId=5b0799f7-725e-5b16-9b83-c0a5a25d03f0&j=5b0799f7-725e-5b16-9b83-c0a5a25d03f0
+    if (
+        isinstance(t, torch.Tensor)
+        and type(t) not in (torch.Tensor, torch.nn.Parameter, FakeTensor)
+        and hasattr(t, "__tensor_flatten__")
+        and hasattr(t, "__tensor_unflatten__")
+    ):
+        baseutils.check(
+            hasattr(t, "__tensor_flatten__") and hasattr(t, "__tensor_unflatten__"),
+            lambda: f"{t=} seems to be a tensor subclass but not traceable",
+        )
+        tensor_attr_names, metadata = t.__tensor_flatten__()
+        tensors = [tensorproxy(getattr(t, name), name=None, history=history) for name in tensor_attr_names]
+        ctor_kwargs.update(
+            {
+                "tensors": tensors,
+                "non_tensors": list(metadata.values()),
+                "subclass_type": type(t),
+            }
+        )
+        p = SubclassTensorProxy(**ctor_kwargs)
+        p._tensor_attr_names = tensor_attr_names
+        p._non_tensor_attr_names = list(metadata.keys())
+        for name, tensor in zip(tensor_attr_names, tensors):
+            setattr(p, name, tensor)
+        for name, value in metadata.items():
+            setattr(p, name, value)
+        return p
+    else:
+        return TensorProxy(**ctor_kwargs)
 
 
 def futuretensorproxy(

--- a/thunder/core/proxies.py
+++ b/thunder/core/proxies.py
@@ -724,7 +724,6 @@ class NumberProxy(Proxy, NumberProxyInterface):
     # fn is the function to call if executing outside a language context
     @staticmethod
     def _elementwise_unary_helper(a, name, fn, type_promotion_kind=None):
-
         vala = pyval(a)
 
         trace: None | TraceCtx = get_tracectx()
@@ -2073,18 +2072,28 @@ class SubclassTensorProxy(TensorProxy):
         base_str = f"{self.device.device_str()} {self.dtype.shortname()}{list(self._shape)}"
 
         if self._subclass_type is not None:
-            type_str = f"{self._subclass_type.__name__} of {base_str}"
+            type_str = f"{self._subclass_type.__name__}[{base_str}]"
         else:
             type_str = base_str
 
         if self._tensors:
-            if (tensor_attr_names := getattr(self, "_tensor_attr_names", [])):
-                tensor_attr_type_str = ", ".join([
-                    f"{name}: {t.type_string()}" for name, t in zip(tensor_attr_names, self._tensors)
-                ])
+            if tensor_attr_names := getattr(self, "_tensor_attr_names", []):
+                tensor_attr_type_str = ", ".join(
+                    [f"{name}: {t.type_string()}" for name, t in zip(tensor_attr_names, self._tensors)]
+                )
             else:
                 tensor_attr_type_str = ", ".join([t.type_string() for t in self._tensors])
-            type_str = type_str + f" ({tensor_attr_type_str})"
+
+            if self._non_tensors:
+                if non_tensor_attr_names := getattr(self, "_non_tensor_attr_names", []):
+                    non_tensor_attr_type_str = ", ".join(
+                        [f"{name}: {v}" for name, v in zip(non_tensor_attr_names, self._non_tensors)]
+                    )
+                else:
+                    non_tensor_attr_type_str = ", ".join(str(v) for v in self._non_tensors)
+                type_str = type_str + f" (tensors: {tensor_attr_type_str}, constants: {non_tensor_attr_type_str})"
+            else:
+                type_str = type_str + f" ({tensor_attr_type_str})"
 
         return type_str
 

--- a/thunder/core/proxies.py
+++ b/thunder/core/proxies.py
@@ -1512,6 +1512,26 @@ class TensorProxy(Proxy, TensorProxyInterface):
     def thunder_fsdp_padding_size(self):
         return self._thunder_fsdp_padding_size
 
+    # n.b.(crcrpar): just returning contiguous for `_make_wrapper_subclasses`
+    def stride(self) -> Sequence[int]:
+        shape = self.shape
+        if len(shape) == 1:
+            return (1,)
+        elif len(shape) == 0:
+            return tuple()
+        else:
+            import numpy
+
+            _stride = reversed(numpy.cumprod([1] + list(shape[1:])).tolist())
+            return tuple(_stride)
+
+    def storage_offset(self) -> int:
+        return -1
+
+    @property
+    def layout(self) -> torch.layout:
+        return torch.strided
+
     # We need to implement `__len__` as
     # > In addition to bypassing any instance attributes in the
     # > interest of correctness, implicit special method lookup

--- a/thunder/core/proxies.py
+++ b/thunder/core/proxies.py
@@ -2014,6 +2014,19 @@ class SubclassTensorProxy(TensorProxy):
                     self._non_tensors.append(a)
             baseutils.check(self._tensors, lambda: f"`{self._name}._tensors` must not be empty")
 
+    def copy_attributes_from(self, other: SubclassTensorProxy) -> None:
+        self._subclass_type = other._subclass_type
+        self._tensors = other._tensors
+        self._non_tensors = other._non_tensors
+        if hasattr(other, "_tensor_attr_names"):
+            self._tensor_attr_names = other._tensor_attr_names
+            for n, t in zip(self._tensor_attr_names, self._tensors):
+                setattr(self, n, t)
+        if hasattr(other, "_non_tensor_attr_names"):
+            self._non_tensor_attr_names = other._non_tensor_attr_names
+            for n, t in zip(self._non_tensor_attr_names, self._non_tensors):
+                setattr(self, n, t)
+
     def __tensor_flatten__(self) -> tuple[list[TensorProxy], dict[str, Any]]:
         return self._tensor_attr_names, self.metadata
 

--- a/thunder/core/proxies.py
+++ b/thunder/core/proxies.py
@@ -1910,6 +1910,7 @@ class TensorProxy(Proxy, TensorProxyInterface):
 
 
 class SubclassTensorProxy(TensorProxy):
+    _DEFAULT_PREFIX = "tensor_subclass"
     SUBCLASS_TYPE_ATTR: ClassVar[str] = "_subclass_type"
     _tensors: list[TensorProxy]
     _non_tensors: list[Any]
@@ -1917,6 +1918,11 @@ class SubclassTensorProxy(TensorProxy):
 
     _tensor_attr_names: list[str] | None
     _non_tensor_attr_names: list[str] | None
+
+    def get_default_prefix(self) -> str:
+        if (subclass_type := getattr(self, SubclassTensorProxy.SUBCLASS_TYPE_ATTR, None)) is None:
+            return super().get_default_prefix()
+        return subclass_type.__name__.lower()
 
     def __init__(self, *args, **kwargs):
         from thunder.core.pytree import tree_flatten
@@ -2351,3 +2357,6 @@ def proxy(x: Any, *, name: str | None = None, history: None | tuple = None) -> A
         return AnyProxy(x, name=name, history=history)
 
     return x
+
+
+PREFIXES_ALLOW_NAME_DUPLICATES: set[str] = {"tensor_subclass"}

--- a/thunder/core/proxies.py
+++ b/thunder/core/proxies.py
@@ -2069,6 +2069,25 @@ class SubclassTensorProxy(TensorProxy):
             tensors = {n: getattr(self, n) for n in tensor_names}
         return f'<{type(self).__name__}(name="{self.name}", dtype={self.dtype}, shape={self._shape}, {tensors=}, {metadata=})>'
 
+    def type_string(self) -> str:
+        base_str = f"{self.device.device_str()} {self.dtype.shortname()}{list(self._shape)}"
+
+        if self._subclass_type is not None:
+            type_str = f"{self._subclass_type.__name__} of {base_str}"
+        else:
+            type_str = base_str
+
+        if self._tensors:
+            if (tensor_attr_names := getattr(self, "_tensor_attr_names", [])):
+                tensor_attr_type_str = ", ".join([
+                    f"{name}: {t.type_string()}" for name, t in zip(tensor_attr_names, self._tensors)
+                ])
+            else:
+                tensor_attr_type_str = ", ".join([t.type_string() for t in self._tensors])
+            type_str = type_str + f" ({tensor_attr_type_str})"
+
+        return type_str
+
 
 class TorchAutogradFunctionCtxProxy(Proxy, TorchAutogradFunctionCtxProxyInterface):
     _DEFAULT_PREFIX = "fc"

--- a/thunder/core/proxies.py
+++ b/thunder/core/proxies.py
@@ -1965,6 +1965,8 @@ class SubclassTensorProxy(TensorProxy):
 
             args, kwargs = tree_map(lambda a: maybe_cast(a), (args, kwargs))
 
+            # NOTE(crcrpar): This doesn't work as https://github.com/Lightning-AI/lightning-thunder/pull/1500's
+            # OpExProcessor's evaluation tries to re-add already registered `name`s to a trace.
             super().__init__(*args, **kwargs)
 
             self._tensors = kwarg_tensors

--- a/thunder/core/proxies.py
+++ b/thunder/core/proxies.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import copy
 from enum import auto, Enum
 from numbers import Number
-from typing import Any
+from typing import Any, ClassVar
 from collections.abc import Callable
 from collections.abc import Sequence
 
@@ -1229,8 +1229,8 @@ def _infer_tensor_properties(
     _thunder_fsdp_padding_size = None
 
     if like is not None:
-        baseutils.check_type(like, (TensorProxy, FutureTensorProxy))
-        _shape = tuple(like._shape)
+        baseutils.check_type(like, (TensorProxy, FutureTensorProxy, SubclassTensorProxy))
+        _shape = tuple(like.shape)
         _device = like.device
         _dtype = like.true_dtype
         _requires_grad = like.requires_grad
@@ -1888,6 +1888,166 @@ class TensorProxy(Proxy, TensorProxyInterface):
     def real(self):
         method = resolve_method("real", self)
         return method(self)
+
+
+class SubclassTensorProxy(TensorProxy):
+    SUBCLASS_TYPE_ATTR: ClassVar[str] = "_subclass_type"
+    _tensors: list[TensorProxy]
+    _non_tensors: list[Any]
+    _subclass_type: torch._C._TensorMeta
+
+    _tensor_attr_names: list[str] | None
+    _non_tensor_attr_names: list[str] | None
+
+    def __init__(self, *args, **kwargs):
+        from thunder.core.pytree import tree_flatten
+
+        kwarg_tensors = kwargs.pop("tensors", [])
+        kwarg_non_tensors = kwargs.pop("non_tensors", [])
+        subclass_type = kwargs.pop("subclass_type", None)
+
+        has_name_before_init = hasattr(self, "_name")
+        # If tensors (and non_tensors) are not empty, then it should be the path of `_make_wrapper_subclass`
+        # where `self` should already have gotten its name.
+        flat_args, spec = tree_flatten((args, kwargs))
+        tensors: list[TensorProxy] = []
+        non_tensors: list[Any] = []
+        for t in args + tuple(kwargs.values()):
+            if type(t) is SubclassTensorProxy:
+                continue
+            if type(t) is TensorProxy:
+                tensors.append(t)
+            else:
+                non_tensors.append(t)
+
+        is_dunder_init_following_make_wrapper_subclass: bool = False
+        if tensors:
+            baseutils.check(
+                has_name_before_init
+                and not kwarg_tensors
+                and not kwarg_non_tensors
+                and self._subclass_type is not None,
+                lambda: (
+                    f"{flat_args=} indicates this instance is created by"
+                    "`torch.Tensor._make_wrapper_subclass`'s lookaside but `name` is not set"
+                ),
+            )
+            is_dunder_init_following_make_wrapper_subclass = True
+
+        if not is_dunder_init_following_make_wrapper_subclass:
+            super().__init__(*args, **kwargs)
+
+            self._tensors = kwarg_tensors
+            self._non_tensors = kwarg_non_tensors
+            self._subclass_type = subclass_type
+        else:
+            # TODO(crcrpar): Think about materializing `self` so that we can
+            # call `__tensor_init__` to know each attribute names.
+            from dataclasses import replace
+            import inspect
+            from thunder.core import prims
+
+            bsym = prims.tensor_subclass_ctor.bind(
+                self._subclass_type,
+                self.name,
+                self.shape,
+                self.device,
+                self.dtype,
+                self.requires_grad,
+                self._tensors,
+                self._non_tensors,
+                output=self,
+            )
+            cls_module = inspect.getmodule(self._subclass_type)
+            bsym.sym = replace(bsym.sym, _module=cls_module)
+
+            # NOTE(crcrpar): A callable being `thunder.jit`ed can call `MySubclassTensor(...)`
+            # inside of it either directly or indirectly: indirect way is to call it through
+            # a custom `torch.autograd.Function` as in
+            # https://github.com/pytorch/ao/blob/000a490/torchao/float8/float8_tensor.py#L139-L209.
+            # If it's a direct call, `trace.bound_symbols` and `trace.scopes[-1]` are identical,
+            # but not, otherwise. As [the lookasdie of `torch.autograd.Function`](
+            # https://github.com/Lightning-AI/lightning-thunder/blob/3d42c10/thunder/core/jit_ext.py#L655)
+            # puts the temporary scope to the current trace.
+            current_trace = get_tracectx()
+            if id(current_trace.bound_symbols) == id(cur_tail_scope := current_trace.scopes[-1]):
+                current_trace.add_bound_symbol(bsym)
+            else:
+                cur_tail_scope.append(bsym)
+
+            if not self._tensors and not self._non_tensors:
+                for a in tensors:
+                    self._tensors.append(a)
+                for a in non_tensors:
+                    self._non_tensors.append(a)
+            baseutils.check(self._tensors, lambda: f"`{self._name}._tensors` must not be empty")
+
+    def __tensor_flatten__(self) -> tuple[list[TensorProxy], dict[str, Any]]:
+        return self._tensor_attr_names, self.metadata
+
+    @property
+    def metadata(self) -> dict[str, Any]:
+        return dict(zip(self._non_tensor_attr_names, self._non_tensors))
+
+    def replace(self, **changes):
+        r"""Return a copy of the SubclassTensorProxy object with new values for the specified fields as given to the constructor as arguments.
+        Valid keyword arguments are ``name``, ``history``, ``shape``, ``dtype``, ``device``, ``requires_grad``, ``distparallel_type``,  ``thunder_fsdp_padding_size``.
+        ``like`` is also a valid keyword and will take metadata from the tensor proxy argument
+        in preference to the old values but overridable by keyword arguments.
+        Note that the copy will use the current (environment) tracectx."""
+
+        like = changes.get("like")
+        (
+            shape,
+            device,
+            dtype,
+            true_dtype,
+            numel,
+            ndim,
+            requires_grad,
+            grad,
+            distparallel_type,
+            thunder_fsdp_padding_size,
+        ) = _infer_tensor_properties(
+            like,
+            changes.get("shape", self._shape if like is None else None),
+            changes.get("device", self._device if like is None else None),
+            changes.get("dtype", self._dtype if like is None else None),
+            changes.get("requires_grad", self._requires_grad if like is None else None),
+            changes.get("grad", self._grad if like is None else None),
+            changes.get("distparallel_type", self._distparallel_type if like is None else None),
+            changes.get("thunder_fsdp_padding_size", self._thunder_fsdp_padding_size if like is None else None),
+        )
+        name = changes.get("name", self.name)
+        history = changes.get("history", self.history)
+        tags = changes.get("tags", self.tags)
+        p = SubclassTensorProxy(
+            name=name,
+            tags=tags,
+            shape=shape,
+            device=device,
+            dtype=dtype,
+            requires_grad=requires_grad,
+            distparallel_type=distparallel_type,
+            thunder_fsdp_padding_size=thunder_fsdp_padding_size,
+            history=history,
+            tensors=self._tensors,
+            non_tensors=self._non_tensors,
+            subclass_type=self._subclass_type,
+        )
+        if hasattr(self, "_tensor_attr_names") and hasattr(self, "_non_tensor_attr_names"):
+            p._tensor_attr_names = self._tensor_attr_names
+            p._non_tensor_attr_names = self._non_tensor_attr_names
+            for name, value in zip(p._tensor_attr_names + p._non_tensor_attr_names, p._tensors + p._non_tensors):
+                setattr(p, name, value)
+        return p
+
+    def __repr__(self):
+        tensors, metadata = {}, {}
+        if hasattr(self, "_tensor_attr_names"):
+            tensor_names, metadata = self.__tensor_flatten__()
+            tensors = {n: getattr(self, n) for n in tensor_names}
+        return f'<{type(self).__name__}(name="{self.name}", dtype={self.dtype}, shape={self._shape}, {tensors=}, {metadata=})>'
 
 
 class TorchAutogradFunctionCtxProxy(Proxy, TorchAutogradFunctionCtxProxyInterface):

--- a/thunder/core/proxies.py
+++ b/thunder/core/proxies.py
@@ -1954,6 +1954,17 @@ class SubclassTensorProxy(TensorProxy):
             is_dunder_init_following_make_wrapper_subclass = True
 
         if not is_dunder_init_following_make_wrapper_subclass:
+            from thunder.core.pytree import tree_map
+
+            def maybe_cast(a):
+                if isinstance(a, torch.device):
+                    return devices.to_device(a)
+                if isinstance(a, torch.dtype):
+                    return dtypes.to_dtype(a)
+                return a
+
+            args, kwargs = tree_map(lambda a: maybe_cast(a), (args, kwargs))
+
             super().__init__(*args, **kwargs)
 
             self._tensors = kwarg_tensors

--- a/thunder/core/pytree.py
+++ b/thunder/core/pytree.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from functools import partial
 from types import FunctionType
 import dataclasses
@@ -64,6 +65,7 @@ def tree_flatten(args, namespace=OPTREE_NAMESPACE):
         and not is_likely_from_collections_namedtuple(args)
         and not dataclasses.is_dataclass(args)
         and not type(args).__module__.startswith("torch.return_types")
+        and not issubclass(type(args), Enum)
     ):
         raise TypeError(f"tree_flatten of type {type(args)} is not supported.")
     return optree.tree_flatten(args, none_is_leaf=True, namespace=namespace)

--- a/thunder/core/trace.py
+++ b/thunder/core/trace.py
@@ -178,9 +178,11 @@ class TraceCtx:
     # Methods related to name construction
     #
 
-    def add_name(self, name: str) -> None:
+    def add_name(self, name: str, *, prefix: str | None = None) -> None:
+        from thunder.core.proxies import PREFIXES_ALLOW_NAME_DUPLICATES
+
         baseutils.check(
-            name not in self.names,
+            name not in self.names or (prefix is not None and prefix in PREFIXES_ALLOW_NAME_DUPLICATES),
             lambda: f"Trying to add the name {name} to a trace, but that name is already used",
         )
         self.names.add(name)
@@ -221,7 +223,7 @@ class TraceCtx:
     #   just records the given name
     def make_name(self, name: str | None = None, *, prefix: str | None = None) -> str:
         if name is not None:
-            self.add_name(name)
+            self.add_name(name, prefix=prefix)
             return name
 
         return self._make_name(prefix=prefix)

--- a/thunder/core/trace_interpreter.py
+++ b/thunder/core/trace_interpreter.py
@@ -131,8 +131,11 @@ def interpret_trace_to_trace(trace, *args, symbol_mapper=None, with_env=False, *
                     old = old.replace(shape=new._shape)
 
             if isinstance(new, VJPDual):
-                swap_map[variableify(new.primal)] = old
-                new.primal = old
+                # note(crcrpar): Without this sanity check, `subclass.__tensor_flatten__`,
+                # seems to cause `new.primal` == `old`, leading to a cycle in swapping.
+                if (key := variableify(new.primal)) != variableify(old):
+                    swap_map[variableify(new.primal)] = old
+                    new.primal = old
             else:
                 assert isinstance(new, ProxyInterface), (old, new)
                 swap_map[variableify(new)] = old

--- a/thunder/core/transform_common.py
+++ b/thunder/core/transform_common.py
@@ -168,7 +168,7 @@ def dce(trace: Trace, needed_proxies: None | set[Variable] = None) -> Trace:
         #   may mark some of the operation's outputs as unused
         some_unused = False
         for out in bsym.flat_proxy_outs:
-            if variableify(out) in needed_proxies and producer_map[out] == bsym:
+            if variableify(out) in needed_proxies and producer_map.get(out, None) == bsym:
                 needed = True
             else:
                 some_unused = True

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -1715,7 +1715,7 @@ def trunc(a: TensorProxy | Number, *, fd: FusionDefinition, lc_to_nv_map: dict) 
 register_supported(PrimIDs.TRUNC, trunc, _elementwise_unary_check)
 
 
-def clone(a: TensorProxy, *, fd: FusionDefinition, lc_to_nv_map: dict) -> Any:
+def clone(a: TensorProxy, memory_format=torch.preserve_format, *, fd: FusionDefinition, lc_to_nv_map: dict) -> Any:
     nva = getnv(a, fd, lc_to_nv_map)
 
     return fd.ops.set(nva)

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -1721,7 +1721,13 @@ def clone(a: TensorProxy, *, fd: FusionDefinition, lc_to_nv_map: dict) -> Any:
     return fd.ops.set(nva)
 
 
-register_supported(PrimIDs.CLONE, clone, _elementwise_unary_check)
+def _clone_check(a: TensorProxy, *, memory_format: torch.memory_format = torch.preserve_format) -> bool:
+    if memory_format not in (torch.preserve_format, torch.contiguous_format):
+        return False
+    return _elementwise_unary_check(a)
+
+
+register_supported(PrimIDs.CLONE, clone, _clone_check)
 
 #
 # Elementwise binary operations

--- a/thunder/executors/torch_autograd.py
+++ b/thunder/executors/torch_autograd.py
@@ -357,7 +357,7 @@ def split_forward_backward(computation_trc: TraceCtx, compile_data, compile_stat
     if getattr(compile_data.fn, "use_fsdp", False):
         bw_trace = _fsdp_comm_bucketing.apply_bucketing_to_backward_trace(bw_trace)
 
-    bw_trace = unroll_tensor_subclasses(bw_trace)
+    bw_trace = unroll_tensor_subclasses(bw_trace, is_bwd_trace=True)
     bw_traces.append(bw_trace)
 
     # Now we can run the optimization passes on the backward trace

--- a/thunder/executors/torch_autograd.py
+++ b/thunder/executors/torch_autograd.py
@@ -250,7 +250,9 @@ def split_forward_backward(computation_trc: TraceCtx, compile_data, compile_stat
     fw_traces = [fw_trace]
     bw_traces = [bw_trace]
 
-    fw_trace = unroll_tensor_subclasses(fw_trace)
+    fw_trace, saved_proxy_for_bwd_to_strides = unroll_tensor_subclasses(
+        fw_trace, is_bwd_trace=False, proxy_to_strides=None
+    )
     fw_traces.append(fw_trace)
 
     from thunder.distributed import FSDPType
@@ -357,7 +359,7 @@ def split_forward_backward(computation_trc: TraceCtx, compile_data, compile_stat
     if getattr(compile_data.fn, "use_fsdp", False):
         bw_trace = _fsdp_comm_bucketing.apply_bucketing_to_backward_trace(bw_trace)
 
-    bw_trace = unroll_tensor_subclasses(bw_trace, is_bwd_trace=True)
+    bw_trace, _ = unroll_tensor_subclasses(bw_trace, is_bwd_trace=True, proxy_to_strides=saved_proxy_for_bwd_to_strides)
     bw_traces.append(bw_trace)
 
     # Now we can run the optimization passes on the backward trace

--- a/thunder/executors/torch_compile.py
+++ b/thunder/executors/torch_compile.py
@@ -56,6 +56,12 @@ def to_torch_translator(bsym: BoundSymbol) -> Callable:
         if torch_op is None:
             raise RuntimeError(f"op not found for {bsym.sym.name}")
 
+        # NOTE(crcrpar): Currently `ltorch.t` is mapped to `torchex.transpose`
+        # thus `args` needs to be updated to have dim0 and dim1
+        if bsym.sym.id == "torch.t":
+            utils.check(len(args) == 1, lambda: f"{bsym.sym.id} takes only one argument but {args=}")
+            args = args + (0, 1)
+
         return torch_op(*args, **kwargs)
 
     return _to_torch

--- a/thunder/executors/torchex.py
+++ b/thunder/executors/torchex.py
@@ -2317,7 +2317,6 @@ def printer_of_tensor_subclass_ctor(
     from itertools import chain
     from thunder.core import baseutils
     from thunder.core import codeutils
-    from thunder.core.prims import filter_types_for_tensor_wrapper_subclass
 
     baseutils.check(not kwarg_printables, lambda: f"No kwargs are supported but {kwarg_printables = }")
 
@@ -2365,12 +2364,6 @@ def printer_of_tensor_subclass_ctor(
         header_lines = (f"# {line}" for line in header_lines)
         return chain(header_lines, [s])
 
-    filtered_types = (cls,)
-    if non_tensors:
-        types = get_nested_types([t.obj if isinstance(t, codeutils.ContextObject) else t for t in non_tensors])
-        filtered_types += filter_types(types)
-    new_imports = {t.__name__: t for t in filtered_types}
-    bsym._import_ctx.update(new_imports)
     return s
 
 

--- a/thunder/executors/torchex.py
+++ b/thunder/executors/torchex.py
@@ -17,8 +17,10 @@ from thunder.core.dtypes import to_torch_dtype, to_dtype
 import thunder.core.devices as devices
 from thunder.core.devices import to_torch_device, to_device
 import thunder.core.prims as prims
-from thunder.core.proxies import NumberProxy, TensorProxy, FutureTensorProxy, pytype
-from thunder.core.symbol import Symbol
+from thunder.core.proxies import NumberProxy, TensorProxy, FutureTensorProxy, variableify, pytype, Proxy
+from thunder.core.pytree import tree_flatten, tree_unflatten
+from thunder.core.symbol import Symbol, BoundSymbol
+from thunder.core.trace import TraceCtx, set_tracectx, reset_tracectx, from_trace
 from thunder.distributed.prims import DistributedReduceOps
 import thunder.distributed.prims as dist_prims
 import thunder.core.utils as utils
@@ -33,7 +35,10 @@ from thunder.core.transforms import (
 )
 
 if TYPE_CHECKING:
+    from typing import Any
+    from collections.abc import Iterable
     from thunder.common import CompileData
+    from thunder.core.codeutils import ContextObject, Printable
 
 ex = OperatorExecutor("torch", version=torch.__version__)
 register_executor(ex)
@@ -2303,11 +2308,77 @@ def _bind_postprocess_of_tensor_subclass_ctor(bsym: BoundSymbol) -> None:
     bsym._import_ctx.update(new_imports)
 
 
+def printer_of_tensor_subclass_ctor(
+    bsym: BoundSymbol,
+    out_printables: Any,
+    arg_printables: Sequence[Printable],
+    kwarg_printables: dict[str, Printable],
+) -> str | Iterable[str]:
+    from itertools import chain
+    from thunder.core import baseutils
+    from thunder.core import codeutils
+    from thunder.core.prims import filter_types
+
+    baseutils.check(not kwarg_printables, lambda: f"No kwargs are supported but {kwarg_printables = }")
+
+    # NOTE(crcrpar): It's not a context but at the moment Tensor subclass is treated as `ContextObject`.
+    wrapped_cls: ContextObject | torch._C._TensorMeta = arg_printables[0]
+    if isinstance(wrapped_cls, torch._C._TensorMeta):
+        cls = wrapped_cls
+    else:
+        cls: torch._C._TensorMeta = wrapped_cls.obj
+    tensors, non_tensors = arg_printables[-2:]
+    new_non_tensors = []
+    for a in non_tensors:
+        if isinstance(a, dtypes.dtype):
+            new_non_tensors.append(dtypes.to_torch_dtype(a))
+        elif isinstance(a, devices.Device):
+            new_non_tensors.append(devices.to_torch_device(a))
+        else:
+            new_non_tensors.append(a)
+
+    arg_str = ", ".join(codeutils.prettyprint(x) for x in [*tensors, *new_non_tensors])
+    kwarg_str = ""
+
+    result_str: str
+    if bsym.output is None or (baseutils.is_collection(bsym.output) and len(bsym.output) == 0):
+        result_str = ""
+    else:
+        result_str = f"{codeutils.prettyprint(out_printables, literals_as_underscores=True)} = "
+
+    # Creates a comment describing the output
+    comment_str: str
+    if isinstance(bsym.output, Proxy):
+        comment_str = f"  # {codeutils.prettyprint(out_printables, with_type=True)}"
+    else:
+        comment_str = ""
+
+    cls_with_module = f"{cls.__name__}"
+    s = f"{result_str}{cls_with_module}({arg_str}{', ' if (len(arg_str) > 0 and len(kwarg_str) > 0) else ''}{kwarg_str}){comment_str}"
+
+    if bsym.header:
+        header_lines = (
+            bsym.header
+            if isinstance(bsym.header, Sequence) and not isinstance(bsym.header, str)
+            else bsym.header.splitlines()
+        )
+        header_lines = (f"# {line}" for line in header_lines)
+        return chain(header_lines, [s])
+
+    filtered_types = (cls,)
+    if non_tensors:
+        types = get_nested_types([t.obj if isinstance(t, codeutils.ContextObject) else t for t in non_tensors])
+        filtered_types += filter_types(types)
+    new_imports = {t.__name__: t for t in filtered_types}
+    bsym._import_ctx.update(new_imports)
+    return s
+
+
 tensor_subclass_ctor = ex.register_operator(
     "tensor_subclass_ctor",
     meta=prims.tensor_subclass_ctor,
     fn=_tensor_subclass_ctor,
     bind_postprocess=_bind_postprocess_of_tensor_subclass_ctor,
-    python_printer=prims.printer_of_tensor_subclass_ctor,
+    python_printer=printer_of_tensor_subclass_ctor,
 )
 _register_implementation(prims.tensor_subclass_ctor, tensor_subclass_ctor, checker=_always_executable)

--- a/thunder/executors/torchex.py
+++ b/thunder/executors/torchex.py
@@ -2317,7 +2317,7 @@ def printer_of_tensor_subclass_ctor(
     from itertools import chain
     from thunder.core import baseutils
     from thunder.core import codeutils
-    from thunder.core.prims import filter_types
+    from thunder.core.prims import filter_types_for_tensor_wrapper_subclass
 
     baseutils.check(not kwarg_printables, lambda: f"No kwargs are supported but {kwarg_printables = }")
 

--- a/thunder/executors/torchex.py
+++ b/thunder/executors/torchex.py
@@ -1419,12 +1419,43 @@ _register_implementation(prims.copy_with_setitem, copy_with_setitem_impl, checke
 #
 
 matmul = _register_torch_operation("matmul")
+_scaled_mm = _register_torch_operation("_scaled_mm")
 outer = _register_torch_operation("outer")
 
 _register_implementation(prims.matmul, matmul, checker=_always_executable)
 
 _register_implementation(ltorch.matmul, matmul, checker=_always_executable)
 _register_implementation(ltorch.outer, outer, checker=_always_executable)
+
+
+def _scaled_mm_transform(
+    a: TensorLike,
+    b: TensorLike,
+    scale_a: TensorLike,
+    scale_b: TensorLike,
+    bias: TensorLike | None = None,
+    scale_result: TensorLike | None = None,
+    out_dtype: dtypeLike | None = None,
+    use_fast_accum: bool = False,
+):
+
+    def is_column_major(mat: TensorLike) -> bool:
+        return mat.stride()[0] == 1 and mat.stride()[0] > 1
+
+    result_dtype: torch.dtype = to_torch_dtype(a.dtype if out_dtype is None else out_dtype)
+    if not is_column_major(b):
+        b = b.t().contiguous().t()
+
+    return _scaled_mm(a, b, scale_a, scale_b, bias, scale_result, result_dtype, use_fast_accum)
+
+
+_register_implementation(
+    ltorch._scaled_mm, _scaled_mm, checker=_always_executable, execution_transform=_scaled_mm_transform
+)
+_register_implementation(
+    ltorch.core_aten_scaled_mm, _scaled_mm, checker=_always_executable, execution_transform=_scaled_mm_transform
+)
+
 
 #
 # Normalization operations

--- a/thunder/executors/torchex.py
+++ b/thunder/executors/torchex.py
@@ -1439,10 +1439,15 @@ def _scaled_mm_transform(
     use_fast_accum: bool = False,
 ):
 
+    def is_row_major(mat: TensorLike) -> bool:
+        return mat.stride()[1] == 1 and mat.stride()[0] > 1
+
     def is_column_major(mat: TensorLike) -> bool:
-        return mat.stride()[0] == 1 and mat.stride()[0] > 1
+        return mat.stride()[0] == 1 and mat.stride()[1] > 1
 
     result_dtype: torch.dtype = to_torch_dtype(a.dtype if out_dtype is None else out_dtype)
+    if not is_row_major(a):
+        a = a.contiguous()
     if not is_column_major(b):
         b = b.t().contiguous().t()
 

--- a/thunder/executors/torchex.py
+++ b/thunder/executors/torchex.py
@@ -2297,13 +2297,13 @@ def _tensor_subclass_ctor(cls, name, shape, device, dtype, requires_grad, tensor
 
 
 def _bind_postprocess_of_tensor_subclass_ctor(bsym: BoundSymbol) -> None:
-    from thunder.core.prims import get_nested_types, filter_types
+    from thunder.core.prims import get_nested_types, filter_types_for_tensor_wrapper_subclass
 
     cls, _name, _shape, _device, _dtype, _requires_grad, _tensors, non_tensors = bsym.args
     filtered_types = (cls,)
     if non_tensors:
         types = get_nested_types(non_tensors)
-        filtered_types += filter_types(types)
+        filtered_types += filter_types_for_tensor_wrapper_subclass(types)
     new_imports = {t.__name__: t for t in filtered_types}
     bsym._import_ctx.update(new_imports)
 
@@ -2382,3 +2382,47 @@ tensor_subclass_ctor = ex.register_operator(
     python_printer=printer_of_tensor_subclass_ctor,
 )
 _register_implementation(prims.tensor_subclass_ctor, tensor_subclass_ctor, checker=_always_executable)
+
+
+def flatten_tensor_subclass_impl(t):
+    tensor_attr_names, metadata = t.__tensor_flatten__()
+    tensors = tuple(getattr(t, name) for name in tensor_attr_names)
+    return tensors
+
+
+flatten_tensor_subclass = ex.register_operator(
+    "flatten_tensor_subclass",
+    meta=prims.flatten_tensor_subclass.meta,
+    fn=flatten_tensor_subclass_impl,
+)
+_register_implementation(
+    prims.flatten_tensor_subclass,
+    flatten_tensor_subclass,
+    checker=_always_executable,
+)
+
+
+def unflatten_tensor_subclass_impl(
+    tensor_subclass_type: torch._C._TensorMeta,
+    inner_tensors: dict[str, TensorLike],
+    metadata: dict,
+):
+    for key in metadata:
+        v = metadata[key]
+        if isinstance(v, dtypes.dtype):
+            metadata[key] = to_torch_dtype(v)
+        elif isinstance(v, devices.Device):
+            metadata[key] = to_torch_device(v)
+    return tensor_subclass_type.__tensor_unflatten__(inner_tensors, metadata, -1, -1)
+
+
+unflatten_tensor_subclass = ex.register_operator(
+    "unflatten_tensor_subclass",
+    meta=prims.unflatten_tensor_subclass.meta,
+    fn=unflatten_tensor_subclass_impl,
+)
+_register_implementation(
+    prims.unflatten_tensor_subclass,
+    unflatten_tensor_subclass,
+    checker=_always_executable,
+)

--- a/thunder/executors/torchex.py
+++ b/thunder/executors/torchex.py
@@ -2277,3 +2277,37 @@ _register_implementation(prims.shape, shape, checker=_always_executable)
 
 shallow_copy = ex.register_operator("shallow_copy", meta=prims.shallow_copy, fn=lambda x: x)
 _register_implementation(prims.shallow_copy, shallow_copy, checker=_always_executable)
+
+
+def _tensor_subclass_ctor(cls, name, shape, device, dtype, requires_grad, tensors, non_tensors):
+    new_non_tensors = []
+    for a in non_tensors:
+        if isinstance(a, dtypes.dtype):
+            new_non_tensors.append(to_torch_dtype(a))
+        elif isinstance(a, devices.Device):
+            new_non_tensors.append(to_torch_device(a))
+        else:
+            new_non_tensors.append(a)
+    return cls(*tensors, *new_non_tensors)
+
+
+def _bind_postprocess_of_tensor_subclass_ctor(bsym: BoundSymbol) -> None:
+    from thunder.core.prims import get_nested_types, filter_types
+
+    cls, _name, _shape, _device, _dtype, _requires_grad, _tensors, non_tensors = bsym.args
+    filtered_types = (cls,)
+    if non_tensors:
+        types = get_nested_types(non_tensors)
+        filtered_types += filter_types(types)
+    new_imports = {t.__name__: t for t in filtered_types}
+    bsym._import_ctx.update(new_imports)
+
+
+tensor_subclass_ctor = ex.register_operator(
+    "tensor_subclass_ctor",
+    meta=prims.tensor_subclass_ctor,
+    fn=_tensor_subclass_ctor,
+    bind_postprocess=_bind_postprocess_of_tensor_subclass_ctor,
+    python_printer=prims.printer_of_tensor_subclass_ctor,
+)
+_register_implementation(prims.tensor_subclass_ctor, tensor_subclass_ctor, checker=_always_executable)

--- a/thunder/executors/torchex.py
+++ b/thunder/executors/torchex.py
@@ -1428,7 +1428,7 @@ _register_implementation(ltorch.matmul, matmul, checker=_always_executable)
 _register_implementation(ltorch.outer, outer, checker=_always_executable)
 
 
-def _scaled_mm_transform(
+def _scaled_mm_impl(
     a: TensorLike,
     b: TensorLike,
     scale_a: TensorLike,
@@ -1445,21 +1445,16 @@ def _scaled_mm_transform(
     def is_column_major(mat: TensorLike) -> bool:
         return mat.stride()[0] == 1 and mat.stride()[1] > 1
 
+    utils.check(is_row_major(a), lambda: f"`a` expected to be row-major but its stride is {a.stride()=}")
+    utils.check(is_column_major(b), lambda: f"`b` expected to be column-major but its stride is {b.stride()=}")
     result_dtype: torch.dtype = to_torch_dtype(a.dtype if out_dtype is None else out_dtype)
-    if not is_row_major(a):
-        a = a.contiguous()
-    if not is_column_major(b):
-        b = b.t().contiguous().t()
 
-    return _scaled_mm(a, b, scale_a, scale_b, bias, scale_result, result_dtype, use_fast_accum)
+    return torch._scaled_mm(a, b, scale_a, scale_b, bias, scale_result, result_dtype, use_fast_accum)
 
 
-_register_implementation(
-    ltorch._scaled_mm, _scaled_mm, checker=_always_executable, execution_transform=_scaled_mm_transform
-)
-_register_implementation(
-    ltorch.core_aten_scaled_mm, _scaled_mm, checker=_always_executable, execution_transform=_scaled_mm_transform
-)
+_scaled_mm_impl = ex.register_operator("_scaled_mm_impl", like=ltorch._scaled_mm, fn=_scaled_mm_impl)
+_register_implementation(ltorch._scaled_mm, _scaled_mm_impl, checker=_always_executable)
+_register_implementation(ltorch.core_aten_scaled_mm, _scaled_mm_impl, checker=_always_executable)
 
 
 #

--- a/thunder/executors/torchex.py
+++ b/thunder/executors/torchex.py
@@ -456,7 +456,7 @@ def _empty_prims_transform(
 
 
 def _clone_prims_transform(a: TensorLike, **kwargs) -> TensorLike:
-    return clone(a)
+    return clone(a, memory_format=kwargs.get("memory_format", torch.preserve_format))
 
 
 def _tensor_from_sequence_prims_transform(

--- a/thunder/tests/test_tensor_subclass.py
+++ b/thunder/tests/test_tensor_subclass.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+import pytest
+import torch
+from torch.utils import _pytree as pytree
+
+import thunder
+from thunder.tests.framework import instantiate
+from thunder.tests.make_tensor import make_tensor
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+@torch._dynamo.allow_in_graph
+class EncapsulateXandScale(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x: torch.Tensor, scale: torch.Tensor):
+        return ScaleTensorSubclass(x, scale)
+
+    @staticmethod
+    def backward(ctx, grad):
+        return grad, None
+
+
+def encapsulate_x_and_scale(x, scale) -> ScaleTensorSubclass:
+    return EncapsulateXandScale.apply(x, scale)
+
+
+@torch._dynamo.allow_in_graph
+class ToScaleTensorSubclass(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x: torch.Tensor):
+        return ScaleTensorSubclass.from_tensor(x)
+
+    @staticmethod
+    def backward(ctx, grad):
+        return grad
+
+
+def to_scale_tensor_subclass(x: torch.Tensor) -> ScaleTensorSubclass:
+    return ToScaleTensorSubclass.apply(x)
+
+
+class ScaleTensorSubclass(torch.Tensor):
+    _x: torch.Tensor
+    _scale: torch.Tensor
+    __slots__ = ["_x", "_scale"]
+
+    def __new__(cls, x: torch.Tensor, scale: torch.Tensor):
+        assert scale.numel() == 1, f"Invalid `scale`: {scale}"
+        dtype = x.dtype
+        device = x.device
+        self = torch.Tensor._make_wrapper_subclass(
+            cls,
+            x.size(),
+            dtype=dtype,
+            device=device,
+            # strides=x.stride(),
+            # storage_offset=x.storage_offset(),
+            # layout=x.layout,
+            requires_grad=x.requires_grad,
+        )
+        self._x = x
+        self._scale = scale
+
+        return self
+
+    # ref: https://github.com/albanD/subclass_zoo/blob/ec47458/base_tensor.py#L22
+    __torch_function__ = torch._C._disabled_torch_function_impl
+
+    def __repr__(self):
+        return f"ScaleTensorSubclass(dtype={self._x.dtype}, device={self._x.device}, x={self._x}, scale={self._scale})"
+
+    def __tensor_flatten__(self) -> tuple[list[str], dict[str, Any]]:
+        return ["_x", "_scale"], {}
+
+    @staticmethod
+    def __tensor_unflatten__(
+        inner_tensors: dict[str, torch.Tensor],
+        metadata: dict[str, Any],
+        outer_size,
+        outer_stride,
+    ) -> ScaleTensorSubclass:
+        return ScaleTensorSubclass(inner_tensors["_x"], inner_tensors["_scale"])
+
+    @staticmethod
+    def from_tensor(x: torch.Tensor) -> ScaleTensorSubclass:
+        scale = x.abs().max()
+        return ScaleTensorSubclass(x, scale)
+
+    @classmethod
+    def __torch_dispatch__(cls, aten_ir_op: torch._ops.OpOverload, types, args=(), kwargs=None):
+
+        def allowed_subclass(typ):
+            return (
+                issubclass(cls, typ)
+                or issubclass(torch._subclasses.FakeTensor, typ)
+                or issubclass(torch._subclasses.functional_tensor.FunctionalTensor, typ)
+            )
+
+        def maybe_unwrap_and_scale(t: ScaleTensorSubclass | Any):
+            if isinstance(t, ScaleTensorSubclass):
+                if t.is_floating_point():
+                    return t._x * t._scale
+                else:
+                    return t._x
+            return t
+
+        if not all(allowed_subclass(t) for t in types):
+            return NotImplementedError(f"Unsupported types are included: {types}")
+
+        scales = tuple(t._scale for t in pytree.tree_flatten((args, kwargs))[0] if isinstance(t, ScaleTensorSubclass))
+        unwrapped_args, unwrapped_kwargs = pytree.tree_map(maybe_unwrap_and_scale, (args, kwargs))
+        out = aten_ir_op(*unwrapped_args, **unwrapped_kwargs)
+        return out
+
+
+@instantiate(
+    dtypes=(thunder.core.dtypes.float32,),
+)
+def test_func_of_subclass_ctor_wrapper(executor, device, _):
+
+    def f(x: torch.Tensor, scale: torch.Tensor) -> ScaleTensorSubclass:
+        y = ScaleTensorSubclass(x, scale)
+        return y
+
+    jitted = executor.make_callable(f)
+
+    dtype = torch.float32
+    shape = (2, 2)
+    x = make_tensor(shape, device=device, dtype=dtype)
+    scale = make_tensor((), device=device, dtype=dtype)
+
+    expected = f(x, scale)
+    actual = jitted(x, scale)
+    torch.testing.assert_close((expected._x, expected._scale), (actual._x, actual._scale))
+
+    def f(x: torch.Tensor, scale: torch.Tensor):
+        y = ScaleTensorSubclass(x, scale)
+        z = ScaleTensorSubclass(y._x, y._scale)
+        return z
+
+    jitted = executor.make_callable(f)
+
+    expected = f(x, scale)
+    actual = jitted(x, scale)
+    torch.testing.assert_close((expected._x, expected._scale), (actual._x, actual._scale))
+
+
+@instantiate(
+    dtypes=(thunder.core.dtypes.float32,),
+)
+def test_func_calling_converter(executor, device, _):
+
+    def f(x: torch.Tensor, scale: torch.Tensor) -> ScaleTensorSubclass:
+        y = encapsulate_x_and_scale(x, scale)
+        return y
+
+    jitted = executor.make_callable(f)
+
+    dtype = torch.float32
+    shape = (2, 2)
+
+    x = make_tensor(shape, device=device, dtype=dtype)
+    scale = make_tensor((), device=device, dtype=dtype)
+
+    expected = f(x, scale)
+    actual = jitted(x, scale)
+    torch.testing.assert_close((expected._x, expected._scale), (actual._x, actual._scale))
+
+    def g(x: torch.Tensor) -> ScaleTensorSubclass:
+        y = to_scale_tensor_subclass(x)
+        return y
+
+    jitted = thunder.jit(g)
+    x = make_tensor(shape, device=device, dtype=dtype)
+
+    expected = g(x)
+    actual = jitted(x)
+    torch.testing.assert_close((expected._x, expected._scale), (actual._x, actual._scale))

--- a/thunder/tests/test_tensor_subclass.py
+++ b/thunder/tests/test_tensor_subclass.py
@@ -159,8 +159,6 @@ def test_func_of_subclass_ctor_wrapper(executor, device, _):
     actual = jitted(x, scale)
     torch.testing.assert_close((expected._x, expected._scale), (actual._x, actual._scale))
 
-    print(thunder.last_traces(jitted)[0])
-
 
 @instantiate(
     dtypes=(thunder.core.dtypes.float32,),
@@ -304,6 +302,10 @@ def test_torchao_float8_linear(executor, device, dtype, bias):
     ):
         pytest.xfail("numerical error")
     torch.testing.assert_close(actual, expected)
+
+    with torch.no_grad():
+        grad = torch.ones_like(actual)
+    actual.backward(grad)
 
     # TODO(crcrpar): Think of how to push tensor subclasses to `thunder.jit`.
     # Currently no subgraphs go to thunder.jit.

--- a/thunder/tests/test_tensor_subclass.py
+++ b/thunder/tests/test_tensor_subclass.py
@@ -159,6 +159,8 @@ def test_func_of_subclass_ctor_wrapper(executor, device, _):
     actual = jitted(x, scale)
     torch.testing.assert_close((expected._x, expected._scale), (actual._x, actual._scale))
 
+    print(thunder.last_traces(jitted)[0])
+
 
 @instantiate(
     dtypes=(thunder.core.dtypes.float32,),

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -3216,18 +3216,15 @@ def amin(a, /, dim=None, keepdim: bool = False):
 
 # NOTE: Using name `torch_max` to avoid conflict with Python's `max`
 @overload
-def torch_max(a: TensorLike, /) -> TensorLike:
-    ...
+def torch_max(a: TensorLike, /) -> TensorLike: ...
 
 
 @overload
-def torch_max(a: TensorLike, /, dim: NumberLike, keepdim: bool = False) -> tuple[TensorLike, TensorLike]:
-    ...
+def torch_max(a: TensorLike, /, dim: NumberLike, keepdim: bool = False) -> tuple[TensorLike, TensorLike]: ...
 
 
 @overload
-def torch_max(a: TensorLike, b: TensorLike, /) -> TensorLike:
-    ...
+def torch_max(a: TensorLike, b: TensorLike, /) -> TensorLike: ...
 
 
 @torchsymbol(torch.max, is_method=True, method_name="max", id="torch.max")

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -3284,18 +3284,18 @@ def clone(a: TensorProxy, *, memory_format=torch.preserve_format) -> TensorProxy
     # If you're hitting this you could try commenting this check out; if your
     # model does not actually rely on specified memory formats then it should
     # be fine.
-    if memory_format is not torch.preserve_format:
+    if memory_format not in (torch.preserve_format, torch.contiguous_format):
         raise NotImplementedError("only preserve_format is currently supported")
-    return prims.clone(a)
+    return prims.clone(a, memory_format=memory_format)
 
 
 @torchsymbol(torch.ops.aten.clone, torch.ops.aten.clone.default, id="torch.ops.aten.clone")
 def core_aten_clone(a: TensorProxy, *, memory_format: None | torch.memory_format = None) -> TensorProxy:
     if memory_format is None:
         memory_format = torch.preserve_format
-    if memory_format is not torch.preserve_format:
+    if memory_format not in (torch.preserve_format, torch.contiguous_format):
         raise NotImplementedError("only preserve_format is currently supported")
-    return prims.clone(a)
+    return prims.clone(a, memory_format=memory_format)
 
 
 # Because we do not use @torchsymbol, we need to manually register the

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -1549,6 +1549,11 @@ def abs(a: NumberLike | TensorLike, /) -> Number | TensorLike:
     return clang.abs(a)
 
 
+@torchsymbol(torch.ops.aten.abs, torch.ops.aten.abs.default, id="torch.ops.aten.abs")
+def core_aten_abs(a: TensorLike) -> TensorLike:
+    return clang.abs(a)
+
+
 @torchsymbol(torch.abs_, is_method=True, tags=(prims.OpTags.IN_PLACE,))
 def abs_(a: NumberLike | TensorLike, /) -> Number | TensorLike:
     return _copy_(a, abs(a))

--- a/thunder/transforms/__init__.py
+++ b/thunder/transforms/__init__.py
@@ -3,6 +3,7 @@ from .materialization import MaterializationTransform
 from .qlora import LORATransform
 from .prune_prologue_checks import PrunePrologueChecks
 from .extraction_only_prologue_transform import ExtractionOnlyPrologueTransform
+from .tensor_wrapper_subclass import unroll_tensor_subclasses
 
 
 __all__ = [
@@ -11,4 +12,5 @@ __all__ = [
     "MaterializationTransform",
     "PrunePrologueChecks",
     "ExtractionOnlyPrologueTransform",
+    "unroll_tensor_subclasses",
 ]

--- a/thunder/transforms/tensor_wrapper_subclass.py
+++ b/thunder/transforms/tensor_wrapper_subclass.py
@@ -1,0 +1,739 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from dataclasses import field
+from numbers import Number
+from typing import TYPE_CHECKING, NamedTuple
+import time
+import warnings
+
+import torch
+from torch.fx import Node
+from torch.fx.immutable_collections import immutable_dict, immutable_list
+from torch.fx.experimental.proxy_tensor import make_fx
+from torch._dispatch.python import enable_python_dispatcher
+from torch._subclasses.fake_tensor import FakeTensor
+from torch._subclasses.fake_tensor import FakeTensorMode
+from torch._subclasses.functional_tensor import FunctionalTensorMode
+from torch.utils._python_dispatch import is_traceable_wrapper_subclass
+
+from thunder.core.baseutils import run_once
+from thunder.core.codeutils import SigInfo
+from thunder.core import devices
+from thunder.core import dtypes
+from thunder.core import prims
+from thunder.core import utils
+from thunder.core.proxies import ProxyInterface
+from thunder.core.proxies import SubclassTensorProxy
+from thunder.core.proxies import TensorProxy
+from thunder.core.proxies import Variable
+from thunder.core.proxies import variableify
+from thunder.core.pytree import tree_flatten
+from thunder.core.pytree import tree_map
+from thunder.core.pytree import tree_unflatten
+from thunder.core.trace import TraceCtx
+from thunder.core.trace import TraceProvenance
+from thunder.core.trace import from_trace
+from thunder.core.trace import tracectx
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from typing import Any
+    from optree import PyTreeSpec
+    from torch.fx import GraphModule
+    from torch._ops import OpOverload
+    from thunder.core.symbol import Symbol, BoundSymbol
+
+
+__all__ = [
+    "unroll_tensor_subclasses",
+]
+
+
+PLACEHOLDER: str = "placeholder"
+CALL_FUNCTION: str = "call_function"
+OUTPUT: str = "output"
+
+
+@run_once
+def warn_tensor_subclass_support() -> None:
+    warnings.warn("Tensor Subclasses with `__torch_dispatch__` defined support is experimental")
+
+
+class OutputWrapperForFxTracing(NamedTuple):
+    inner_tensors: dict[str, torch.Tensor] | torch.Tensor
+    metadata: dict[str, Any] | None
+
+
+def _materialize_tensor_proxy(t: TensorProxy, fake_tensor_mode: FakeTensorMode | None) -> torch.Tensor:
+    shape = t.shape
+    device = devices.to_torch_device(t.device)
+    dtype = dtypes.to_torch_dtype(t.dtype)
+    requires_grad = t.requires_grad
+
+    with torch.device("meta"):
+        t = torch.empty(shape, dtype=dtype, requires_grad=requires_grad)
+    if fake_tensor_mode is None:
+        return t
+    fakified_empty_tensor = fake_tensor_mode.fake_tensor_converter.from_meta_and_device(
+        fake_mode=fake_tensor_mode, t=t, device=device
+    )
+    return fakified_empty_tensor
+
+
+def _make_fake_subclass_tensor_from_subclass_tensor_proxy(
+    tensor_proxy: SubclassTensorProxy,
+    fake_tensor_mode: FakeTensorMode,
+) -> torch.Tensor:
+    utils.check(
+        (subclass_type := getattr(tensor_proxy, SubclassTensorProxy.SUBCLASS_TYPE_ATTR, None)) is not None,
+        lambda: f"{tensor_proxy} does not have `{SubclassTensorProxy.SUBCLASS_TYPE_ATTR}`",
+    )
+    utils.check(
+        tensor_proxy._tensors,
+        lambda: f"{tensor_proxy} has an empty `{tensor_proxy._tensors=}`",
+    )
+    tensor_attr_names = tensor_proxy._tensor_attr_names
+    non_tensor_attr_names = tensor_proxy._non_tensor_attr_names
+    inner_tensors = dict(
+        zip(
+            tensor_attr_names,
+            [_materialize_tensor_proxy(t, fake_tensor_mode=fake_tensor_mode) for t in tensor_proxy._tensors],
+        )
+    )
+    new_non_tensors = []
+    for a in tensor_proxy._non_tensors:
+        if isinstance(a, dtypes.dtype):
+            new_non_tensors.append(dtypes.to_torch_dtype(a))
+        elif isinstance(a, devices.Device):
+            new_non_tensors.append(devices.to_torch_device(a))
+        else:
+            new_non_tensors.append(a)
+    metadata = dict(zip(non_tensor_attr_names, new_non_tensors))
+    subclass_tensor = subclass_type.__tensor_unflatten__(
+        inner_tensors,
+        metadata,
+        outer_size=-1,
+        outer_stride=-1,
+    )
+    fakified = fake_tensor_mode.from_tensor(subclass_tensor, static_shapes=True)
+    return fakified
+
+
+def materialize_tensor_proxy(
+    t: TensorProxy | SubclassTensorProxy,
+    fake_tensor_mode: FakeTensorMode,
+) -> torch.Tensor:
+    if isinstance(t, SubclassTensorProxy):
+        return _make_fake_subclass_tensor_from_subclass_tensor_proxy(t, fake_tensor_mode)
+    return _materialize_tensor_proxy(t, fake_tensor_mode)
+
+
+def maybe_materialize_tensor(
+    t: ProxyInterface,
+    fake_tensor_mode: FakeTensorMode,
+) -> ProxyInterface | torch.Tensor:
+    if isinstance(t, (TensorProxy, SubclassTensorProxy)):
+        return materialize_tensor_proxy(t, fake_tensor_mode)
+    if isinstance(t, (Number, str)):
+        return t
+    return t.value
+
+
+def proxy_fake_tensor(t: torch.Tensor | FakeTensor) -> ProxyInterface:
+    if isinstance(t, FakeTensor) or (isinstance(t, torch.Tensor) and not issubclass(type(t), torch.Tensor)):
+        return TensorProxy(
+            None,
+            shape=list(t.shape),
+            dtype=dtypes.to_dtype(t.dtype),
+            device=devices.to_device(t.device),
+            requires_grad=t.requires_grad,
+        )
+    if torch.utils._python_dispatch.is_traceable_wrapper_subclass(t):
+        tensor_attr_names, metadata = t.__tensor_flatten__()
+        tensor_proxies = [proxy_fake_tensor(getattr(t, name)) for name in tensor_attr_names]
+        non_tensor_attr_names = list(metadata.keys())
+        non_tensors = list(metadata.values())
+        p = SubclassTensorProxy(
+            None,
+            shape=list(t.shape),
+            dtype=dtypes.to_dtype(t.dtype),
+            device=devices.to_device(t.device),
+            requires_grad=t.requires_grad,
+            tensors=tensor_proxies,
+            non_tensors=non_tensors,
+            subclass_type=type(t),
+        )
+        p._tensor_attr_names = tensor_attr_names
+        p._non_tensor_attr_names = non_tensor_attr_names
+        for name, value in zip(tensor_attr_names + non_tensor_attr_names, tensor_proxies + non_tensors):
+            setattr(p, name, value)
+        return p
+    return t
+
+
+def trace_from_bsym_or_bsyms(bsym_or_bsyms: BoundSymbol | Sequence[BoundSymbol]) -> TraceCtx:
+    from thunder.core.compile_data import get_compile_data
+
+    cd = get_compile_data()
+    ad_hoc_executor = None
+    if cd is not None:
+        from thunder.extend import AdHocExecutor
+
+        executors_list = list(filter(lambda t: isinstance(t, AdHocExecutor), cd.executors_list))
+        if executors_list:
+            ad_hoc_executor = executors_list[0]
+
+    bsyms = list(utils.sequencify(bsym_or_bsyms))
+    trace_args = bsyms[0].flat_proxy_args
+    trace_name = bsyms[0].sym.name
+
+    if ad_hoc_executor is not None and ad_hoc_executor._implmap:
+        tmp_bsyms = []
+        for bsym in bsyms:
+            if ad_hoc_executor.can_execute(bsym) and bsym.subsymbols:
+                tmp_bsyms.extend(bsym.subsymbols)
+            else:
+                tmp_bsyms.append(bsym)
+        bsyms = tmp_bsyms
+    unpack_bsyms = [
+        prims.unpack_trivial.bind(a, name=a.name, output=a)
+        for a in filter(lambda a: isinstance(a, ProxyInterface), trace_args)
+    ]
+
+    trace = TraceCtx()
+    trace.bound_symbols.extend(unpack_bsyms + bsyms)
+    trace.args = trace_args
+    with tracectx(trace):
+        prims.python_return(bsyms[-1].output)
+    with tracectx(trace):
+        # note(crcrpar): Give prefix `tmp` to avoid infinite recursion due to the same name
+        trace._siginfo = SigInfo.from_name_and_args(f"tmp_{trace_name}", trace.args)
+    return trace
+
+
+def make_trace_executable(trace_to_convert: TraceCtx, *args_for_eval, **kwargs_for_eval):
+    from functools import wraps
+    from thunder import trace
+    from thunder.core.transforms import eval_trace
+    from thunder.executors.torch_compile import to_torch_translator
+
+    @wraps(trace_to_convert.python_callable())
+    def torch_interpreted_func(*args, **kwargs):
+        return eval_trace(trace_to_convert, *args, **kwargs, symbol_mapper=to_torch_translator)
+
+    torch_trace = trace(inline_trace=False)(torch_interpreted_func, *args_for_eval, **kwargs_for_eval)
+    return torch_trace
+
+
+@dataclass
+class DesugarTensorSubclass:
+    computation_trace: TraceCtx
+    swap_map: dict[Variable, ProxyInterface] = field(init=False, default_factory=dict)
+    fake_tensor_mode: FakeTensorMode = field(init=False, default_factory=FakeTensorMode)
+    flat_trace_args: Sequence[ProxyInterface] = field(init=False, default=None)
+    subclass_proxy_to_flatten: set[Variable] = field(init=False, default_factory=set)
+    bsym_to_new_outputs: dict[BoundSymbol, list[TensorProxy]] = field(init=False, default_factory=dict)
+
+    def __post_init__(self) -> None:
+        # Check if this trace is backward trace
+        is_backward_trace: bool = False
+        if len(self.computation_trace.bound_symbols) > 6:
+            maybe_unpack_C0_bsym = self.computation_trace.bound_symbols[4]
+            maybe_unpack_C1_bsym = self.computation_trace.bound_symbols[5]
+            is_backward_trace = (
+                maybe_unpack_C0_bsym.args
+                and maybe_unpack_C1_bsym.args
+                and (
+                    maybe_unpack_C0_bsym.sym.id,
+                    maybe_unpack_C1_bsym.sym.id,
+                    getattr(maybe_unpack_C0_bsym.args[0], "name", ""),
+                    getattr(maybe_unpack_C1_bsym.args[0], "name", ""),
+                )
+                == (
+                    prims.PrimIDs.UNPACK_SEQUENCE,
+                    prims.PrimIDs.UNPACK_SEQUENCE,
+                    "C0",
+                    "C1",
+                )
+            )
+            if is_backward_trace:
+                self.flat_trace_args, _ = tree_flatten((maybe_unpack_C0_bsym.output, maybe_unpack_C1_bsym.output))
+        if not is_backward_trace:
+            self.flat_trace_args, _ = tree_flatten((self.computation_trace.args, self.computation_trace.kwargs))
+        for arg in self.flat_trace_args:
+            if isinstance(arg, SubclassTensorProxy):
+                self.subclass_proxy_to_flatten.add(variableify(arg))
+
+    def _get_tensor_attr_names(self, p: SubclassTensorProxy) -> list[str]:
+        return p._tensor_attr_names
+
+    def _get_non_tensor_attr_names(self, p: SubclassTensorProxy) -> list[str]:
+        return p._non_tensor_attr_names
+
+    def translate_fx_graph_into_bsym(
+        self,
+        bsym: BoundSymbol,
+        fx_graph: GraphModule,
+    ) -> BoundSymbol | tuple[BoundSymbol, ...]:
+        import thunder.torch as ltorch
+        from thunder.torch import _torch_to_thunder_function_map
+
+        unwrapped_bsym_args: dict[int, ProxyInterface] = {}
+        list_of_flattening_bsyms: list[BoundSymbol] = []
+        for a in bsym.flat_args:
+            if isinstance(a, SubclassTensorProxy):
+                if variableify(a) in self.subclass_proxy_to_flatten:
+                    self.computation_trace.push_scope([])
+                    with tracectx(self.computation_trace):
+                        prims.flatten_tensor_subclass(a)
+                    flattening_bsym = self.computation_trace.pop_scope()[0]
+                    list_of_flattening_bsyms.append(flattening_bsym)
+                tensor_attr_names = self._get_tensor_attr_names(a)
+                tensors = a._tensors
+
+                non_tensor_attr_names = self._get_non_tensor_attr_names(a)
+                non_tensors = a._non_tensors
+                metadata = dict(zip(non_tensor_attr_names, non_tensors))
+                for name, t in zip(tensor_attr_names, tensors):
+                    utils.check(
+                        isinstance(t, TensorProxy),
+                        lambda: f"{a=}, {tensor_attr_names = }, {tensors=}",
+                    )
+                    unwrapped_bsym_args[len(unwrapped_bsym_args)] = t
+                # TODO(crcrpar): Think about how to verify the correctness of this flattening
+                flat_metadata, _ = tree_flatten(metadata)
+                for v in flat_metadata:
+                    unwrapped_bsym_args[len(unwrapped_bsym_args)] = v
+            else:
+                if not isinstance(a, ProxyInterface):
+                    from thunder.core.proxies import proxy
+
+                    with tracectx(self.computation_trace):
+                        a = proxy(a)
+                unwrapped_bsym_args[len(unwrapped_bsym_args)] = a
+
+        node: Node
+        list_of_placeholder_node: list[Node] = []
+        list_of_function_call_node: list[Node] = []
+        node_of_output: Node
+        for node in fx_graph.graph.nodes:
+            if node.op == PLACEHOLDER:
+                list_of_placeholder_node.append(node)
+            if node.op == CALL_FUNCTION:
+                list_of_function_call_node.append(node)
+            if node.op == OUTPUT:
+                node_of_output = node
+        args = [n.target for n in list_of_placeholder_node]
+        arg_name_to_index = {a: i for i, a in enumerate(args)}
+        ltorch_ops_for_node_of_ops = []
+        for node in list_of_function_call_node:
+            op: OpOverload = node.target
+            if op not in _torch_to_thunder_function_map:
+                msg = (
+                    f"`thunder.torch` does not have corresponding op for {op}. "
+                    "Think about adding it to thunder/torch/default_torch_ops.py"
+                    f"\nThe op is found while flattening the following BoundSymbol:\n{bsym}"
+                    f"\ntorch.fx graph:\n{fx_graph.print_readable(print_output=False)}"
+                )
+                raise RuntimeError(msg)
+            ltorch_ops_for_node_of_ops.append(_torch_to_thunder_function_map[op])
+
+        bsyms: list[BoundSymbol] = []
+        if list_of_flattening_bsyms:
+            bsyms.extend(list_of_flattening_bsyms)
+        fxnode_output_name_to_tensor_proxy: dict[str, OpOverload] = {}
+        for node, ltorch_op in zip(list_of_function_call_node, ltorch_ops_for_node_of_ops):
+            args: list[Node] = node.args
+
+            arg_proxies: list[ProxyInterface] = []
+            for a in args:
+                if isinstance(a, Node):
+                    if isinstance(a.target, str):
+                        arg_proxies.append(unwrapped_bsym_args[arg_name_to_index[a.target]])
+                    else:
+                        arg_proxies.append(fxnode_output_name_to_tensor_proxy[str(a)])
+                else:
+                    if isinstance(a, immutable_dict):
+                        arg_proxies.append(dict(a))
+                    elif isinstance(a, immutable_list):
+                        arg_proxies.append(list(a))
+                    else:
+                        arg_proxies.append(a)
+
+            self.computation_trace.push_scope([])
+
+            try:
+                with tracectx(self.computation_trace):
+                    out = ltorch_op(*arg_proxies)
+            except Exception as e:
+                msg = (
+                    f"Failing to map `torch.{node}` to `thunder.torch` op of "
+                    f"{ltorch_op} with args of {arg_proxies}\n"
+                    f"BoundSymbol in question is\n```python\n{bsym}\n```\n"
+                    f"Corresponding torch.fx Graph is\n```python\n{fx_graph.print_readable(print_output=False)}\n```\n"
+                    f"Original error is {e}"
+                )
+                raise type(e)(msg)
+            else:
+                fxnode_output_name_to_tensor_proxy[str(node)] = out
+                bsyms.extend(self.computation_trace.pop_scope())
+        if len(bsyms) == 0:
+            return [bsym]
+
+        orig_output = bsym.flat_outs[0]
+        if is_subclass_ctor_bsym := bsym.sym.id == prims.PrimIDs.TENSOR_SUBCLASS_CTOR:
+            utils.check_type(orig_output, SubclassTensorProxy)
+        if isinstance(orig_output, SubclassTensorProxy):
+            # note(crcrpar): args[0] would be list of tensors, and args[1] could be list of non-tensors.
+            args: list[Node] = node_of_output.args[0]
+            new_tensor_proxies = []
+            new_non_tensor_values = []
+            for a in args:
+                value = a
+                if isinstance(a, Node):
+                    if isinstance(a.target, str):
+                        value = unwrapped_bsym_args[arg_name_to_index[a.target]]
+                    else:
+                        value = fxnode_output_name_to_tensor_proxy[str(a)]
+                if isinstance(value, TensorProxy):
+                    new_tensor_proxies.append(value)
+                elif isinstance(value, (immutable_dict, immutable_list)):
+                    if isinstance(value, immutable_dict):
+                        new_non_tensor_values.append(dict(value))
+                    else:
+                        new_non_tensor_values.append(list(v))
+                else:
+                    new_non_tensor_values.append(value)
+            utils.check(
+                len(orig_output._tensors) == len(new_tensor_proxies),
+                lambda: (
+                    f"The number of new tensor proxies for {orig_output=} does not match: "
+                    f"{len(new_tensor_proxies)=} != {len(orig_output._tensors)=}"
+                ),
+            )
+            with tracectx(self.computation_trace):
+                new_subclass = orig_output.replace()
+            new_subclass._tensors = new_tensor_proxies
+            for name, value in zip(new_subclass._tensor_attr_names, new_tensor_proxies):
+                setattr(new_subclass, name, value)
+            bsyms.append(
+                prims.unflatten_tensor_subclass.bind(
+                    new_subclass._subclass_type,
+                    dict(zip(new_subclass._tensor_attr_names, new_tensor_proxies)),
+                    dict(zip(new_subclass._non_tensor_attr_names, new_subclass._non_tensors)),
+                    output=new_subclass,
+                )
+            )
+
+            self.swap_map[variableify(orig_output)] = new_subclass
+            self.subclass_proxy_to_flatten.add(variableify(new_subclass))
+
+        else:
+            non_none_args = [n for n in node_of_output.args[0] if n is not None]
+            utils.check(len(non_none_args) == 1, lambda: f"{node_of_output.args = }")
+            new_out_node = non_none_args[0]
+            self.swap_map[variableify(orig_output)] = fxnode_output_name_to_tensor_proxy[str(new_out_node)]
+
+        args = ", ".join([t.name if isinstance(t, ProxyInterface) else f"{t}" for t in bsym.flat_args])
+        header = f"{bsym.sym.id}({args})"
+        for i, sbsym in enumerate(bsyms, 1):
+            sbsym.header = f"[{i}/{len(bsyms)}] unrolled `__torch_dispatch__` of `{header}`"
+        return bsyms
+
+    def convert_trace_to_fx_graph_and_get_fake_result(
+        self,
+        trace: TraceCtx,
+    ) -> tuple[GraphModule, tuple[OutputWrapperForFxTracing, ...], tuple[torch.Tensor, ...], PyTreeSpec]:
+        def create_ctor(unflatten_method, tensor_names):
+            def ctor(tensors, metadata):
+                inner_tensors = dict(zip(tensor_names, tensors))
+                return unflatten_method(inner_tensors, metadata, -1, -1)
+
+            return ctor
+
+        args = tree_map(
+            lambda t: maybe_materialize_tensor(
+                t,
+                self.fake_tensor_mode,
+            ),
+            trace.args,
+        )
+        desugared_args = []
+        arg_idx_to_sugar: dict[int, tuple[int, Any]] = {}
+        for a in args:
+            if is_traceable_wrapper_subclass(a):
+                start_idx = len(desugared_args)
+                attrs, metadta = a.__tensor_flatten__()
+                desugared_args.extend([getattr(a, name) for name in attrs])
+                desugared_args.append(metadta)
+                end_idx = len(desugared_args)
+                arg_idx_to_sugar[start_idx] = end_idx, create_ctor(type(a).__tensor_unflatten__, attrs)
+            else:
+                desugared_args.append(a)
+
+        out_specs: list[Any] = []
+        orig_output: list[torch.Tensor] = []
+
+        def transform_out(out: torch.Tensor) -> OutputWrapperForFxTracing:
+            orig_output.append(out)
+            if is_traceable_wrapper_subclass(out):
+                from enum import Enum
+
+                attrs, metadata = out.__tensor_flatten__()
+                tensors = [getattr(out, name) for name in attrs]
+                for key in metadata:
+                    v = metadata[key]
+                    if issubclass(type(v), Enum) and not isinstance(v, (torch.dtype, torch.device)):
+                        metadata[key] = str(metadata[key])
+                output = OutputWrapperForFxTracing(dict(zip(attrs, tensors)), metadata)
+            else:
+                output = OutputWrapperForFxTracing(out, None)
+            return output
+
+        desugared_proxy_args = []
+        for a in trace.args:
+            if isinstance(a, SubclassTensorProxy):
+                names, metadata = a.__tensor_flatten__()
+                desugared_proxy_args.extend([getattr(a, name) for name in names])
+                desugared_proxy_args.append(metadata)
+            else:
+                desugared_proxy_args.append(a)
+
+        extrace = make_trace_executable(trace, *trace.args, **trace.kwargs)
+        utils.check(
+            (len(extrace.bound_symbols) == len(trace.bound_symbols))
+            or (
+                len(extrace.bound_symbols) == len(trace.bound_symbols) - 1
+                and any(bsym.sym.id == prims.PrimIDs.SHALLOW_COPY for bsym in trace.bound_symbols)
+            ),
+            lambda: (
+                f"Input trace is\n{trace}\nExecution trace is\n{extrace}\n"
+                f"Input has {len(trace.bound_symbols)} syms but execution trace has {len(extrace.bound_symbols)}"
+            ),
+        )
+        f = extrace.python_callable(include_decorators=False)
+
+        def f_with_wrap_and_unwrap(*desugared_args) -> tuple[OutputWrapperForFxTracing, ...]:
+            args = []
+            cur_idx = 0
+            while cur_idx < len(desugared_args):
+                if cur_idx in arg_idx_to_sugar:
+                    end_idx, construct_subclass = arg_idx_to_sugar[cur_idx]
+                    args_of_subclass = desugared_args[cur_idx:end_idx]
+                    tensors = args_of_subclass[:-1]
+                    metadata = args_of_subclass[-1]
+                    subclass = construct_subclass(tensors, metadata)
+                    args.append(subclass)
+
+                    cur_idx = end_idx
+                else:
+                    args.append(desugared_args[cur_idx])
+                    cur_idx += 1
+
+            out = f(*args)
+            # Specialcasing the output of initial computation trace
+            if isinstance(out, dict) and len(out) == 2 and ("output", "flat_args") == tuple(out.keys()):
+                sequencified_out = out
+            else:
+                sequencified_out = utils.sequencify(out)
+            flat_out, out_spec = tree_flatten(sequencified_out)
+            out_specs.append(out_spec)
+            flat_cosmeticized_out = tree_map(transform_out, flat_out)
+            return tree_unflatten(flat_cosmeticized_out, out_spec)
+
+        with (
+            enable_python_dispatcher(),
+            FunctionalTensorMode(
+                pre_dispatch=False,
+                export=False,
+                _allow_token_discovery=True,
+            ),
+        ):
+            fx: GraphModule = make_fx(f_with_wrap_and_unwrap)(*desugared_args)
+
+        return fx, fx(*desugared_args), tuple(orig_output), out_specs[0]
+
+    def __call__(self, bsym: BoundSymbol) -> list[BoundSymbol]:
+        updated_bsym: BoundSymbol = bsym.from_bsym_swap_proxies(self.swap_map)
+        if bsym.sym.id == prims.PrimIDs.RETURN:
+            new_swap_map = {}
+            for k, v in self.swap_map.items():
+                if isinstance(v, SubclassTensorProxy):
+                    continue
+                new_swap_map[k] = v
+            if not self.subclass_proxy_to_flatten or True:
+                return [updated_bsym]
+
+        is_bsym_of_subclass_ctor = bsym.sym.id == prims.PrimIDs.TENSOR_SUBCLASS_CTOR
+        returns_subclass = any(isinstance(a, SubclassTensorProxy) for a in updated_bsym.flat_proxy_outs)
+        no_subclass_args = all(not isinstance(a, SubclassTensorProxy) for a in updated_bsym.flat_proxy_args)
+        is_unpack = bsym.sym.id in {prims.PrimIDs.UNPACK_TRIVIAL, prims.PrimIDs.UNPACK_SEQUENCE}
+        is_subclass_ctor = is_bsym_of_subclass_ctor or (no_subclass_args and returns_subclass and not is_unpack)
+        if not is_subclass_ctor and no_subclass_args:
+            return [updated_bsym]
+
+        utils.check(
+            len(updated_bsym.flat_outs) < 2,
+            lambda: f"bsym has {len(updated_bsym.flat_outs)} outputs",
+            exception_type=NotImplementedError,
+        )
+
+        trace = trace_from_bsym_or_bsyms(updated_bsym)
+        fx, sequencified_cosmeticized_out, orig_output, _ = self.convert_trace_to_fx_graph_and_get_fake_result(trace)
+        utils.check(
+            len(sequencified_cosmeticized_out) == len(orig_output),
+            lambda: f"{len(sequencified_cosmeticized_out)=}, {len(orig_output)=}",
+        )
+        if is_subclass_ctor:
+            utils.check(len(sequencified_cosmeticized_out) == 1 and len(orig_output) == 1, lambda: "")
+            fake_tensor_subclass = orig_output[0]
+            subclass_proxy = updated_bsym.flat_outs[0]
+            tensor_attr_names, metadata = fake_tensor_subclass.__tensor_flatten__()
+            subclass_proxy._tensor_attr_names = tensor_attr_names
+            subclass_proxy._non_tensor_attr_names = list(metadata.keys())
+            self.subclass_proxy_to_flatten.add(variableify(subclass_proxy))
+            for name, value in zip(
+                tensor_attr_names + subclass_proxy._non_tensor_attr_names,
+                subclass_proxy._tensors + subclass_proxy._non_tensor_attr_names,
+            ):
+                setattr(subclass_proxy, name, value)
+            return [updated_bsym]
+
+        out = []
+        for i, (cosmeticized_out, orig_out) in enumerate(zip(sequencified_cosmeticized_out, orig_output)):
+            if isinstance(cosmeticized_out.inner_tensors, dict):
+                utils.check(
+                    is_traceable_wrapper_subclass(orig_out), lambda: f"{cosmeticized_out=} don't match {orig_out=}"
+                )
+                out.append(orig_out)
+            else:
+                out.append(orig_out)
+
+        with tracectx(self.computation_trace):
+            out_proxy = tree_map(proxy_fake_tensor, out)
+
+        utils.check(
+            len(updated_bsym.flat_outs) == len(out_proxy),
+            lambda: f"{len(bsym.flat_outs)=}, {len(out_proxy)=}, {out_proxy=}, {bsym.flat_outs=}",
+        )
+        sequence_out = [variableify(a) for a in updated_bsym.flat_outs]
+        self.swap_map.update(dict(zip(sequence_out, utils.sequencify(out_proxy))))
+
+        bsym_with_modified_output = updated_bsym.from_bsym_swap_proxies(self.swap_map)
+        self.bsym_to_new_outputs[bsym_with_modified_output] = bsym_with_modified_output
+        return self.translate_fx_graph_into_bsym(bsym_with_modified_output, fx)
+
+
+def tensor_subclass_dce(trace: TraceCtx) -> TraceCtx:
+    """Remove ``tensor.__tensor_flatten__``s as possible.
+
+    This function tries to remove flattening of tensor subclass
+    by replacing their outputs with tensor args of ``tensor``\'s constructor,
+    either '`TensorSubclass(...)` or `TensorSubclass.__tensor_unflatten__(...)`.
+
+    This function does not remove ``TensorSubclass(...)`` nor ``TensorSubclass.__tensor_unflatten__(...)``
+    as they could be a saved tensor for backward.
+    """
+    start_time_ns = time.perf_counter_ns()
+    swap_map: dict[Variable, TensorProxy] = {}
+    producer_map = utils.producers(trace)
+    bsym_to_exclude: set[BoundSymbol] = set()
+
+    subclass_flatten_bsym: BoundSymbol
+    for subclass_flatten_bsym in filter(
+        lambda bsym: bsym.sym.id == prims.PrimIDs.FLATTEN_TENSOR_SUBCLASS,
+        trace.bound_symbols,
+    ):
+        subclass_tensor_proxy: SubclassTensorProxy = subclass_flatten_bsym.flat_args[0]
+        flatten_tensors: tuple[TensorProxy, ...] = subclass_flatten_bsym.output
+        ctor_bsym: BoundSymbol = producer_map[subclass_tensor_proxy]
+        match ctor_bsym.sym.id:
+            case prims.PrimIDs.TENSOR_SUBCLASS_CTOR:
+                ctor_tensors: list[TensorProxy] = ctor_bsym.args[6]
+            case prims.PrimIDs.UNFLATTEN_TENSOR_SUBCLASS:
+                ctor_tensors: list[TensorProxy] = list(ctor_bsym.args[1].values())
+            case _:
+                continue
+        utils.check(
+            len(flatten_tensors) == len(ctor_tensors),
+            lambda: f"{flatten_tensors} and {ctor_tensors} have different number of tensors",
+        )
+
+        for k, v in zip(flatten_tensors, ctor_tensors):
+            if k.name == v.name:
+                continue
+            swap_map[variableify(k)] = v
+        bsym_to_exclude.add(subclass_flatten_bsym)
+
+    if not swap_map:
+        return trace
+
+    new_bsyms: list[BoundSymbol] = []
+    bsym: BoundSymbol
+    for bsym in trace.bound_symbols:
+        if bsym in bsym_to_exclude:
+            continue
+        new_bsyms.append(bsym.from_bsym_swap_proxies(swap_map, skip_output=True))
+
+    new_trace = from_trace(trace)
+    new_trace.bound_symbols = new_bsyms
+    end_time_ns = time.perf_counter_ns()
+    elapsed_time_ns = end_time_ns - start_time_ns
+    elapsed_time_millis = elapsed_time_ns // 1000000
+    new_trace.set_provenance(
+        TraceProvenance(f"DCE of Tensor Subclass Flattening/Unflattening (took {elapsed_time_millis} milliseconds)")
+    )
+
+    return new_trace
+
+
+def unroll_tensor_subclasses(trace: TraceCtx) -> TraceCtx:
+    """Unroll tensor subclasses in ``computation_trace``.
+
+    Two things are happening inside of this function:
+        * Reevaluate every single bsym of ``computation_trace.bound_symbols``.
+        * Flatten tensor subclasses
+
+    Each :class:`thunder.core.symbol.BoundSymbol` is reevaluated with torch.fx tracing and
+    ``FakeTensorMode``. This is necessary because Thunder's initial trace cannot correctly infer the output
+    type of an op with tensor subclasses. By translating each bsym into a callable and tracing it with
+    ``torch.fx`` and ``FakeTensorMode``, we can tell the output type and the exact behavior of the bsym
+    which is extended by subclass's ``__torch_dispatch__`` (note that the sequence of observed operations
+    are free from tensor subclasses, everything is flattened).
+    The output type information is then reflected to the output :class:`thunder.core.proxies.Proxy`.
+
+    With this function applied, the :class:`thunder.core.trace.TraceCtx` is free from tensor subclasses.
+    Exceptions are prologue (meaning the first few lines of the trace, before any math) and epilogue (meaning
+    the last few lines of the trace, right before return statement).
+
+    Args:
+        trace:
+
+    Returns:
+        TraceCtx: transformed trace that is free from tensor subclasses, every ``__torch_dispatch__``
+            behavior is spelled out.
+    """
+    start_time_ns = time.perf_counter_ns()
+
+    desugar_tensor_subclass = DesugarTensorSubclass(computation_trace=trace)
+    updated_bsyms: list[BoundSymbol] = []
+    bsym: BoundSymbol
+    for bsym in trace.bound_symbols:
+        maybe_desugared_bsyms = desugar_tensor_subclass(bsym)
+        updated_bsyms.extend(maybe_desugared_bsyms)
+
+    if not desugar_tensor_subclass.subclass_proxy_to_flatten:
+        return trace
+
+    end_time_ns = time.perf_counter_ns()
+    elapsed_time_ns = end_time_ns - start_time_ns
+    elapsed_time_millis = elapsed_time_ns // 1000000
+
+    computation_trace_with_subclass_tensor_unrolled = from_trace(trace)
+    computation_trace_with_subclass_tensor_unrolled.bound_symbols.extend(updated_bsyms)
+    computation_trace_with_subclass_tensor_unrolled.set_provenance(
+        TraceProvenance(f"tensor subclasses unrolled (took {elapsed_time_millis} milliseconds)")
+    )
+    dced_computation_trace = tensor_subclass_dce(computation_trace_with_subclass_tensor_unrolled)
+    warn_tensor_subclass_support()
+    return dced_computation_trace

--- a/thunder/transforms/tensor_wrapper_subclass.py
+++ b/thunder/transforms/tensor_wrapper_subclass.py
@@ -984,19 +984,19 @@ def tensor_subclass_dce(trace: TraceCtx, is_bwd_trace: bool) -> TraceCtx:
     # Handle adhoc executor subsymbols for backward trace
     if is_bwd_trace:
         from thunder.core.compile_data import get_compile_data
-        from thunder.extend import AdHocExecutor
+        from thunder.extend import TemporaryExecutor
 
         cd = get_compile_data()
-        ad_hoc_executor: AdHocExecutor | None = None
+        temporary_executor: TemporaryExecutor | None = None
         if cd is not None:
-            executors_list = list(filter(lambda executor: isinstance(executor, AdHocExecutor), cd.executors_list))
+            executors_list = list(filter(lambda executor: isinstance(executor, T), cd.executors_list))
             if executors_list:
-                ad_hoc_executor = executors_list[0]
+                temporary_executor = executors_list[0]
 
-        if ad_hoc_executor is not None and ad_hoc_executor._implmap:
+        if temporary_executor is not None and temporary_executor._implmap:
             new_bsyms = []
             for bsym in trace.bound_symbols:
-                if ad_hoc_executor.can_execute(bsym) and bsym.subsymbols:
+                if temporary_executor.can_execute(bsym) and bsym.subsymbols:
                     new_bsyms.extend(bsym.subsymbols)
                 else:
                     new_bsyms.append(bsym)

--- a/thunder/transforms/tensor_wrapper_subclass.py
+++ b/thunder/transforms/tensor_wrapper_subclass.py
@@ -175,22 +175,22 @@ def trace_from_bsym_or_bsyms(bsym_or_bsyms: BoundSymbol | Sequence[BoundSymbol])
     from thunder.core.compile_data import get_compile_data
 
     cd = get_compile_data()
-    ad_hoc_executor = None
+    temporary_executor = None
     if cd is not None:
-        from thunder.extend import AdHocExecutor
+        from thunder.extend import TemporaryExecutor
 
-        executors_list = list(filter(lambda t: isinstance(t, AdHocExecutor), cd.executors_list))
+        executors_list = list(filter(lambda t: isinstance(t, TemporaryExecutor), cd.executors_list))
         if executors_list:
-            ad_hoc_executor = executors_list[0]
+            temporary_executor = executors_list[0]
 
     bsyms = list(utils.sequencify(bsym_or_bsyms))
     trace_args = bsyms[0].flat_proxy_args
     trace_name = bsyms[0].sym.name
 
-    if ad_hoc_executor is not None and ad_hoc_executor._implmap:
+    if temporary_executor is not None and temporary_executor._implmap:
         tmp_bsyms = []
         for bsym in bsyms:
-            if ad_hoc_executor.can_execute(bsym) and bsym.subsymbols:
+            if temporary_executor.can_execute(bsym) and bsym.subsymbols:
                 tmp_bsyms.extend(bsym.subsymbols)
             else:
                 tmp_bsyms.append(bsym)


### PR DESCRIPTION
## What does this PR do?

There are about a handful of my pull requests of this topic.
This is based on a recent main commit and could be helpful for some other tensor subclasses.

I try to keep the transform agnostic to tensor subclass implementations while the tests are focused on `torchao.float8.Float8Tensor` of v0.7.0.

There are many caveats:
- A standalone script of the same model and jit hyperparameters seems to fail to reproduce the failures I see from tests that I run with pytest.
- Interpreter fails randomly in tests with torchao. The frequency isn't high and I've not figured out how to reproduce the error. The error would look like this: https://gist.github.com/crcrpar/25d1d450d661657711a086df891f5407
- Rematerialization could fail. #1754 seems to mitigate the situation, but I still see some failures.
- For torchao.float8, nvfuserex needs to get more careful of strides/memory_format to satisfy the conditions of `torch._scaled_mm`, especially in backward.