### PR TITLE
avoid calling transform when checker explicitly rejects symbol

### DIFF
--- a/thunder/executors/passes.py
+++ b/thunder/executors/passes.py
@@ -56,7 +56,7 @@ def _transform_for_operator_executor_execution(trace: TraceCtx, executors_list: 
                 if (isinstance(ex, OperatorExecutor) and ex.can_execute(bsym)) or (
                     isinstance(ex, FusionExecutor) and ex.can_fuse(bsym)
                 ):
-                    execution_transform: None | Callable = ex.get_execution_transform(bsym.sym)
+                    execution_transform: None | Callable = ex.get_execution_transform(bsym)
                     if execution_transform is not None:
                         self.add_bsyms_from_function(execution_transform, *bsym.args, **bsym.kwargs)
                         return

--- a/thunder/extend/__init__.py
+++ b/thunder/extend/__init__.py
@@ -118,10 +118,15 @@ class Executor:
 
         return True
 
-    def get_execution_transform(self, sym: Symbol) -> None | Callable:
+    def get_execution_transform(self, bsym: BoundSymbol) -> None | Callable:
+        sym = bsym.sym
+
         impl: None | ImplInfo = self.implmap.get(sym.id, None)
 
         if impl is None:
+            return None
+
+        if not (impl.checker is None or impl.checker(*bsym.args, **bsym.kwargs)):
             return None
 
         return impl.execution_transform


### PR DESCRIPTION
The existing logic isn't right.

When calling `can_fuse`, we could have a scenario where all subsymbol is executable.
For which case, if the registered op has an explicit checker to reject it, we should avoid kicking in the transformation, which might rely on assumption checked in the checker.