### PR TITLE
add a use_hf option to benchmarking

### DIFF
--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -252,6 +252,7 @@ class Benchmark_litGPT:
         use_torchao_fp8_precompute_scale_for_fsdp: bool = False,
         fp8_shard_intermediate_activation: bool = False,
         use_sdpa: bool = False,
+        use_hf: bool = False,
     ):
         seed = 1337
         torch.manual_seed(seed)
@@ -288,6 +289,7 @@ class Benchmark_litGPT:
         self.fp8_shard_intermediate_activation = fp8_shard_intermediate_activation
 
         self.use_sdpa = use_sdpa
+        self.use_hf = use_hf
 
         if self.use_sdpa and sdpa_available and self.compile not in ["eager", "inductor"]:
             warnings.warn(
@@ -424,8 +426,42 @@ class Benchmark_litGPT:
 
     def init_model(self):
         init_device = torch.device("meta") if self.distributed_mode in FSDP_MODES else self.device
-        with init_device:
-            model = GPT(self.config)
+        if self.use_hf:
+            warnings.warn(
+                f"HuggingFace transformers mode is experimental, many options do not apply. Preliminary testing  with transformers==4.50.3."
+            )
+
+            # for the materialization, we need reset_parameters
+            def RotaryEmbedding_reset_parameters(self):
+                inv_freq, self.attention_scaling = self.rope_init_fn(self.config, self.inv_freq.device)
+                with torch.no_grad():
+                    self.inv_freq.copy_(inv_freq)
+
+            from transformers.models.qwen2.modeling_qwen2 import Qwen2RotaryEmbedding
+            from transformers.models.llama.modeling_llama import LlamaRotaryEmbedding
+
+            Qwen2RotaryEmbedding.reset_parameters = RotaryEmbedding_reset_parameters
+            LlamaRotaryEmbedding.reset_parameters = RotaryEmbedding_reset_parameters
+
+            def RMSNorm_reset_parameters(self):
+                with torch.no_grad():
+                    self.weight.fill_(1)
+
+            from transformers.models.qwen2.modeling_qwen2 import Qwen2RMSNorm
+            from transformers.models.llama.modeling_llama import LlamaRMSNorm
+
+            Qwen2RMSNorm.reset_parameters = RMSNorm_reset_parameters
+            LlamaRMSNorm.reset_parameters = RMSNorm_reset_parameters
+
+            import transformers
+
+            hf_model_name = f"{self.config.hf_config['org']}/{self.config.hf_config['name']}"
+            hf_cfg = transformers.AutoConfig.from_pretrained(hf_model_name)
+            with init_device:
+                model = transformers.AutoModel.from_config(hf_cfg)
+        else:
+            with init_device:
+                model = GPT(self.config)
 
         # Handle fp8 related Linear layer swapping (for torchao or TransformerEngine)
         model = self._torchao_fp8_handler.convert_model_to_fp8(model)
@@ -623,7 +659,6 @@ class Benchmark_litGPT:
                 jit_options = {}
                 jit_options["fp8_shard_intermediate_activation"] = self.fp8_shard_intermediate_activation
                 model = thunder.jit(model, executors=executors, transforms=transforms, **jit_options)
-
         elif self.compile != "eager":
             raise ValueError(f"Invalid compile option: {self.compile}")
 
@@ -702,6 +737,8 @@ class Benchmark_litGPT:
                             logits = self.model(input_ids)
                     else:
                         logits = self.model(input_ids)
+                    if not isinstance(logits, torch.Tensor):
+                        logits = logits["last_hidden_state"]
                     logits = logits.reshape(-1, logits.size(-1))
                     targets = targets.reshape(-1)
                     loss = (
@@ -718,6 +755,8 @@ class Benchmark_litGPT:
                     logits = self.model(input_ids)
             else:
                 logits = self.model(input_ids)
+            if not isinstance(logits, torch.Tensor):
+                logits = logits["last_hidden_state"]
             # This information is accurate only in the case when torch.compile
             # uses a single graph for the entire forward pass In the case of
             # torch.compile using multiple graphs, the saved_tensors will be
@@ -860,9 +899,11 @@ def benchmark_main(return_metrics_as_json=False, json_path="", **kwargs) -> None
 
     if global_rank in [0, None]:
         benchmark.add_perf_metrics()
-
+        model_name = benchmark.model_name
+        if benchmark.use_hf:
+            model_name += "_hf"
         print(
-            f"Model name: {benchmark.model_name}\nSeq Length: {benchmark.config.block_size}\nMicro BS: {benchmark.micro_batch_size}\nGlobal BS: {benchmark.global_batch_size}"
+            f"Model name: {model_name}\nSeq Length: {benchmark.config.block_size}\nMicro BS: {benchmark.micro_batch_size}\nGlobal BS: {benchmark.global_batch_size}"
         )
         print(
             f"Number of Layers: {benchmark.config.n_layer}\nNumber of parameters: {sum(p.numel() for p in benchmark.model.parameters() if p.requires_grad) / 1e9:.02f}B"


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] n/a Did you make sure to update the docs?
- [ ] n/a Did you write any new necessary tests?

</details>

## What does this PR do?

This adds a somewhat ad-hoc hugging-face variant for the benchmarking. We want this for better comparability, in the longer term, we could phase out the benchmark_hf.py (unless anyone depends on it).

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
