### PR TITLE
start check trace

### DIFF
--- a/thunder/dev_utils/check_trace.py
+++ b/thunder/dev_utils/check_trace.py
@@ -1,0 +1,31 @@
+def check_subsymbols(parent_bsym):
+    if parent_bsym.sym.is_prim:
+        # assert that there are no subsymbols?
+        return
+    known_proxies = {a.name: a for a in parent_bsym.flat_proxy_args}
+    for bsym in parent_bsym.subsymbols:
+        for a in bsym.flat_proxy_args:
+            assert a.name in known_proxies, f"unknown proxy {a.name} is used in {bsym}"
+            assert known_proxies[a.name] is a, f"proxy name collision {a.name} in {bsym}"
+        for o in bsym.flat_proxy_outs:
+            assert known_proxies.get(o.name, o) is o, f"known proxy or proxy name collision {a.name} in {bsym}"
+            known_proxies[o.name] = o
+        check_subsymbols(bsym)
+    for o in parent_bsym.flat_proxy_outs:
+        assert known_proxies.get(o.name, o) is o, f"known proxy or proxy name collision {a.name} in {parent_bsym}"
+
+
+def check_trace(trace):
+    """checks a trace for consistency"""
+    # TODO:
+    # - args vs. unpack trivial
+    # - args vs. flat_args in return
+    known_proxies = {}
+    for bsym in trace.bound_symbols:
+        for a in bsym.flat_proxy_args:
+            assert a.name in known_proxies, f"unknown proxy {a.name} is used in {bsym}"
+            assert known_proxies[a.name] is a, f"proxy name collision {a.name} in {bsym}"
+        for o in bsym.flat_proxy_outs:
+            assert known_proxies.get(o.name, o) is o, f"proxy name collision {a.name} in {bsym}"
+            known_proxies[o.name] = o
+        check_subsymbols(bsym)

--- a/thunder/tests/test_check_trace.py
+++ b/thunder/tests/test_check_trace.py
@@ -3,6 +3,7 @@ from thunder.dev_utils.check_trace import check_trace
 import torch
 import pytest
 
+
 def test_missing_symbol():
     def fn(a, b):
         c = a + b

--- a/thunder/tests/test_check_trace.py
+++ b/thunder/tests/test_check_trace.py
@@ -1,0 +1,25 @@
+import thunder
+from thunder.dev_utils.check_trace import check_trace
+import torch
+import pytest
+
+def test_missing_symbol():
+    def fn(a, b):
+        c = a + b
+        d = 2 * c
+        return d
+
+    jfn = thunder.jit(fn)
+
+    a = torch.randn(2, 2)
+    b = torch.randn(2, 2)
+
+    jfn(a, b)
+
+    tr = thunder.last_traces(jfn)[-1]
+    check_trace(tr)
+
+    del tr.bound_symbols[-3]
+
+    with pytest.raises(AssertionError, match="unknown proxy"):
+        check_trace(tr)


### PR DESCRIPTION
A start on a trace checker (see #1180 for context / ideas to extend)

A debug option would be nice, it could do any to all of
- do checks in the main transform loop (on the traces put in last_traces etc.),
- do checks in between inserted manually,
- do checks in from_trace on the input trace.