### PR TITLE
Change default recipes to have non optional executors argument

### DIFF
--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -304,8 +304,12 @@ def compile(
         recipe = thunder.recipes.BaseRecipe(executors=default_executor_names)
 
     if recipe is not None and plugins:
-        if recipe not in thunder.recipes.get_recipes():
-            raise ValueError(f"Recipe {recipe} not recognized. Available recipes are {thunder.recipes.get_recipes()}.")
+        valid_classes = set(thunder.recipes.names_to_recipes.values())
+        if type(recipe) not in valid_classes:
+            raise ValueError(
+                f"Recipe {type(recipe).__name__} not recognized. "
+                f"Available recipes: {list(thunder.recipes.names_to_recipes.keys())}"
+            )
         recipe.add_plugins(plugins)
 
     return recipe.apply(fn)

--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -304,8 +304,8 @@ def compile(
         recipe = thunder.recipes.BaseRecipe(executors=default_executor_names)
 
     if recipe is not None and plugins:
-        if not isinstance(recipe, BaseRecipe):
-            raise TypeError(f"`recipe` must be an instance of BaseRecipe, got {type(recipe).__name__}")
+        if recipe not in thunder.recipes.get_recipes():
+            raise ValueError(f"Recipe {recipe} not recognized. Available recipes are {thunder.recipes.get_recipes()}.")
         recipe.add_plugins(plugins)
 
     return recipe.apply(fn)

--- a/thunder/core/recipe.py
+++ b/thunder/core/recipe.py
@@ -6,7 +6,7 @@ import warnings
 import torch
 
 from thunder.core.transform_common import Transform
-from thunder.extend import Executor, get_default_executors
+from thunder.extend import Executor, get_all_executors
 
 
 @contextmanager
@@ -80,7 +80,7 @@ class Recipe:
         return None
 
     def setup_executors(self) -> list[Executor]:
-        return list(get_default_executors())
+        return list(get_all_executors())
 
     def setup_config(self) -> dict[str, Any]:
         return {}

--- a/thunder/recipes/base.py
+++ b/thunder/recipes/base.py
@@ -1,5 +1,6 @@
 from thunder import Recipe, Plugin, DebugOptions, Transform, Executor
 from thunder.core.recipe import Interpreter
+from thunder.executors import nvfuser_available
 from thunder.executors.torch_compile import torch_compile_ex
 from thunder.transforms.prune_prologue_checks import PrunePrologueChecks
 
@@ -9,13 +10,15 @@ from typing import Any
 class BaseRecipe(Recipe):
     def __init__(
         self,
+        executors,
         show_progress=False,
-        fuser="nvfuser",
         interpreter="thunder.jit",
         plugins=None,
     ):
         super().__init__(interpreter=interpreter, plugins=plugins)
-        self.fuser = fuser
+        if not isinstance(executors, list) or not all(isinstance(x, str) for x in executors):
+            raise TypeError("executors must be a list of strings")
+        self.executors = executors
         self.show_progress = show_progress
 
     def setup_config(self) -> dict[str, Any]:
@@ -29,13 +32,20 @@ class BaseRecipe(Recipe):
         return transforms
 
     def setup_executors(self) -> list[Executor]:
-        executors = super().setup_executors()
+        available_ex = super().setup_executors()
+        available_ex_map = {ex.name: ex for ex in available_ex}
 
-        if self.fuser == "nvfuser":
-            return executors
-        elif self.fuser == "torch.compile":
-            executors = [el for el in executors if el.name not in ["torchcompile_xentropy", "nvfuser"]]
-            executors.append(torch_compile_ex)
-            return executors
+        selected_ex = []
+        for name in self.executors:
+            if name == "nvfuser" and not nvfuser_available:
+                raise RuntimeError("NVFuser was specified as an executor but is not available.")
 
-        raise ValueError(f"Invalid fuser {self.fuser}. Allowed fusers: 'nvfuser', 'torch.compile'.")
+            if name not in available_ex_map:
+                raise ValueError(f"Executor {name} is not supported.")
+
+            selected_ex.append(available_ex_map[name])
+
+        if not selected_ex:
+            raise ValueError(f"No matching executors found for: {self.executors}")
+
+        return selected_ex

--- a/thunder/recipes/hf_transformers.py
+++ b/thunder/recipes/hf_transformers.py
@@ -40,12 +40,12 @@ class InplaceIndexCopyTransform(thunder.Transform):
 class HFTransformers(BaseRecipe):
     def __init__(
         self,
+        executors,
         show_progress=False,
-        fuser="nvfuser",
         interpreter="thunder.jit",
         plugins=None,
     ):
-        super().__init__(show_progress=show_progress, fuser=fuser, interpreter=interpreter, plugins=plugins)
+        super().__init__(executors=executors, show_progress=show_progress, interpreter=interpreter, plugins=plugins)
         # for kv-cache inplace ops
         self.inplace_index_copy_transform = InplaceIndexCopyTransform()
 

--- a/thunder/tests/test_recipes.py
+++ b/thunder/tests/test_recipes.py
@@ -6,6 +6,7 @@ import transformers
 import torch
 
 from thunder.extend import deregister_executor
+from thunder.executors import nvfuser_available
 from torch.testing import assert_close, make_tensor
 from thunder.tests.framework import version_between, IS_WINDOWS
 
@@ -27,6 +28,7 @@ def test_default_recipe_basic_bert():
 
 
 @pytest.mark.skipif(IS_WINDOWS, reason="slow on Windows")
+@pytest.mark.skipif(not nvfuser_available(), reason="NVFuser is not available")
 def test_recipe_basic_bert():
     bert = transformers.BertForSequenceClassification(transformers.BertConfig())
     del bert.bert.encoder.layer[1:]
@@ -49,7 +51,7 @@ def test_recipe_basic_bert():
     # cleanup after test
     deregister_executor("inplace_index_copy_ex")
 
-
+@pytest.mark.skipif(not nvfuser_available(), reason="NVFuser is not available")
 def test_recipe_basic_bert_fx():
     bert = transformers.BertForSequenceClassification(transformers.BertConfig())
     del bert.bert.encoder.layer[1:]

--- a/thunder/tests/test_recipes.py
+++ b/thunder/tests/test_recipes.py
@@ -37,6 +37,7 @@ def test_recipe_basic_bert():
     expected = bert(inp)
 
     from thunder.recipes import HFTransformers
+
     executors = ["cudnn", "sdpa", "torchcompile_xentropy", "nvfuser"]
     thunder_bert = thunder.compile(bert, recipe=HFTransformers(executors=executors))
 
@@ -57,11 +58,12 @@ def test_recipe_basic_bert_fx():
     inp = torch.randint(1, 20, (1, 32))
 
     from thunder.recipes import HFTransformers
+
     executors = ["cudnn", "sdpa", "torchcompile_xentropy", "nvfuser"]
     thunder_bert = thunder.compile(bert, recipe=HFTransformers(executors=executors, interpreter="thunder.fx"))
 
     actual = thunder_bert(inp)
-    expected = bert(inp)    
+    expected = bert(inp)
 
     assert_close(actual, expected)
 

--- a/thunder/tests/test_recipes.py
+++ b/thunder/tests/test_recipes.py
@@ -36,15 +36,9 @@ def test_recipe_basic_bert():
 
     expected = bert(inp)
 
-    thunder_bert = thunder.compile(bert, recipe="hf-transformers")
-
-    actual = thunder_bert(inp)
-
-    assert_close(actual, expected)
-
     from thunder.recipes import HFTransformers
-
-    thunder_bert = thunder.compile(bert, recipe=HFTransformers())
+    executors = ["cudnn", "sdpa", "torchcompile_xentropy", "nvfuser"]
+    thunder_bert = thunder.compile(bert, recipe=HFTransformers(executors=executors))
 
     actual = thunder_bert(inp)
     expected = bert(inp)
@@ -63,11 +57,11 @@ def test_recipe_basic_bert_fx():
     inp = torch.randint(1, 20, (1, 32))
 
     from thunder.recipes import HFTransformers
-
-    thunder_bert = thunder.compile(bert, recipe=HFTransformers(interpreter="thunder.fx"))
+    executors = ["cudnn", "sdpa", "torchcompile_xentropy", "nvfuser"]
+    thunder_bert = thunder.compile(bert, recipe=HFTransformers(executors=executors, interpreter="thunder.fx"))
 
     actual = thunder_bert(inp)
-    expected = bert(inp)
+    expected = bert(inp)    
 
     assert_close(actual, expected)
 


### PR DESCRIPTION
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?


## What does this PR do?

Fixes https://github.com/Lightning-AI/lightning-thunder/issues/2066 by having BaseRecipe explicitly take an `executors` argument as a list of strings.
The way it works with this PR is that `thunder.compile` and `thunder.jit` may be used without a recipe, but whenever a recipe is passed is has to be of type BaseRecipe or any subclass of it (cannot be string as before), with explicit executors passed to the recipe when initialized.
In addition, if `nvfuser` is passed in `executors`, it fails if nvfuser is not available.
