### PR TITLE
Simplify quickstarts with transformers

### DIFF
--- a/examples/quickstart/hf_bert.py
+++ b/examples/quickstart/hf_bert.py
@@ -25,13 +25,14 @@ def main():
 
     print(f"Eager: {benchmark(model, **inp):.2f}ms")
 
-    thunder_model = thunder.compile(
-        model,
-        recipe="hf-transformers",
-        plugins="reduce-overhead" if torch.cuda.is_available() else None
-    )
+    thunder_model = thunder.compile(model)
 
     print(f"Thunder: {benchmark(thunder_model, **inp):.2f}ms")
+
+    if torch.cuda.is_available():
+        thunder_model = thunder.compile(model, plugins="reduce-overhead")
+
+        print(f"Thunder with 'reduce-overhead': {benchmark(thunder_model, **inp):.2f}ms")
 
 
 if __name__ == "__main__":

--- a/examples/quickstart/hf_llm.py
+++ b/examples/quickstart/hf_llm.py
@@ -32,18 +32,16 @@ def main():
         out = model.generate(**inp, do_sample=False, cache_implementation=cache, max_new_tokens=100)
         print(tokenizer.decode(out[0].tolist()))
 
-    print(f"Eager: {benchmark_n(2, generate, model, inp):.2f}ms")
+    print("\nGenerating with PyTorch eager:")
+    eager_time = benchmark_n(2, generate, model, inp)
 
-    thunder_model = thunder.compile(
-        model,
-        recipe="hf-transformers",
-        plugins="reduce-overhead" if torch.cuda.is_available() else None
-    )
+    thunder_model = thunder.compile(model)
 
-    generate(thunder_model, inp, cache="static")
-    print({bsym.sym.name for bsym in thunder.last_traces(thunder_model)[-1].bound_symbols})
+    print("\nGenerating with Thunder:")
+    thunder_time = benchmark_n(2, generate, thunder_model, inp, cache='static')
 
-    print(f"Thunder: {benchmark_n(2, generate, thunder_model, inp, cache='static'):.2f}ms")
+    print(f"\nEager: {eager_time:.2f}ms")
+    print(f"Thunder: {thunder_time:.2f}ms")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What does this PR do?

With the latest `transformers` models can be traced through without a recipe.

Also on latest generation GPUs we get a good speed up without reduce overhead, so I moved it to an extra step.

As a note, I'm getting an memory access error using CUDAGraphs on the llm quickstart with the latest nvfuser, so I'm not adding the reduce overhead plugin to that particular quickstart for now.