### PR TITLE
Fix torch.compile base recipe

### DIFF
--- a/thunder/recipes/base.py
+++ b/thunder/recipes/base.py
@@ -34,7 +34,7 @@ class BaseRecipe(Recipe):
         if self.fuser == "nvfuser":
             return executors
         elif self.fuser == "torch.compile":
-            executors = [el for el in executors if el.name not in ["torchcompile_cat", "nvfuser"]]
+            executors = [el for el in executors if el.name not in ["torchcompile_xentropy", "nvfuser"]]
             executors.append(torch_compile_ex)
             return executors
 


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes the base recipe for torch.compile, which did not work due to having two torch.compile executors (`thunder.executors.torch_compile.TorchCompileExecutor('torchcompile_xentropy')` and `thunder.executors.torch_compile.TorchCompileExecutor('torchcompile')`). see https://github.com/Lightning-AI/lightning-thunder/issues/2063

Also, torchcompile_cat is not in the default executors so it should be removed from the recipe.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
