### PR TITLE
Add parity check of shape/dtype/device of runtime and trace

### DIFF
--- a/thunder/tests/conftest.py
+++ b/thunder/tests/conftest.py
@@ -1,5 +1,4 @@
 import pytest
-from collections import defaultdict
 import pytest_benchmark
 from thunder.dynamo.compiler_graph_benchmark import GRAPH_BY_GRAPH_BENCHMARK_PARAMS_KEYS
 
@@ -37,3 +36,7 @@ def pytest_benchmark_group_stats(config, benchmarks, group_by):
 
     result = pytest_benchmark.plugin.pytest_benchmark_group_stats(config, benchmarks, group_by)
     outcome.force_result(result)
+
+
+def pytest_collection_modifyitems(items):
+    items.sort(key=lambda item: item.name)

--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -2383,7 +2383,7 @@ floor_divide_opinfo = OpInfo(
             pytest.mark.xfail(strict=True),
             "test_core_vs_torch_consistency",
             dtypes=datatypes.float_math_dtypes,
-        )
+        ),
     ),
 )
 elementwise_binary_ops.append(floor_divide_opinfo)
@@ -3739,7 +3739,7 @@ diagonal_opinfo = OpInfo(
         DecorateInfo(
             pytest.mark.xfail(strict=True),
             "test_core_vs_torch_consistency",
-        )
+        ),
     ),
 )
 shape_ops.append(diagonal_opinfo)
@@ -3946,7 +3946,7 @@ unfold_opinfo = OpInfo(
             pytest.mark.xfail(strict=True),
             "test_core_vs_torch_consistency",
         ),
-    )
+    ),
 )
 
 shape_ops.append(unfold_opinfo)
@@ -4235,7 +4235,7 @@ getitem_opinfo = OpInfo(
         DecorateInfo(
             pytest.mark.xfail(strict=True),
             "test_core_vs_torch_consistency",
-        )
+        ),
     ),
 )
 shape_ops.append(getitem_opinfo)

--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -2309,6 +2309,15 @@ copysign_opinfo = OpInfo(
             pytest.mark.xfail,
             "test_vjp_correctness",
         ),
+        # TODO(crcrpar): [Fix runtime-trace shape/dtype/device mismatch]
+        # In https://github.com/Lightning-AI/lightning-thunder/pull/2069,
+        # torch-consistency test checks the parity of shape/dtype/device
+        # between runtime and trace. This needs to be a temporary decorator
+        # and we are working on resolving the mismatches.
+        DecorateInfo(
+            pytest.mark.xfail(strict=True),
+            "test_core_vs_torch_consistency",
+        ),
     ),
 )
 elementwise_binary_ops.append(copysign_opinfo)
@@ -2369,6 +2378,12 @@ floor_divide_opinfo = OpInfo(
             "test_core_vs_torch_consistency",
             dtypes=(datatypes.bool8,),
         ),
+        # See [Fix runtime-trace shape/dtype/device mismatch]
+        DecorateInfo(
+            pytest.mark.xfail(strict=True),
+            "test_core_vs_torch_consistency",
+            dtypes=datatypes.float_math_dtypes,
+        )
     ),
 )
 elementwise_binary_ops.append(floor_divide_opinfo)
@@ -3720,6 +3735,11 @@ diagonal_opinfo = OpInfo(
         # thunder.torch.diagonal meta function is not correctly implemented for
         # input case ((1, 2, 0, 3), -1, 0, -1)
         DecorateInfo(pytest.mark.xfail(strict=True), "test_vjp_correctness"),
+        # See: [Fix runtime-trace shape/dtype/device mismatch]
+        DecorateInfo(
+            pytest.mark.xfail(strict=True),
+            "test_core_vs_torch_consistency",
+        )
     ),
 )
 shape_ops.append(diagonal_opinfo)
@@ -3920,6 +3940,13 @@ unfold_opinfo = OpInfo(
     sample_input_generator=unfold_sample_generator,
     error_input_generator=unfold_error_generator,
     torch_reference=torch.Tensor.unfold,
+    test_directives=(
+        # See [Fix runtime-trace shape/dtype/device mismatch]
+        DecorateInfo(
+            pytest.mark.xfail(strict=True),
+            "test_core_vs_torch_consistency",
+        ),
+    )
 )
 
 shape_ops.append(unfold_opinfo)
@@ -4204,6 +4231,11 @@ getitem_opinfo = OpInfo(
             pytest.mark.xfail,
             "test_vjp_correctness",
         ),
+        # See [Fix runtime-trace shape/dtype/device mismatch]
+        DecorateInfo(
+            pytest.mark.xfail(strict=True),
+            "test_core_vs_torch_consistency",
+        )
     ),
 )
 shape_ops.append(getitem_opinfo)


### PR DESCRIPTION
## What does this PR do?

Adding a check of the consistency aforementioned in the title.

related:
- https://github.com/Lightning-AI/lightning-thunder/issues/2068
- https://github.com/Lightning-AI/lightning-thunder/issues/1983
- https://github.com/Lightning-AI/lightning-thunder/issues/1952