### PR TITLE
Better error message for not implemented inplace

### DIFF
--- a/thunder/core/functionalization.py
+++ b/thunder/core/functionalization.py
@@ -100,8 +100,9 @@ def check_inplace_to_views(computation_trace: Trace) -> dict[VariableInterface, 
         check(
             orig_tensor.numel == in_tensor.numel,
             lambda: (
-                f"in-place op of `{bsym.sym.id}` to `{in_tensor}`, a view tensor of "
-                f"`{orig_tensor}` is not supported because {in_tensor.numel} != {orig_tensor.numel}"
+                "Thunder does not yet support in-place operations of Tensors that are views of a "
+                f"larger Tensor (such as slices). Please modify usage of `{bsym.sym.id}` "
+                f"({bsym.source_filename}:{bsym.source_positions.lineno})."
             ),
             NotImplementedError,
         )

--- a/thunder/tests/test_inplace_functionalization.py
+++ b/thunder/tests/test_inplace_functionalization.py
@@ -305,7 +305,7 @@ def test_error_of_inplace_to_views(executor, device, _):
         return c, d, e
 
     jitted_f = executor.make_callable(f)
-    with pytest.raises(NotImplementedError, match="in-place op of `torch.Tensor.mul_`"):
+    with pytest.raises(NotImplementedError, match="Please modify usage of `torch.Tensor.mul_`"):
         _ = jitted_f(a, b)
 
 


### PR DESCRIPTION
Fixes #1985. New error message:
```
NotImplementedError: Thunder does not yet support in-place operations of Tensors that are views of a larger Tensor (such as slices). Please modify usage of `torch.zero_` (/Users/liana/thunder/test.py:6).
```