### PR TITLE
move header printing to outside python_printer

### DIFF
--- a/thunder/core/symbol.py
+++ b/thunder/core/symbol.py
@@ -96,15 +96,6 @@ def default_python_printer(
 
     s = f"{result_str}{bsym.name_with_module()}({arg_str}{', ' if (len(arg_str) > 0 and len(kwarg_str) > 0) else ''}{kwarg_str}){comment_str}"
 
-    if bsym.header:
-        header_lines = (
-            bsym.header
-            if isinstance(bsym.header, Sequence) and not isinstance(bsym.header, str)
-            else bsym.header.splitlines()
-        )
-        header_lines = (f"# {line}" for line in header_lines)
-        return chain(header_lines, [s])
-
     return s
 
 
@@ -674,6 +665,18 @@ class BoundSymbol(BoundSymbolInterface):
         lines = []
 
         s = self.sym.python_printer(self, self._out_printables, self._arg_printables, self._kwarg_printables)
+
+        if self.header:
+            if isinstance(s, str):
+                s = [s]
+
+            header_lines = (
+                self.header
+                if isinstance(self.header, Sequence) and not isinstance(self.header, str)
+                else self.header.splitlines()
+            )
+            header_lines = (f"# {line}" for line in header_lines)
+            s = chain(header_lines, s)
 
         comment = "# " if commented else ""
 

--- a/thunder/tests/test_core.py
+++ b/thunder/tests/test_core.py
@@ -1378,7 +1378,8 @@ def test_bound_symbol_header_context(executor, device: str, dtype: dtypes.dtype)
     assert sin_symbol.sym.name == "sin"
     assert "# Testing\n# This symbol's\n# Header\nt0 = prims.sin(x)" in str(sin_symbol)
     assert "\n  # Testing\n  # This symbol's\n  # Header\n  t0 = prims.sin(x)" in str(trace)
-    assert str(trace).count("Testing") == 1
+    # the unbind, the sin and the return all have the header
+    assert str(trace).count("Testing") == 3
 
 
 # Check to verify the issue in "KeyError thrown in thunder.executor.utils.Region


### PR DESCRIPTION
This lets thunder print headers also for symbols that bring their own printer.