### PR TITLE
ThunderFX: passes all kwargs except torch.compile's kwargs directly to thunder.jit

### DIFF
--- a/thunder/dynamo/compiler.py
+++ b/thunder/dynamo/compiler.py
@@ -212,23 +212,10 @@ def thunderfx(fn: Callable, /, **kwargs) -> Callable:
     """
     import thunder
 
-    from thunder.dynamo.utils import get_thunder_jit_kwargs, get_torch_compile_kwargs
+    from thunder.dynamo.utils import get_torch_compile_kwargs
 
-    thunder_jit_kwargs = get_thunder_jit_kwargs(**kwargs)
     torch_compile_kwargs = get_torch_compile_kwargs(**kwargs)
-
-    rest_kwargs = {k: v for k, v in kwargs.items() if k not in thunder_jit_kwargs and k not in torch_compile_kwargs}
-    check(
-        not rest_kwargs,
-        lambda: f"There are kwargs that are not supported by either thunder.jit or torch.compile: {rest_kwargs}",
-    )
-
-    overlap = [kwarg_name for kwarg_name in thunder_jit_kwargs if kwarg_name in torch_compile_kwargs]
-    check(
-        not overlap,
-        lambda: f"There are overlapping kwargs between thunder.jit and torch.compile: {overlap}",
-        ValueError,
-    )
+    thunder_jit_kwargs = {k: v for k, v in kwargs.items() if k not in torch_compile_kwargs}
 
     backend = ThunderCompiler(**thunder_jit_kwargs)
     compiled = torch.compile(fn, backend=backend, **torch_compile_kwargs)

--- a/thunder/dynamo/report.py
+++ b/thunder/dynamo/report.py
@@ -1134,17 +1134,10 @@ def get_thunder_fxgraph_reports(fn: Callable, stream: TextIO = sys.stdout, **com
     Returns:
         A function that takes *args, **kwargs and returns a list of ThunderFXGraphReport objects.
     """
-    from thunder.dynamo.utils import get_thunder_jit_kwargs, get_torch_compile_kwargs
+    from thunder.dynamo.utils import get_torch_compile_kwargs
 
-    thunder_jit_kwargs = get_thunder_jit_kwargs(**compile_kwargs)
     torch_compile_kwargs = get_torch_compile_kwargs(**compile_kwargs)
-    rest_kwargs = {
-        k: v for k, v in compile_kwargs.items() if k not in thunder_jit_kwargs and k not in torch_compile_kwargs
-    }
-    check(
-        not rest_kwargs,
-        lambda: f"There are kwargs that are not supported by either thunder.jit or torch.compile: {rest_kwargs}",
-    )
+    thunder_jit_kwargs = {k: v for k, v in compile_kwargs.items() if k not in torch_compile_kwargs}
 
     def inner_fn(*args, **kwargs):
         reports = fx_report(fn, **torch_compile_kwargs)(*args, **kwargs)
@@ -1304,15 +1297,8 @@ def thunderfx_benchmark_report(
 
     folder_path = Path(folder_path)
     folder_path.mkdir(exist_ok=True, parents=True)
-    thunder_jit_kwargs = get_thunder_jit_kwargs(**compile_kwargs)
     torch_compile_kwargs = get_torch_compile_kwargs(**compile_kwargs)
-    rest_kwargs = {
-        k: v for k, v in compile_kwargs.items() if k not in thunder_jit_kwargs and k not in torch_compile_kwargs
-    }
-    check(
-        not rest_kwargs,
-        lambda: f"There are compile_kwargs that are not supported by either thunder.jit or torch.compile: {rest_kwargs}",
-    )
+    thunder_jit_kwargs = {k: v for k, v in compile_kwargs.items() if k not in torch_compile_kwargs}
 
     def inner_fn(*args, **kwargs):
         if check_torch_runnablility:

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -1013,6 +1013,17 @@ def test_thunderfx():
     trc = last_traces(thunder_compiled_fns[-1])[-1]
     assert any(bsym.sym.id == "nvtx_range_push" for bsym in trc.bound_symbols)
 
+    def fn(x, w):
+        return x @ w
+
+    x = torch.randn(4, 4, device="cuda", requires_grad=True)
+    w = torch.randn(4, 4, device="cuda", requires_grad=True)
+    # Tests the compile_options in thunder.jit
+    cfn = thunderfx(fn, nv_enable_matmul=True)
+    cfn(x, w)
+    trc = cfn.last_traces[-1]
+    assert any(bsym.sym.name == "nvFusion0" for bsym in trc.bound_symbols)
+
 
 def test_thunderfx_last_traces():
     def foo(x):


### PR DESCRIPTION

<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes #1937.

For a user-friendly experience, thunderfx accepts `kwargs` that may include the kwargs from both `torch.compile` and `thunder.jit`. Since `thunder.jit` uses `**compile_options`, the current check is too tight. This PR updates to separate the kwargs from `torch.compile` options and passes all remaining kwargs directly to `thunder.jit`

