### PR TITLE
fix copy_with_setitem_grad to handle broadcasting correctly

### DIFF
--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -1425,9 +1425,9 @@ def _copy_with_setitem_grad(a: TensorProxy, index, value: Number | TensorProxy):
 
     if isinstance(value, TensorProxy):
         value_grad = g[index]
-        expanded_dims = value_grad.ndim - value.ndim
-        if expanded_dims > 0:
-            value_grad = prims.sum(value_grad, tuple(range(expanded_dims)))
+        # NOTE: `value` could be broadcasted.
+        if not utils.same_shape(value_grad.shape, value.shape):
+            value_grad = sum_to(value_grad, value.shape)
         put_grad(value, value_grad)
 
     return fwd

--- a/thunder/tests/test_ops.py
+++ b/thunder/tests/test_ops.py
@@ -289,6 +289,15 @@ def test_setitem(requires_grad):
         fn, torch.randn(5, requires_grad=requires_grad), torch.tensor(2.0, requires_grad=requires_grad)
     )
 
+    def bcast_fn(a, value):
+        a = clone_if_requires_grad(a)
+        a[..., :3] = value
+        return a * 2
+
+    _test_forward_and_backward(
+        bcast_fn, torch.randn(5, 3, 5, requires_grad=requires_grad), torch.randn(1, 3, requires_grad=requires_grad)
+    )
+
     # set value: tensor of same rank
     _test_forward_and_backward(
         fn, torch.randn(5, requires_grad=requires_grad), torch.tensor([1.0, 2.0, 3.0], requires_grad=requires_grad)


### PR DESCRIPTION
Fixes #1962 

Grad rule didn't handle broadcasting from unit-dims correctly, this PR fixes it.