### PR TITLE
sdpa_ex: relax test tolerances

### DIFF
--- a/thunder/tests/test_grad.py
+++ b/thunder/tests/test_grad.py
@@ -601,11 +601,11 @@ def test_vjp_correctness_sdpa_manual(op, device, dtype, executor, comp):
             disable_torch_autograd=True,
             executors=[sdpa_ex, *executor.executors_list()],
         )(filtered_args, (v,))
-        comp(actual_out, expect_out)
+        comp(actual_out, expect_out, atol=1e-3, rtol=1e-3)
 
         # compare gradients of query, key, value, and attn_mask
         for eg, ag in zip(expected_grad, actual_grad):
-            comp(eg, ag)
+            comp(eg, ag, atol=7e-3, rtol=7e-3)
 
 
 @ops((get_opinfo("zeta"),), supported_dtypes=(dtypes.float64,))

--- a/thunder/tests/test_sdpaex_executor.py
+++ b/thunder/tests/test_sdpaex_executor.py
@@ -206,7 +206,7 @@ def test_sdpa_attn_mask(attn_mask_requires_grad, device: str, dtype: torch.dtype
     output = actual.mean()
     output.backward()
 
-    torch.testing.assert_close(actual, expected)
+    torch.testing.assert_close(actual, expected, atol=7e-3, rtol=7e-3)
     torch.testing.assert_close(attn_mask1.grad, attn_mask.grad)
     torch.testing.assert_close(query.grad, query1.grad)
     torch.testing.assert_close(key.grad, key1.grad)


### PR DESCRIPTION
Ref: NVBUG 5319322

Test - `pytest  thunder/tests/test_grad.py -v -k test_vjp_correctness_sdpa_manual_grad_forward_scaled_dot_product_attention_torch_cuda_thunder.dtypes.bfloat16/float16` fails with numerical mismatch on GB200.

Relaxing the tolerance fixes the test.

Default atol and rtol for bf16 and float16 for assert_close
![image](https://github.com/user-attachments/assets/3c4c091e-ec1f-4933-b64c-d6ac59a44855)


https://docs.pytorch.org/docs/stable/testing.html