### PR TITLE
Initial support for Python 3.13

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -33,6 +33,7 @@ jobs:
         include:
           - { os: "ubuntu-22.04", python-version: "3.11", requires: "latest" }
           - { os: "ubuntu-22.04", python-version: "3.12", requires: "latest" }
+          - { os: "ubuntu-22.04", python-version: "3.13", requires: "latest" }
         exclude:
           - { os: "windows-2022", suite: "ops" }
           - { os: "windows-2022", suite: "grads" }
@@ -134,7 +135,7 @@ jobs:
               -n 4 --durations=250
 
       - name: Testing interpreter
-        if: matrix.python-version == '3.11' || matrix.python-version == '3.12'
+        if: matrix.python-version == '3.11' || matrix.python-version == '3.12' || matrix.python-version == '3.13'
         run: |
           python -m pytest \
             thunder/tests/test_interpreter.py \

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     keywords=["deep learning", "AI"],
-    python_requires=">=3.10, <3.13",
+    python_requires=">=3.10, <3.14",
     setup_requires=["wheel"],
     install_requires=_load_requirements(_PATH_REQUIRES, file_name="base.txt"),
     extras_require=_prepare_extras(),


### PR DESCRIPTION
Not much to see here, mostly opcode changes.
Most notable:
- The method / function is now `func, self_or_null` in a number of places,
- locals() now returns a new dict on every call,
- formatting got an update (e.g. values go through `__format__` usually),
- MAKE_FUNCTION is split up (but `__closure__` is still readonly when accessed from Python. Ugh.)
