### PR TITLE
[ThunderFX] Falls back to inductor when the fwd+bwd of a Node fails

### DIFF
--- a/thunder/core/pytree.py
+++ b/thunder/core/pytree.py
@@ -23,6 +23,14 @@ optree.register_pytree_node(
 
 
 optree.register_pytree_node(
+    torch.fx.immutable_collections.immutable_list,
+    lambda l: (list(l), None, None),
+    lambda _, children: tuple(children),
+    namespace=OPTREE_NAMESPACE,
+)
+
+
+optree.register_pytree_node(
     slice,
     lambda s: ([s.start, s.stop, s.step], None, None),
     lambda _, children: slice(*children),

--- a/thunder/core/pytree.py
+++ b/thunder/core/pytree.py
@@ -4,6 +4,7 @@ import dataclasses
 
 import optree
 import torch
+from torch.fx.immutable_collections import immutable_list
 import thunder.core.dtypes as dtypes
 import thunder.core.devices as devices
 from thunder.core.baseutils import ProxyInterface, is_likely_from_collections_namedtuple
@@ -23,9 +24,9 @@ optree.register_pytree_node(
 
 
 optree.register_pytree_node(
-    torch.fx.immutable_collections.immutable_list,
+    immutable_list,
     lambda l: (list(l), None, None),
-    lambda _, children: tuple(children),
+    lambda _, children: immutable_list(children),
     namespace=OPTREE_NAMESPACE,
 )
 
@@ -67,6 +68,7 @@ def tree_flatten(args, namespace=OPTREE_NAMESPACE):
             torch._subclasses.fake_tensor.FakeTensor,
             torch.device,
             torch.autograd.function.FunctionCtx,
+            immutable_list,
         }
         and not isinstance(args, (ProxyInterface))
         and not is_likely_from_collections_namedtuple(args)

--- a/thunder/dynamo/utils.py
+++ b/thunder/dynamo/utils.py
@@ -270,10 +270,10 @@ def try_execute_thunder_symbol(thunder_symbol: Symbol, node: torch.fx.Node) -> t
             return False
 
         example_value = arg_node.meta["example_value"]
-        if isinstance(example_value, torch.Tensor):
-            return example_value.requires_grad
-        elif isinstance(example_value, Sequence):
-            return any(x.requires_grad for x in example_value)
+        flattened_example_value, _ = tree_flatten(example_value)
+        for x in flattened_example_value:
+            if isinstance(x, torch.Tensor) and x.requires_grad:
+                return True
         return False
 
     args, _ = tree_flatten((node.args, node.kwargs))

--- a/thunder/dynamo/utils.py
+++ b/thunder/dynamo/utils.py
@@ -254,6 +254,7 @@ def try_execute_thunder_symbol(thunder_symbol: Symbol, node: torch.fx.Node) -> t
     from thunder.core.trace import TraceCtx
     from thunder.core.compile_data import compile_data_and_stats
     from thunder.common import CompileData, CompileStats
+    from thunder.core.transforms import value_and_grad
 
     # This is required for verifying `_enter_autocast`
     # which pushes state onto `CompileData.autocast_stack`.
@@ -285,8 +286,9 @@ def try_execute_thunder_symbol(thunder_symbol: Symbol, node: torch.fx.Node) -> t
         # We need to be under trace context to generate proxies.
         with thunder.core.trace.tracectx(TraceCtx()):
             try:
-                thunder_symbol(*proxy_args, **proxy_kwargs)
+                value_and_grad(thunder_symbol)(*proxy_args, **proxy_kwargs)
             except Exception as e:
+                print(f"DEBUG: {e}")
                 return False, SplitReason(
                     SplitReasonType.EXCEPTION_META_THUNDER_OP,
                     f"Failed while running meta for node with name: {node.name} and target: {node.target}, see exception field",

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -1576,3 +1576,24 @@ def test_aot_optimize():
 
     with pytest.raises(AssertionError, match="No longer profiling"):
         pfoo(x)
+
+
+def test_spliter_bwd():
+    def fn(x, idx, val):
+        x = x.clone()
+        x[idx] = val
+        return x
+
+    x = torch.randn(1, 4, 5, dtype=torch.bfloat16, requires_grad=True)
+    idx = torch.rand(1, 4, 5) > 0.5
+    nz = torch.count_nonzero(idx)
+    val = torch.randn(nz, dtype=torch.bfloat16, requires_grad=True)
+
+    cfn = thunderfx(fn)
+    cfn(x, idx, val)
+    reason = cfn._backend.subgraph_infos[0].split_reasons
+    assert len(reason) == 1
+    assert "Failed while running meta for node with name: setitem" in reason[0].info
+    assert "Advanced indexing" in reason[0].exception and reason[0].exception.endswith(
+        "found a tensor with dtype thunder.dtypes.bool8 and 3 dimensions"
+    )


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes #2036.

As mentioned in #2036, this PR extends the check in the splitter to determine whether a FX Node is supported by Thunder. It does so by running a forward and backward pass using `value_and_grad(thunder_symbol)(*proxy_args, **proxy_kwargs)` if any of the Node’s inputs have `requires_grad=True`; otherwise, it runs just the forward pass via `thunder_symbol(*proxy_args, **proxy_kwargs)`.
