### PR TITLE
removing nv_enable_embedding

### DIFF
--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -2681,8 +2681,8 @@ def _embedding_check(
     if nvfuser_version() < LooseVersion("0.2.25"):
         return False
     enable_embedding: None | bool = get_compile_option("nv_enable_embedding", "Enable nvFuser embedding.")
-    if not enable_embedding:
-        return False
+    if enable_embedding is not None:
+        warnings.warn("nv_enable_embedding is no longer used. embedding through nvfuserex is enabled by default, option nv_enable_embedding is ignored")
     # Verify input and weight are supported tensors.
     if not are_supported_tensors(input, weight) or (weight.ndim != 2):
         return False

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -2682,7 +2682,9 @@ def _embedding_check(
         return False
     enable_embedding: None | bool = get_compile_option("nv_enable_embedding", "Enable nvFuser embedding.")
     if enable_embedding is not None:
-        warnings.warn("nv_enable_embedding is no longer used. embedding through nvfuserex is enabled by default, option nv_enable_embedding is ignored")
+        warnings.warn(
+            "nv_enable_embedding is no longer used. embedding through nvfuserex is enabled by default, option nv_enable_embedding is ignored"
+        )
     # Verify input and weight are supported tensors.
     if not are_supported_tensors(input, weight) or (weight.ndim != 2):
         return False

--- a/thunder/tests/test_nvfuser.py
+++ b/thunder/tests/test_nvfuser.py
@@ -1183,7 +1183,7 @@ def test_embedding(
         return torch.nn.functional.embedding(*inputs)
 
     for sample in embedding_opinfo.sample_inputs(device, dtype):
-        compiled_func = thunder.jit(embedding_fn, executors_list=executor.executors_list(), nv_enable_embedding=True)
+        compiled_func = thunder.jit(embedding_fn, executors_list=executor.executors_list())
         out = compiled_func(sample.args)
         expected_out = torch.nn.functional.embedding(*sample.args)
         fwd_trace = thunder.last_traces(compiled_func)[-1]


### PR DESCRIPTION
nvfuser embedding fwd support has been improved to match / outperform other backends. Hence switch to enable it by default.