### PR TITLE
Make `ltorch.cumsum` result int64 when `a` is int or bool and `dtype` is not specified

### DIFF
--- a/thunder/tests/test_ops.py
+++ b/thunder/tests/test_ops.py
@@ -336,3 +336,19 @@ def test_max_with_int():
     ids = torch.randint(0, 10, size=(1, 512))
 
     thunder.jit(f)(x, ids)
+
+
+def test_ltorch_cumsum_result_dtype_for_int_input():
+
+    def f(a):
+        return torch.cumsum(a, dim=0)
+
+    x = torch.randint(0, 128, (4,), dtype=torch.int32)
+    jitted = thunder.jit(f)
+    out = jitted(x)
+    # runtime check
+    assert out.dtype is torch.int64
+
+    trc = thunder.last_traces(jitted)[0]
+    bsym_of_cumsum = trc.bound_symbols[1]
+    assert bsym_of_cumsum.output.dtype is dtypes.int64

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -3016,6 +3016,9 @@ def cumsum(a: TensorLike, dim: int, *, dtype: None | dtypeLike = None) -> Tensor
     # check the input dimension
     utils.canonicalize_dim(a.ndim, dim)
     if dtype is None:
+        # ref: https://github.com/pytorch/pytorch/blob/78fe079c/torch/_refs/__init__.py#L2301-L2315
+        if a.dtype in dtypes.integer_dtypes:
+            return TensorProxy(like=a, dtype=dtypes.int64)
         return TensorProxy(like=a)
     else:
         return TensorProxy(like=a, dtype=to_dtype(dtype))


### PR DESCRIPTION
## What does this PR do?

Fixes #1952.
Fix the dtype mismatch between "compile time" and runtime which led nvfuser region to fail as in the linked issue.