### PR TITLE
Update README.md - fixed link to thunder docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ For **performance experts**, Thunder is the most ergonomic framework for underst
 
 # Quick start
 
-Install Thunder via pip ([more options](https://lightning.ai/docs/litserve/home/install)):
+Install Thunder via pip ([more options](https://lightning.ai/docs/thunder/latest/fundamentals/installation.html)):
 
 ```bash
 pip install torch==2.6.0 torchvision==0.21 nvfuser-cu124-torch26


### PR DESCRIPTION
fixed link to thunder install docs in README Quick start, was pointing to litserve install docs

<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes # (issue).

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
