### PR TITLE
[thunderfx report]: Fixes the check_metrics when there's no backward

### DIFF
--- a/thunder/dynamo/benchmark_utils.py
+++ b/thunder/dynamo/benchmark_utils.py
@@ -504,6 +504,9 @@ def check_metrics(
     memory_record = False
     log_strs = ""
     for m1, m2, name in zip(measure1, measure2, ("forward", "backward")):
+        if m1 is None:
+            assert m2 is None
+            continue
         if timer_fn.name == "WallTimeWithMemoryUsage":
             memory_ret = check_memory_usage(
                 m1.max_allocated_memory,

--- a/thunder/dynamo/benchmark_utils.py
+++ b/thunder/dynamo/benchmark_utils.py
@@ -7,6 +7,7 @@ import torch
 from torch.utils.benchmark import Timer as TorchBenchmarkTimer
 from torch.profiler import profile, ProfilerActivity
 from thunder.dynamo.utils import thunder_options_to_str
+from thunder.core.utils import check
 from torch.utils.benchmark.utils.common import select_unit as select_time_unit
 
 if TYPE_CHECKING:
@@ -504,8 +505,11 @@ def check_metrics(
     memory_record = False
     log_strs = ""
     for m1, m2, name in zip(measure1, measure2, ("forward", "backward")):
+        check(
+            (m1 is None) == (m2 is None),
+            f"{name} measurement for the two compilation methods should either both be None or both not None, but got {m1} and {m2}",
+        )
         if m1 is None:
-            assert m2 is None
             continue
         if timer_fn.name == "WallTimeWithMemoryUsage":
             memory_ret = check_memory_usage(

--- a/thunder/dynamo/report.py
+++ b/thunder/dynamo/report.py
@@ -1351,4 +1351,6 @@ def save_failing_repros(
             report.run_repro(compile_fn, check_consistency)
         except Exception as e:
             comment = f"Failed to run the function using {compile_fn.name} with exception: {e}"
-            report.write_repro(repros_folder, compile_fn, extra_comment_str=comment)
+            report.write_repro(
+                repros_folder, compile_fn, extra_comment_str=comment, check_consistency=check_consistency
+            )


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

When no backward execution occurs, the measurement is None. This PR fixes the issue by properly checking for None before using the measurement.

P.S.: This check was mistakenly removed in [this PR](https://github.com/Lightning-AI/lightning-thunder/pull/1813). I'm adding it back.

