### PR TITLE
bump GPU distributed timeout

### DIFF
--- a/.azure/gpu-tests.yml
+++ b/.azure/gpu-tests.yml
@@ -195,5 +195,5 @@ jobs:
           #  ./codecov --token=$(CODECOV_TOKEN) --commit=$(Build.SourceVersion) \
           #    --flags=gpu,pytest,distributed --name="GPU-coverage" --env=linux,azure
         condition: eq(variables['testing'], 'distributed')
-        timeoutInMinutes: "25"
+        timeoutInMinutes: "30"
         displayName: "Testing: distributed"


### PR DESCRIPTION
...probably not the ultimate fix  (seems that something is unstable with the dev PT and distributed), but maybe for better error messages. 