### PR TITLE
Remove unused imports from `test_networks.py`

### DIFF
--- a/thunder/tests/test_networks.py
+++ b/thunder/tests/test_networks.py
@@ -1,5 +1,4 @@
 import math
-from dataclasses import dataclass
 from functools import partial
 import warnings
 

--- a/thunder/tests/test_networks.py
+++ b/thunder/tests/test_networks.py
@@ -5,8 +5,6 @@ import warnings
 
 import pytest
 import torch
-import torch.nn as nn
-import torch.nn.functional as F
 from torch.testing import assert_close, make_tensor
 
 import thunder


### PR DESCRIPTION
## What does this PR do?

removed:
- `dataclasses`
- `torch.nn`
- `torch.nn.functional`