### PR TITLE
Forward to original fn when `thunder.examine.examine` called on jitted function

### DIFF
--- a/thunder/examine/__init__.py
+++ b/thunder/examine/__init__.py
@@ -66,13 +66,15 @@ def examine(fn: Callable, *args, show_call_stack: bool | int = False, **kwargs):
             f"examine: expected `fn` to be a callable instead received {type(fn)}. Use `examine(fn, *args, **kwargs)` to test `fn(*args, **kwargs)`"
         )
         return
-    elif hasattr(fn, "_lc_cd"): # `fn` has been jitted with Thunder
+    elif hasattr(fn, "_lc_cd"):  # `fn` has been jitted with Thunder
         compile_data = getattr(fn, "_lc_cd", None)
-        if hasattr(compile_data, "fn"): # get original, non-jitted function for use with `examine`
+        if hasattr(compile_data, "fn"):  # get original, non-jitted function for use with `examine`
             original_fn = getattr(compile_data, "fn", None)
             fn = original_fn
-        else: # should not reach
-            print("examine: expected `fn` to have not been compiled. Please use `examine` with original, non-jitted function.")
+        else:  # should not reach
+            print(
+                "examine: expected `fn` to have not been compiled. Please use `examine` with original, non-jitted function."
+            )
 
     with CollectFunctionsUsed(collected_ops):
         try:

--- a/thunder/examine/__init__.py
+++ b/thunder/examine/__init__.py
@@ -66,6 +66,13 @@ def examine(fn: Callable, *args, show_call_stack: bool | int = False, **kwargs):
             f"examine: expected `fn` to be a callable instead received {type(fn)}. Use `examine(fn, *args, **kwargs)` to test `fn(*args, **kwargs)`"
         )
         return
+    elif hasattr(fn, "_lc_cd"): # `fn` has been jitted with Thunder
+        compile_data = getattr(fn, "_lc_cd", None)
+        if hasattr(compile_data, "fn"): # get original, non-jitted function for use with `examine`
+            original_fn = getattr(compile_data, "fn", None)
+            fn = original_fn
+        else: # should not reach
+            print("examine: expected `fn` to have not been compiled. Please use `examine` with original, non-jitted function.")
 
     with CollectFunctionsUsed(collected_ops):
         try:

--- a/thunder/tests/test_examine.py
+++ b/thunder/tests/test_examine.py
@@ -1,0 +1,25 @@
+import thunder.examine
+import torch
+import pytest
+
+def test_examine_fn():
+    def foo(x):
+        x[0] = 5 * x[1]
+
+    x = torch.ones(2, 2)
+    thunder.examine.examine(foo, x)
+
+def test_examine_jfn():
+    def foo(x):
+        x[0] = 5 * x[1]
+
+    jfoo = thunder.compile(foo)
+    x = torch.ones(2, 2)
+    thunder.examine.examine(jfoo, x)
+
+def test_examine_noncallable(capsys):
+    x = torch.ones(2, 2)
+    y = torch.ones(2, 2)
+    thunder.examine.examine(x, y)
+    captured = capsys.readouterr()
+    assert "expected `fn` to be a callable" in captured.out 

--- a/thunder/tests/test_examine.py
+++ b/thunder/tests/test_examine.py
@@ -2,12 +2,14 @@ import thunder.examine
 import torch
 import pytest
 
+
 def test_examine_fn():
     def foo(x):
         x[0] = 5 * x[1]
 
     x = torch.ones(2, 2)
     thunder.examine.examine(foo, x)
+
 
 def test_examine_jfn():
     def foo(x):
@@ -17,9 +19,10 @@ def test_examine_jfn():
     x = torch.ones(2, 2)
     thunder.examine.examine(jfoo, x)
 
+
 def test_examine_noncallable(capsys):
     x = torch.ones(2, 2)
     y = torch.ones(2, 2)
     thunder.examine.examine(x, y)
     captured = capsys.readouterr()
-    assert "expected `fn` to be a callable" in captured.out 
+    assert "expected `fn` to be a callable" in captured.out


### PR DESCRIPTION
Fixes #1986, adds basic tests for `thunder.examine.examine`.
