### PR TITLE
Fix CI benchmarks

### DIFF
--- a/thunder/benchmarks/benchmark_hf.py
+++ b/thunder/benchmarks/benchmark_hf.py
@@ -166,7 +166,7 @@ if __name__ == "__main__":
     torch.backends.cuda.matmul.allow_tf32 = True
     root.mkdir(parents=True, exist_ok=True)
 
-    # inference_gen()
-    # inference_fwd()
+    inference_gen()
+    inference_fwd()
     training_fwd()
     training_fwd_bwd()

--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -1848,11 +1848,7 @@ def pad_backward(a, padding_config, g):
 
     # Un-pad by padding with zero values
     zero_padding_config = [(-lo, -hi, 0) for lo, hi, _ in padding_config]
-
-    if utils.is_integer_dtype(a.dtype):
-        zero_value = 0
-    else:
-        zero_value = 0.0
+    zero_value = dtypes.dtype_to_numbertype(g.dtype)(0)
 
     g = prims.pad(g, zero_value, zero_padding_config)
 

--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -1849,7 +1849,12 @@ def pad_backward(a, padding_config, g):
     # Un-pad by padding with zero values
     zero_padding_config = [(-lo, -hi, 0) for lo, hi, _ in padding_config]
 
-    g = prims.pad(g, 0.0, zero_padding_config)
+    if utils.is_integer_dtype(a.dtype):
+        zero_value = 0
+    else:
+        zero_value = 0.0
+
+    g = prims.pad(g, zero_value, zero_padding_config)
 
     # Un-slice by slicing with a stride of value (dilation + 1)
     for dim, (_, _, d) in enumerate(padding_config):


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes CI benchmarks that were failing due to padding with floats an integer array in `pad_backward`. Some functions were also accidentally uncommented.
