### PR TITLE
switch sphinxcontrib fulltoc to cleaned setup.cfg version

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -4,7 +4,7 @@ nbsphinx ~=0.9.7
 ipython[all] ~=8.36.0
 pandoc ==2.4
 docutils >=0.16
-sphinxcontrib-fulltoc @ https://github.com/t-vi/sphinx-contrib-fulltoc/archive/master.zip
+sphinxcontrib-fulltoc @ git+https://github.com/t-vi/sphinx-contrib-fulltoc@master
 sphinxcontrib-mockautodoc
 
 sphinx-autodoc-typehints ==1.23.0

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -4,7 +4,7 @@ nbsphinx ~=0.9.7
 ipython[all] ~=8.36.0
 pandoc ==2.4
 docutils >=0.16
-sphinxcontrib-fulltoc ==1.2.0
+sphinxcontrib-fulltoc @ https://github.com/t-vi/sphinx-contrib-fulltoc/archive/master.zip
 sphinxcontrib-mockautodoc
 
 sphinx-autodoc-typehints ==1.23.0


### PR DESCRIPTION
seems to be needed for CI (https://bugs.launchpad.net/pbr/+bug/2109910)