### PR TITLE
add nvfuser to quickstart requirements

### DIFF
--- a/examples/quickstart/requirements.txt
+++ b/examples/quickstart/requirements.txt
@@ -1,2 +1,3 @@
 transformers
 accelerate
+nvfuser-cu128-torch27


### PR DESCRIPTION
adds nvfuser to quickstart requirements to not fail (after https://github.com/Lightning-AI/lightning-thunder/pull/2096)