### PR TITLE
Clean up executors after testing recipes

### DIFF
--- a/thunder/tests/test_extend.py
+++ b/thunder/tests/test_extend.py
@@ -129,7 +129,6 @@ def test_get_all_executors_includes_all_native_executors():
         "fa3",
         "torch",
         "cudnn_layernorm",
-        "inplace_index_copy_ex",
         "sdpa",
         "torchcompile",
         "torchcompile_cat",

--- a/thunder/tests/test_extend.py
+++ b/thunder/tests/test_extend.py
@@ -129,6 +129,7 @@ def test_get_all_executors_includes_all_native_executors():
         "fa3",
         "torch",
         "cudnn_layernorm",
+        "inplace_index_copy_ex",
         "sdpa",
         "torchcompile",
         "torchcompile_cat",

--- a/thunder/tests/test_recipes.py
+++ b/thunder/tests/test_recipes.py
@@ -42,8 +42,6 @@ def test_recipe_basic_bert():
 
     assert_close(actual, expected)
 
-    deregister_executor("inplace_index_copy_ex")
-
     from thunder.recipes import HFTransformers
 
     thunder_bert = thunder.compile(bert, recipe=HFTransformers())
@@ -53,6 +51,7 @@ def test_recipe_basic_bert():
 
     assert_close(actual, expected)
 
+    # cleanup after test
     deregister_executor("inplace_index_copy_ex")
 
 
@@ -72,6 +71,7 @@ def test_recipe_basic_bert_fx():
 
     assert_close(actual, expected)
 
+    # cleanup after test
     deregister_executor("inplace_index_copy_ex")
 
 

--- a/thunder/tests/test_recipes.py
+++ b/thunder/tests/test_recipes.py
@@ -5,6 +5,7 @@ import thunder
 import transformers
 import torch
 
+from thunder.extend import deregister_executor
 from torch.testing import assert_close, make_tensor
 from thunder.tests.framework import version_between, IS_WINDOWS
 
@@ -41,6 +42,8 @@ def test_recipe_basic_bert():
 
     assert_close(actual, expected)
 
+    deregister_executor("inplace_index_copy_ex")
+
     from thunder.recipes import HFTransformers
 
     thunder_bert = thunder.compile(bert, recipe=HFTransformers())
@@ -49,6 +52,8 @@ def test_recipe_basic_bert():
     expected = bert(inp)
 
     assert_close(actual, expected)
+
+    deregister_executor("inplace_index_copy_ex")
 
 
 def test_recipe_basic_bert_fx():
@@ -66,6 +71,8 @@ def test_recipe_basic_bert_fx():
     expected = bert(inp)
 
     assert_close(actual, expected)
+
+    deregister_executor("inplace_index_copy_ex")
 
 
 def test_recipe_mlp():


### PR DESCRIPTION
The CI failed: https://github.com/Lightning-AI/lightning-thunder/actions/runs/13966210029/job/39097040135#step:10:4870
```
FAILED thunder/tests/test_extend.py::test_get_all_executors_includes_all_native_executors - AssertionError: assert {'apex', 'cud...'python', ...} == {'apex', 'cud..., 'sdpa', ...}
  
  Extra items in the left set:
  'inplace_index_copy_ex'
  
  Full diff:
    {
        'apex',
        'cudnn',
        'cudnn_layernorm',
        'fa3',
  +     'inplace_index_copy_ex',
        'python',
        'sdpa',
        'torch',
        'torchcompile',
        'torchcompile_cat',
        'torchcompile_xentropy',
        'transformer_engine',
    }
```
 I assume it's due to the recent change #1887.  