### PR TITLE
remove out arg from prim and clang operators.

### DIFF
--- a/docs/source/advanced/contrib_thunder.rst
+++ b/docs/source/advanced/contrib_thunder.rst
@@ -383,7 +383,7 @@ lines
 
   @torchctx
   def _topk_prim_grad(
-      a: TensorProxy, /, k: int, dim: None | int = None, largest: bool = True, sorted: bool = True, *, out=None
+      a: TensorProxy, /, k: int, dim: None | int = None, largest: bool = True, sorted: bool = True
   ):
       fwd = prims.topk(a, k, dim, largest, sorted, out=out)
       val, idx = fwd

--- a/thunder/clang/__init__.py
+++ b/thunder/clang/__init__.py
@@ -2164,21 +2164,21 @@ def argmin(a: TensorProxy, /, dim: int | None = None, keepdim: bool | None = Fal
 
 @clangop()
 def topk(
-    a: TensorLike, /, k: int, dim: int | None = None, largest: bool = True, sorted: bool = True, *, out=None
+    a: TensorLike, /, k: int, dim: int | None = None, largest: bool = True, sorted: bool = True
 ) -> tuple[TensorProxy, TensorProxy]:
     if dim is None:
         dim = a.ndim - 1 if a.ndim > 0 else 0
     dim = utils.canonicalize_dim(a.ndim, dim)
 
-    return prims.topk(a, k, dim, bool(largest), bool(sorted), out=out)
+    return prims.topk(a, k, dim, bool(largest), bool(sorted))
 
 
 @clangop()
 def sort(
-    a: TensorLike, /, dim: None | int = None, descending: bool = False, stable: bool = False, *, out=None
+    a: TensorLike, /, dim: None | int = None, descending: bool = False, stable: bool = False
 ) -> (TensorProxy, TensorProxy):
     if dim is None:
         dim = a.ndim - 1 if a.ndim > 0 else 0
     dim = utils.canonicalize_dim(a.ndim, dim)
 
-    return prims.sort(a, dim, descending, stable, out=out)
+    return prims.sort(a, dim, descending, stable)

--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -3620,14 +3620,7 @@ def scatter_meta(a: TensorProxy, /, index: TensorProxy, src: TensorProxy | Numbe
 scatter = make_prim(PrimIDs.SCATTER, "scatter", meta=scatter_meta)
 
 
-def topk_meta(
-    a: TensorProxy, /, k: int, dim: int, largest: Number, sorted: Number, *, out: None | TensorProxy
-) -> (TensorProxy, TensorProxy):
-    utils.check(
-        out is None,
-        lambda: "Only `out` which is None is currently supported",
-    )
-
+def topk_meta(a: TensorProxy, /, k: int, dim: int, largest: Number, sorted: Number) -> (TensorProxy, TensorProxy):
     utils.check_type(a, TensorProxy)
     utils.check_type(k, (int, IntegerProxy))
     utils.check_type(dim, (int, IntegerProxy))
@@ -3647,14 +3640,7 @@ def topk_meta(
 topk = make_prim(PrimIDs.TOPK, "topk", meta=topk_meta, tags=(OpTags.REDUCTION_OP,))
 
 
-def sort_meta(
-    a: TensorProxy, /, dim: int, descending: Number, sorted: Number, *, out: None | TensorProxy
-) -> (TensorProxy, TensorProxy):
-    utils.check(
-        out is None,
-        lambda: "Only `out` which is None is currently supported",
-    )
-
+def sort_meta(a: TensorProxy, /, dim: int, descending: Number, sorted: Number) -> (TensorProxy, TensorProxy):
     utils.check_type(a, TensorProxy)
     utils.check_type(dim, (int, IntegerProxy))
     utils.check(pytype(descending) is bool, lambda: f"Expected {descending=} to be a boolean type")

--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -1215,10 +1215,8 @@ def _sum_prim_grad(a: TensorProxy, /, dims: Sequence[int]) -> TensorProxy:
 register_grad(pids.SUM, _sum_prim_grad)
 
 
-def _topk_prim_grad(
-    a: TensorProxy, /, k: int, dim: None | int = None, largest: bool = True, sorted: bool = True, *, out=None
-):
-    fwd = prims.topk(a, k, dim, largest, sorted, out=out)
+def _topk_prim_grad(a: TensorProxy, /, k: int, dim: None | int = None, largest: bool = True, sorted: bool = True):
+    fwd = prims.topk(a, k, dim, largest, sorted)
     val, idx = fwd
 
     val_grad = get_grad(val)
@@ -1236,10 +1234,10 @@ register_grad(pids.TOPK, _topk_prim_grad)
 
 
 def _sort_prim_grad(
-    a: TensorProxy, /, dim: None | int = None, descending: bool = False, stable: bool = False, *, out=None
+    a: TensorProxy, /, dim: None | int = None, descending: bool = False, stable: bool = False
 ) -> (TensorProxy, TensorProxy):
     dim = -1 if dim is None else dim
-    sorted_a, sort_idx = prims.sort(a, dim, descending, stable, out=out)
+    sorted_a, sort_idx = prims.sort(a, dim, descending, stable)
 
     sorted_a_grad = get_grad(sorted_a)
 

--- a/thunder/executors/torchex.py
+++ b/thunder/executors/torchex.py
@@ -1229,13 +1229,11 @@ def _argmin_transform(a: TensorProxy, /, dim: int):
 
 # NOTE This transform translates number proxies to boolean values
 # and handles dim = None
-def _topk_transform(
-    a: TensorProxy, /, k: int, dim: int | None = None, largest: Number = 1, sorted: Number = 1, *, out=None
-):
+def _topk_transform(a: TensorProxy, /, k: int, dim: int | None = None, largest: Number = 1, sorted: Number = 1):
     if dim is None:
         dim = a.ndim - 1 if a.ndim > 0 else 0
 
-    return topk(a, k, dim, bool(largest), bool(sorted), out=out)
+    return topk(a, k, dim, bool(largest), bool(sorted))
 
 
 _register_implementation(prims.amax, checker=_always_executable, execution_transform=_amax_prim_transform)
@@ -1268,14 +1266,12 @@ _register_implementation(ltorch.topk, topk, checker=_always_executable, executio
 
 # NOTE this transform translates number proxies to boolean values
 # and handles dim = None
-def _sort_transform(
-    a: TensorProxy, /, dim: int | None = None, descending: bool = False, stable: bool = False, *, out=None
-):
+def _sort_transform(a: TensorProxy, /, dim: int | None = None, descending: bool = False, stable: bool = False):
     if dim is None:
         dim = a.ndim - 1 if a.ndim > 0 else 0
 
     # NOTE: args past `a` are passed as kwargs to avoid issues with multiple `torch.sort` overloadings
-    return sort(a, dim=dim, descending=bool(descending), stable=bool(stable), out=out)
+    return sort(a, dim=dim, descending=bool(descending), stable=bool(stable))
 
 
 _register_implementation(prims.sort, checker=_always_executable, execution_transform=_sort_transform)

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -803,14 +803,13 @@ def randn_like(
 
 
 @torchsymbol(torch.bernoulli, is_method=True)
-def bernoulli(a: TensorLike, *, generator=None, out=None):
+def bernoulli(a: TensorLike, *, generator=None):
     # NOTE: Currently, we don't model randomness
     utils.check(
         generator is None,
         lambda: "bernoulli: generator is not None which is currently unsupported",
         NotImplementedError,
     )
-    utils.check(out is None, lambda: "bernoulli: out is not None which is currently unsupported", NotImplementedError)
     utils.check(dtypes.is_float_dtype(a.dtype), lambda: f"bernoulli only supports floating point dtypes, got {a.dtype}")
     return (uniform_like(a) < a).to(a.dtype)
 
@@ -3000,16 +2999,16 @@ def argmin(a: TensorLike, /, dim: int | None = None, keepdim: bool | None = Fals
 
 @torchsymbol(torch.topk, is_method=True)
 def topk(
-    a: TensorLike, /, k: int, dim: None | int = None, largest: bool = True, sorted: bool = True, *, out=None
+    a: TensorLike, /, k: int, dim: None | int = None, largest: bool = True, sorted: bool = True
 ) -> (TensorLike, TensorLike):
-    return clang.topk(a, k, dim, largest, sorted, out=out)
+    return clang.topk(a, k, dim, largest, sorted)
 
 
 @torchsymbol(torch.sort, is_method=True)
 def sort(
-    a: TensorLike, /, dim: None | int = None, descending: bool = False, stable: bool = False, *, out=None
+    a: TensorLike, /, dim: None | int = None, descending: bool = False, stable: bool = False
 ) -> (TensorLike, TensorLike):
-    return clang.sort(a, dim, descending, stable, out=out)
+    return clang.sort(a, dim, descending, stable)
 
 
 #


### PR DESCRIPTION
As per the title.

Originally discussed here: https://github.com/Lightning-AI/lightning-thunder/pull/1896#discussion_r2014469339