### PR TITLE
[test_ops] Make repro command more specific

### DIFF
--- a/thunder/tests/test_ops.py
+++ b/thunder/tests/test_ops.py
@@ -129,7 +129,7 @@ def test_core_vs_torch_consistency(op, device: str, dtype: dtypes.dtype, executo
         path = os.path.relpath(__file__)
         repro_cmd = (
             f"command to reproduce the error: THUNDER_OPTEST_SAMPLE_INDEX={i} "
-            f'pytest {path} -k "test_core_vs_torch_consistency and {device} and {dtype} and {op.name}"'
+            f"pytest {path}::test_core_vs_torch_consistency_{op.name}_{executor.name}_{device}_{dtype}"
         )
 
         try:


### PR DESCRIPTION
## What does this PR do?

Currently it misses executor name. If a test case is failing on cuda, then the displayed repro command would run both nvfuserex and torchex, which is not expected from a repro command.

With this change, an example of displayed repro commands is 

```
            except Exception as e:
                if repro_cmd not in str(e):
>                   raise type(e)(f"{str(e)}\n{repro_cmd}") from e
E                   RuntimeError: Runtime output has shape of `(4, 4)`, device of `cuda:0`, and dtype of `torch.float64` but compiletime output has shape of `(4, 4)`, device of `cpu`, and dtype of `torch.float64`
E                   command to reproduce the error: THUNDER_OPTEST_SAMPLE_INDEX=1 pytest thunder/tests/test_ops.py::test_core_vs_torch_consistency_floor_divide_torch_cuda_thunder.dtypes.float64

thunder/tests/test_ops.py:148: RuntimeError
```

On main branch it's `THUNDER_OPTEST_SAMPLE_INDEX=1 pytest thunder/tests/test_ops.py -k "test_core_vs_torch_consistency and cuda and thunder.dtypes.float64 and floor_divide"` that does not specify the executor.

Follw-up of #2131