### PR TITLE
Fix HFTransformers recipe for kv-cache

### DIFF
--- a/thunder/recipes/hf_transformers.py
+++ b/thunder/recipes/hf_transformers.py
@@ -104,7 +104,7 @@ class HFTransformers(BaseRecipe):
     def apply(self, model):
         thunder_model = super().apply(model)
 
-        # here we rebind methods to the ThunderModule (model.__class__._foo is the unbound method 
+        # here we rebind methods to the ThunderModule (model.__class__._foo is the unbound method
         # and __get__ binds it to the ThunderModule as self).
         if getattr(thunder_model, "generate", None):
             thunder_model.generate = model.__class__.generate.__get__(thunder_model, thunder_model.__class__)

--- a/thunder/recipes/hf_transformers.py
+++ b/thunder/recipes/hf_transformers.py
@@ -104,10 +104,12 @@ class HFTransformers(BaseRecipe):
     def apply(self, model):
         thunder_model = super().apply(model)
 
+        # here we rebind methods to the ThunderModule (model.__class__._foo is the unbound method 
+        # and __get__ binds it to the ThunderModule as self).
         if getattr(thunder_model, "generate", None):
             thunder_model.generate = model.__class__.generate.__get__(thunder_model, thunder_model.__class__)
 
         if getattr(thunder_model, "_sample", None):
-            thunder_model.sample = model.__class__._sample.__get__(thunder_model, thunder_model.__class__)
+            thunder_model._sample = model.__class__._sample.__get__(thunder_model, thunder_model.__class__)
 
         return thunder_model

--- a/thunder/recipes/hf_transformers.py
+++ b/thunder/recipes/hf_transformers.py
@@ -29,8 +29,7 @@ class InplaceIndexCopyTransform(thunder.Transform):
         comp_new = thunder.core.trace.from_trace(comp)
         for bsym in comp.bound_symbols:
             if bsym.sym == thunder.torch.index_copy:
-                if bsym.args[0].history is not None:
-                    bsym.args[0].tags.add(thunder.core.proxies.ProxyTag.STATIC_MEMORY_LOCATION)
+                bsym.args[0].tags.add(thunder.core.proxies.ProxyTag.STATIC_MEMORY_LOCATION)
                 bsym = bsym.from_bsym(sym=self.inplace_index_copy)
             else:
                 bsym = bsym.from_bsym()

--- a/thunder/tests/test_recipes.py
+++ b/thunder/tests/test_recipes.py
@@ -79,6 +79,7 @@ def test_recipe_basic_bert_fx():
     # cleanup after test
     deregister_executor("inplace_index_copy_ex")
 
+
 @pytest.mark.skipif(not nvfuser_available(), reason="nvFuser is not available")
 def test_recipe_qwen2_5_kvcache():
     model_name = "Qwen/Qwen2.5-3B"

--- a/thunder/tests/test_recipes.py
+++ b/thunder/tests/test_recipes.py
@@ -98,7 +98,7 @@ def test_recipe_qwen2_5_kvcache():
 
     tokenizer = transformers.AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
     encoded = tokenizer("Hello, how are", return_tensors="pt", add_special_tokens=False)
-    input_ids = encoded["input_ids"].cuda()
+    input_ids = encoded["input_ids"]
 
     torch.manual_seed(0)
     expected = model.generate(input_ids, max_new_tokens=5, do_sample=False, use_cache=True)

--- a/thunder/tests/test_recipes.py
+++ b/thunder/tests/test_recipes.py
@@ -91,7 +91,6 @@ def test_recipe_qwen2_5_kvcache():
         model_name,
         config=config,
         torch_dtype="auto",
-        device_map="auto",
         trust_remote_code=True,
         ignore_mismatched_sizes=True,
     )


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

This fixes an issue when trying to use the `HFTransformers` recipe when using HF kv-caching option (`use_cache=True`). The use of `partial` freezes the model, so history is still set to none when the cache is passed on the next iteration, so the test added in this PR was failing.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
