### PR TITLE
`prims.where` ignores shape/device of `pred` if it's a CPU scalar tensor

### DIFF
--- a/thunder/clang/__init__.py
+++ b/thunder/clang/__init__.py
@@ -2147,7 +2147,7 @@ def where(pred, a, b):
     a, b = maybe_convert_to_dtype(a, promotiontype), maybe_convert_to_dtype(b, promotiontype)
 
     # Broadcasts
-    pred, a, b = maybe_broadcast(pred, a, b)
+    pred, a, b = maybe_broadcast(pred, a, b, treat_cpu_scalar_tensors_as_numbers=False)
 
     # Short circuits in the case that the predicate is a number
     if isinstance(pred, Number) and pytype(pred) is bool:

--- a/thunder/clang/__init__.py
+++ b/thunder/clang/__init__.py
@@ -1330,28 +1330,7 @@ def stack(tensors: list[TensorProxy], dim: int):
 @clangop()
 def compute_broadcast_shape(*_shapes):
     """Computes the common shape with the fewest dimensions that all input shapes can be broadcast to."""
-    shapes = tuple(x for x in filter(lambda x: x is not None, _shapes))
-
-    # Short-circuits if there are no inputs shapes
-    #   This might happen in calls like add(2, 3)
-    if len(shapes) == 0:
-        return None
-
-    common_shape = [
-        1,
-    ] * reduce(max, (len(shape) for shape in shapes))
-
-    for shape in shapes:
-        for idx in range(-1, -1 - len(shape), -1):
-            if common_shape[idx] == 1:
-                common_shape[idx] = shape[idx]
-
-            utils.check(
-                (shape[idx] == 1) or (common_shape[idx] == shape[idx]),
-                lambda: f"Attempting to broadcast a dimension of length {shape[idx]}!",
-            )
-
-    return tuple(common_shape)
+    return prims.compute_broadcast_shape(*_shapes)
 
 
 @run_once
@@ -2147,7 +2126,7 @@ def where(pred, a, b):
     a, b = maybe_convert_to_dtype(a, promotiontype), maybe_convert_to_dtype(b, promotiontype)
 
     # Broadcasts
-    pred, a, b = maybe_broadcast(pred, a, b, treat_cpu_scalar_tensors_as_numbers=False)
+    pred, a, b = maybe_broadcast(pred, a, b)
 
     # Short circuits in the case that the predicate is a number
     if isinstance(pred, Number) and pytype(pred) is bool:

--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -2831,7 +2831,8 @@ def _where_meta(pred: Number | TensorProxy, a: Number | TensorProxy, b: Number |
 
     # Determines output shape
     # NOTE Assumes at least one of pred, a, and b is a TensorProxy because of prior check for Number x Number x Number
-    shapes = tuple(x.shape for x in (pred, a, b) if isinstance(x, TensorProxy))
+    # `pred` can be a CPU bool scalar tensor, thus to filter it out by checking the numel.
+    shapes = tuple(x.shape for x in (pred, a, b) if isinstance(x, TensorProxy) and x.numel > 1)
     resultshape = shapes[0]
 
     return TensorProxy(shape=resultshape, device=resultdevice, dtype=dtype)

--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -2787,32 +2787,6 @@ lerp = make_prim(
 )
 
 
-def compute_broadcast_shape(*_shapes):
-    """Computes the common shape with the fewest dimensions that all input shapes can be broadcast to."""
-    shapes = tuple(x for x in filter(lambda x: x is not None, _shapes))
-
-    # Short-circuits if there are no inputs shapes
-    #   This might happen in calls like add(2, 3)
-    if len(shapes) == 0:
-        return None
-
-    common_shape = [
-        1,
-    ] * reduce(max, (len(shape) for shape in shapes))
-
-    for shape in shapes:
-        for idx in range(-1, -1 - len(shape), -1):
-            if common_shape[idx] == 1:
-                common_shape[idx] = shape[idx]
-
-            utils.check(
-                (shape[idx] == 1) or (common_shape[idx] == shape[idx]),
-                lambda: f"Attempting to broadcast a dimension of length {shape[idx]}!",
-            )
-
-    return tuple(common_shape)
-
-
 # TODO Restore Number x Number x Number support
 def _where_meta(pred: Number | TensorProxy, a: Number | TensorProxy, b: Number | TensorProxy, /) -> TensorProxy:
     # Checks types
@@ -2858,7 +2832,7 @@ def _where_meta(pred: Number | TensorProxy, a: Number | TensorProxy, b: Number |
     # Determines output shape
     # NOTE Assumes at least one of pred, a, and b is a TensorProxy because of prior check for Number x Number x Number
     shapes = tuple(x.shape for x in (pred, a, b) if isinstance(x, TensorProxy))
-    resultshape = compute_broadcast_shape(*shapes)
+    resultshape = shapes[0]
 
     return TensorProxy(shape=resultshape, device=resultdevice, dtype=dtype)
 

--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -2787,6 +2787,32 @@ lerp = make_prim(
 )
 
 
+def compute_broadcast_shape(*_shapes):
+    """Computes the common shape with the fewest dimensions that all input shapes can be broadcast to."""
+    shapes = tuple(x for x in filter(lambda x: x is not None, _shapes))
+
+    # Short-circuits if there are no inputs shapes
+    #   This might happen in calls like add(2, 3)
+    if len(shapes) == 0:
+        return None
+
+    common_shape = [
+        1,
+    ] * reduce(max, (len(shape) for shape in shapes))
+
+    for shape in shapes:
+        for idx in range(-1, -1 - len(shape), -1):
+            if common_shape[idx] == 1:
+                common_shape[idx] = shape[idx]
+
+            utils.check(
+                (shape[idx] == 1) or (common_shape[idx] == shape[idx]),
+                lambda: f"Attempting to broadcast a dimension of length {shape[idx]}!",
+            )
+
+    return tuple(common_shape)
+
+
 # TODO Restore Number x Number x Number support
 def _where_meta(pred: Number | TensorProxy, a: Number | TensorProxy, b: Number | TensorProxy, /) -> TensorProxy:
     # Checks types
@@ -2832,7 +2858,7 @@ def _where_meta(pred: Number | TensorProxy, a: Number | TensorProxy, b: Number |
     # Determines output shape
     # NOTE Assumes at least one of pred, a, and b is a TensorProxy because of prior check for Number x Number x Number
     shapes = tuple(x.shape for x in (pred, a, b) if isinstance(x, TensorProxy))
-    resultshape = shapes[0]
+    resultshape = compute_broadcast_shape(*shapes)
 
     return TensorProxy(shape=resultshape, device=resultdevice, dtype=dtype)
 

--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -2818,7 +2818,7 @@ def _where_meta(pred: Number | TensorProxy, a: Number | TensorProxy, b: Number |
     # Checks devices and determines result device
     utils.check_same_device(pred, a, b)
     resultdevice = devices.cpu
-    devices_ = tuple(x.device for x in (pred, a, b) if isinstance(x, TensorProxy))
+    devices_ = tuple(x.device for x in (pred, a, b) if isinstance(x, TensorProxy) and not utils.is_cpu_scalar_tensor(x))
     if len(devices_) > 0:
         resultdevice = devices_[0]
 
@@ -2831,19 +2831,8 @@ def _where_meta(pred: Number | TensorProxy, a: Number | TensorProxy, b: Number |
 
     # Determines output shape
     # NOTE Assumes at least one of pred, a, and b is a TensorProxy because of prior check for Number x Number x Number
-    shapes = tuple(x.shape for x in (pred, a, b) if isinstance(x, TensorProxy))
-    # It's possible that `pred` is a CPU bool scalar tensor and either or both of `a` and `b` are a CUDA tensor.
-    # In that case, `shapes[0]`, i.e., `pred.shape` should not be the result shape.
-    if (
-        len(shapes) > 1
-        and isinstance(pred, TensorProxy)
-        and pred.numel == 1
-        and pred.device.devicetype is devices.DeviceType.CPU
-        and (isinstance(a, TensorProxy) or isinstance(b, TensorProxy))
-    ):
-        resultshape = shapes[1]
-    else:
-        resultshape = shapes[0]
+    shapes = tuple(x.shape for x in (pred, a, b) if isinstance(x, TensorProxy) and not utils.is_cpu_scalar_tensor(x))
+    resultshape = shapes[0]
 
     return TensorProxy(shape=resultshape, device=resultdevice, dtype=dtype)
 

--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -2832,6 +2832,8 @@ def _where_meta(pred: Number | TensorProxy, a: Number | TensorProxy, b: Number |
     # Determines output shape
     # NOTE Assumes at least one of pred, a, and b is a TensorProxy because of prior check for Number x Number x Number
     shapes = tuple(x.shape for x in (pred, a, b) if isinstance(x, TensorProxy) and not utils.is_cpu_scalar_tensor(x))
+    if not shapes:
+        shapes = (pred.shape,)
     resultshape = shapes[0]
 
     return TensorProxy(shape=resultshape, device=resultdevice, dtype=dtype)

--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -3721,6 +3721,10 @@ diagonal_opinfo = OpInfo(
         # input case ((1, 2, 0, 3), -1, 0, -1)
         DecorateInfo(pytest.mark.xfail(strict=True), "test_vjp_correctness"),
         # See: [Fix runtime-trace shape/dtype/device mismatch]
+        # In https://github.com/Lightning-AI/lightning-thunder/pull/2069,
+        # torch-consistency test checks the parity of shape/dtype/device
+        # between runtime and trace. This needs to be a temporary decorator
+        # and we are working on resolving the mismatches.
         DecorateInfo(
             pytest.mark.xfail(strict=True),
             "test_core_vs_torch_consistency",

--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -2309,15 +2309,6 @@ copysign_opinfo = OpInfo(
             pytest.mark.xfail,
             "test_vjp_correctness",
         ),
-        # TODO(crcrpar): [Fix runtime-trace shape/dtype/device mismatch]
-        # In https://github.com/Lightning-AI/lightning-thunder/pull/2069,
-        # torch-consistency test checks the parity of shape/dtype/device
-        # between runtime and trace. This needs to be a temporary decorator
-        # and we are working on resolving the mismatches.
-        DecorateInfo(
-            pytest.mark.xfail(strict=True),
-            "test_core_vs_torch_consistency",
-        ),
     ),
 )
 elementwise_binary_ops.append(copysign_opinfo)
@@ -2377,12 +2368,6 @@ floor_divide_opinfo = OpInfo(
             skip,
             "test_core_vs_torch_consistency",
             dtypes=(datatypes.bool8,),
-        ),
-        # See [Fix runtime-trace shape/dtype/device mismatch]
-        DecorateInfo(
-            pytest.mark.xfail(strict=True),
-            "test_core_vs_torch_consistency",
-            dtypes=datatypes.float_math_dtypes,
         ),
     ),
 )


### PR DESCRIPTION
In order to fix the shape/device mismatch between runtime and trace, this PR adds the excluding `pred` if it's a CPU scalar tensor when deciding shape/device of outputs.


When the `condition` of `torch.where` is a CPU scalar tensor, the broadcast doesn't occur as we can see in the following trace:
```python
def computation(cond, a, b):
  # cond: "cpu b8[]"
  # a: "cpu f32[4, 4]"
  # b: "cpu f32[]"

  # repro.py:11:             return torch.where(cond, a, b)
  t0 = ltorch.where(cond, a, b)  # t0: "cpu f32[]"
    # t0 = prims.where(cond, a, b)  # t0: "cpu f32[]"
  return (t0,)
```
This causes a mismatch between runtime results and trace outputs.

This trace is obtained by running the script below:
```python
import torch
import thunder

def f(cond, a, b):
    return torch.where(cond, a, b)

if __name__ == "__main__":
    jitted = thunder.jit(f)
    with torch.device("cpu"):
        cond = torch.tensor(True, dtype=torch.bool)
        a = torch.tensor([
            [ 6.5077,  7.6115,  8.6770,  6.2419],
            [ 7.1474, -4.7458, -8.1032,  8.7696],
            [ 7.9486,  5.3679, -7.8606, -5.3753],
            [-5.8697,  7.7565, -1.9403,  4.1512],
        ])
        b = torch.tensor(-2.6034)
    out = jitted(cond, a, b)

    print(thunder.last_traces(jitted)[0])
```

If tensors are on CUDA, then the trace is
```python
def computation(cond, a, b):
  # cond: "cuda:0 b8[]"
  # a: "cuda:0 f32[4, 4]"
  # b: "cuda:0 f32[]"

  # repro.py:11:             return torch.where(cond, a, b)
  t2 = ltorch.where(cond, a, b)  # t2: "cuda:0 f32[4, 4]"
    # t0 = prims.broadcast_in_dim(cond, (4, 4), ())  # t0: "cuda:0 b8[4, 4]"
    # t1 = prims.broadcast_in_dim(b, (4, 4), ())  # t1: "cuda:0 f32[4, 4]"
    # t2 = prims.where(t0, a, t1)  # t2: "cuda:0 f32[4, 4]"
  return (t2,)
```
The difference between traces of CPU and CUDA would be attributed to https://github.com/Lightning-AI/lightning-thunder/blob/d0f647479f73787389c4fa6ced3b0b9ada4083c0/thunder/clang/__init__.py#L1410-L1417.

Rel: 
- #2069
- #2187