### PR TITLE
nicer printing of Enum objects

### DIFF
--- a/thunder/core/trace.py
+++ b/thunder/core/trace.py
@@ -4,6 +4,7 @@ from contextvars import ContextVar
 from contextlib import contextmanager
 import pathlib
 from typing import Optional, Any, Tuple, Type, Dict, List, Union
+from enum import Enum
 from collections.abc import Callable
 from collections.abc import Sequence, Hashable
 import string
@@ -188,6 +189,8 @@ class TraceCtx:
                 self.obj_name_ctr += 1
                 if obj is None:
                     name = f"_object_{name}"
+                elif isinstance(obj, Enum):
+                    name = f"_{baseutils.print_type(type(obj), with_quotes=False)}_{obj.name}"
                 else:
                     name = f"_{baseutils.print_type(type(obj), with_quotes=False)}_{name}"
             else:

--- a/thunder/core/trace.py
+++ b/thunder/core/trace.py
@@ -190,7 +190,8 @@ class TraceCtx:
                 if obj is None:
                     name = f"_object_{name}"
                 elif isinstance(obj, Enum):
-                    name = f"_{baseutils.print_type(type(obj), with_quotes=False)}_{obj.name}"
+                    # even though it should be unique, we need to do the counter suffix for technical problems
+                    name = f"_{baseutils.print_type(type(obj), with_quotes=False)}_{obj.name}_{name}"
                 else:
                     name = f"_{baseutils.print_type(type(obj), with_quotes=False)}_{name}"
             else:

--- a/thunder/tests/test_core.py
+++ b/thunder/tests/test_core.py
@@ -3279,3 +3279,21 @@ def test_prims_pack_list():
     expected = [a, b]
 
     assert isinstance(actual, list) and actual == expected
+
+
+def test_enum_printing():
+    from enum import Enum
+
+    def fn():
+        pass
+
+    class A(Enum):
+        VALUE = 1
+
+    trc = thunder.TraceCtx(fn)
+    with thunder.core.trace.tracectx(trc):
+        thunder.core.prims.python_return(A.VALUE)
+
+    # the important bit here is that A_VALUE is there, so we can see
+    # the enum constant's value
+    assert "return _A_VALUE" in str(trc)


### PR DESCRIPTION
While debugging composable FSDP + DDP, I wanted to see the DistParallelType enum value.

Trace refencing an Enum A's VALUE before this PR:
```
def fn():
  return _A_0
```

Trace after this PR:
```
def fn():
  return _A_VALUE_0
```