### PR TITLE
Raises error when the input of fx_report is thunder-compiled function

### DIFF
--- a/thunder/dynamo/report.py
+++ b/thunder/dynamo/report.py
@@ -41,7 +41,7 @@ from thunder.dynamo.repro_script_template import (
     CALLABLE_NAME,
     COMPILED_CALLABLE_NAME,
 )
-from thunder import last_traces, last_backward_traces
+from thunder import last_traces, last_backward_traces, compile_stats
 from thunder.benchmarks.utils import backward_only
 from thunder.dynamo.benchmark_utils import (
     TorchCompileSpecification,
@@ -692,6 +692,11 @@ def fx_report(fn: Callable, **torch_compile_kwargs) -> Callable[..., FXReport]:
                 )
                 graph_report.write_benchmark(tmpdir, my_thunderjit, WallTime, file_name=f"{graph_name}_mythunder_benchmark.py")
     """
+    cs = compile_stats(fn)
+    if cs is not None:
+        raise ValueError(
+            "fx_report requires the original (uncompiled) callable and cannot be used on the Thunder-compiled function."
+        )
     graphs = []
     break_reasons = []
 

--- a/thunder/dynamo/report.py
+++ b/thunder/dynamo/report.py
@@ -692,8 +692,7 @@ def fx_report(fn: Callable, **torch_compile_kwargs) -> Callable[..., FXReport]:
                 )
                 graph_report.write_benchmark(tmpdir, my_thunderjit, WallTime, file_name=f"{graph_name}_mythunder_benchmark.py")
     """
-    cs = compile_stats(fn)
-    if cs is not None:
+    if compile_stats(fn) is not None:
         raise ValueError(
             "fx_report requires the original (uncompiled) callable and cannot be used on the Thunder-compiled function."
         )

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -1169,6 +1169,14 @@ def test_fxreport(executor, device: str, dtype: dtypes.dtype, use_benchmark, tmp
     def foo(x, y):
         return x + y
 
+    from thunder import jit
+
+    with pytest.raises(
+        ValueError,
+        match=r"fx_report requires the original \(uncompiled\) callable and cannot be used on the Thunder-compiled function.",
+    ):
+        fx_report(jit(foo))
+
     x = torch.randn(4, 4, device=device, requires_grad=True)
     y = torch.randn(4, 4, device=device, requires_grad=True)
     results = fx_report(foo, dynamic=True)(x, y)


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes #2002.

