### PR TITLE
add result to DebugTransform post callback

### DIFF
--- a/thunder/dev_utils/debug_transform.py
+++ b/thunder/dev_utils/debug_transform.py
@@ -24,7 +24,7 @@ class DebugTransform(thunder.core.transforms.Transform):
     """
     A transform for debugging purposes.
 
-    This class allows pre- and post-execution callbacks to be applied around bousdsymbols of a trace.
+    This transform applies pre- and post-execution callbacks around bound symbols of a trace.
 
     Args:
         pre_callback: An optional callable that is executed before each bound symbol is processed.

--- a/thunder/dev_utils/debug_transform.py
+++ b/thunder/dev_utils/debug_transform.py
@@ -31,7 +31,7 @@ class DebugTransform(thunder.core.transforms.Transform):
             It should have the signature ``(BoundSymbol, *args, **kwargs)`` and return a string. If :obj:`None`, no
             pre-execution callback is used.
         post_callback: An optional callable that is executed after each bound symbol is processed.
-            It should have the signature ``(BoundSymbol, output, *args, **kwargs)`` and return a string. If :obj:`None`, no
+            It should have the signature ``(BoundSymbol, output, /, *args, **kwargs)`` and return a string. If :obj:`None`, no
             post-execution callback is used.
     """
 

--- a/thunder/dev_utils/debug_transform.py
+++ b/thunder/dev_utils/debug_transform.py
@@ -14,7 +14,7 @@ def create_debug_boundsymbol(name: str, bsym: BoundSymbol, call_ctx: Callable, p
 
     debug_sym = Symbol(name, lambda *_, **__: None, is_prim=True, _bind_postprocess=bind_postprocess)
     if pass_result:
-        debug_bsym = debug_sym.bind(*bsym.args, output=None, result=bsym.output, **bsym.kwargs)
+        debug_bsym = debug_sym.bind(bsym.output, *bsym.args, output=None, **bsym.kwargs)
     else:
         debug_bsym = debug_sym.bind(*bsym.args, output=None, **bsym.kwargs)
     return debug_bsym
@@ -58,8 +58,8 @@ class DebugTransform(thunder.core.transforms.Transform):
 
             if self.post_callback is not None:
 
-                def _post_call_ctx(post_debug_bsym, bsym, *args, **kwargs):
-                    out = self.post_callback(bsym, *args, **kwargs)
+                def _post_call_ctx(post_debug_bsym, bsym, output, *args, **kwargs):
+                    out = self.post_callback(bsym, output, *args, **kwargs)
                     thunder.core.utils.check_type(out, str)
                     post_debug_bsym.header = out
 

--- a/thunder/dev_utils/debug_transform.py
+++ b/thunder/dev_utils/debug_transform.py
@@ -25,7 +25,7 @@ class DebugTransform(thunder.core.transforms.Transform):
     A transform for debugging purposes.
 
     This class allows pre- and post-execution callbacks to be applied around bousdsymbols of a trace.
-    
+
     Args:
         pre_callback: An optional callable that is executed before each bound symbol is processed.
             It should have the signature ``(BoundSymbol, *args, **kwargs)`` and return a string. If :obj:`None`, no
@@ -34,6 +34,7 @@ class DebugTransform(thunder.core.transforms.Transform):
             It should have the signature ``(BoundSymbol, output, *args, **kwargs)`` and return a string. If :obj:`None`, no
             post-execution callback is used.
     """
+
     def __init__(
         self,
         *,

--- a/thunder/dev_utils/debug_transform.py
+++ b/thunder/dev_utils/debug_transform.py
@@ -21,6 +21,19 @@ def create_debug_boundsymbol(name: str, bsym: BoundSymbol, call_ctx: Callable, p
 
 
 class DebugTransform(thunder.core.transforms.Transform):
+    """
+    A transform for debugging purposes.
+
+    This class allows pre- and post-execution callbacks to be applied around bousdsymbols of a trace.
+    
+    Args:
+        pre_callback: An optional callable that is executed before each bound symbol is processed.
+            It should have the signature ``(BoundSymbol, *args, **kwargs)`` and return a string. If :obj:`None`, no
+            pre-execution callback is used.
+        post_callback: An optional callable that is executed after each bound symbol is processed.
+            It should have the signature ``(BoundSymbol, output, *args, **kwargs)`` and return a string. If :obj:`None`, no
+            post-execution callback is used.
+    """
     def __init__(
         self,
         *,

--- a/thunder/tests/test_transforms.py
+++ b/thunder/tests/test_transforms.py
@@ -252,7 +252,7 @@ def test_debug_transform():
     def pre_callback(bsym, *args, **kwargs):
         return f"Pre - {bsym.sym.name}"
 
-    def post_callback(bsym, *args, **kwargs):
+    def post_callback(bsym, output, *args, **kwargs):
         return f"Post - {bsym.sym.name}"
 
     jfn = debug_execution_trace(thunder.jit(fn), pre_callback=pre_callback, post_callback=post_callback)


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

before:
```
  debug_pre_mul1(y, y)

  # /teamspace/studios/this_studio/main.py:12:          return (x + y * y) / x
  t6 = torch.mul(y, y)  # t6: "cpu f32[3, 3]"
    # t6 = ltorch.mul(y, y)  # t6: "cpu f32[3, 3]"
      # t6 = prims.mul(y, y)  # t6: "cpu f32[3, 3]"
  # Post - mul
  debug_post_mul1(y, y)
```

after:
```
  debug_pre_mul1(y, y)

  # /teamspace/studios/this_studio/main.py:12:          return (x + y * y) / x
  t6 = torch.mul(y, y)  # t6: "cpu f32[3, 3]"
    # t6 = ltorch.mul(y, y)  # t6: "cpu f32[3, 3]"
      # t6 = prims.mul(y, y)  # t6: "cpu f32[3, 3]"
  # Post - mul
  debug_post_mul1(t6, y, y)
```

added `result` kwarg to the`post_callback` which passes the bsym outputs

https://github.com/Lightning-AI/lightning-thunder/issues/1996

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
