### PR TITLE
add decomposition for repeat interleave

### DIFF
--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -4535,6 +4535,22 @@ view_as_opinfo = OpInfo(
 shape_ops.append(view_as_opinfo)
 
 
+def repeat_interleave_sample_generator(op, device, dtype, requires_grad, **kwargs):
+    make = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)
+
+    yield SampleInput(make(), repeats=2)
+    yield SampleInput(make(2, 3, 4), repeats=2)
+    yield SampleInput(make(2, 3, 4), repeats=2, dim=1)
+
+
+repeat_interleave_opinfo = OpInfo(
+    ltorch.repeat_interleave,
+    sample_input_generator=repeat_interleave_sample_generator,
+    torch_reference=torch.Tensor.repeat_interleave,
+)
+shape_ops.append(repeat_interleave_opinfo)
+
+
 def repeat_sample_generator(op, device, dtype, requires_grad, **kwargs):
     make = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)
 

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -3085,6 +3085,28 @@ def _sum_grad(
 register_grad(sum, _sum_grad)
 
 
+@torchsymbol(torch.repeat_interleave, is_method=True)
+def repeat_interleave(
+    input: TensorProxy, repeats: TensorProxy | int, dim: int | None = None, *, output_size: int | None = None
+):
+    if output_size is not None:
+        raise NotImplementedError("thunder.torch.repeat_interleave does not support dim argument yet")
+    if isinstance(repeats, TensorProxy):
+        raise NotImplementedErrror("thunder.torch.repeat_interleave does not support tensor repeats yet")
+    if dim is None:
+        return input.reshape((-1, 1)).expand(-1, repeats).reshape(-1)
+
+    if dim < 0:
+        dim += len(input.shape)
+
+    intermediate_shape = list(input.shape)
+    intermediate_shape.insert(dim + 1, repeats)
+    new_shape = list(input.shape)
+    new_shape[dim] *= repeats
+
+    return input.unsqueeze(dim + 1).expand(intermediate_shape).reshape(new_shape)
+
+
 # NOTE This decomposition can not be efficiently fused, so make it primitive
 @torchsymbol(torch.cumsum, is_method=True, is_prim=True)
 def cumsum(a: TensorLike, dim: int, *, dtype: None | dtypeLike = None) -> TensorLike:

--- a/thunder/torch/default_torch_ops.py
+++ b/thunder/torch/default_torch_ops.py
@@ -231,7 +231,6 @@ torch_auto_registered_ops = {
         torch.randint_like,
         torch.ravel,
         torch.renorm,
-        torch.repeat_interleave,
         torch.resolve_conj,
         torch.resolve_neg,
         # torch.rms_norm, # only in torch>=2.4
@@ -539,7 +538,6 @@ torch_auto_registered_ops = {
         torch.Tensor.refine_names,
         torch.Tensor.rename,
         torch.Tensor.renorm,
-        torch.Tensor.repeat_interleave,
         torch.Tensor.reshape_as,
         torch.Tensor.resize,
         torch.Tensor.resize_as,


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

## What does this PR do?

litgpt introduced the use of `torch.repeat_interleave` for query grouping in https://github.com/Lightning-AI/litgpt/pull/1013 .
The auto-registered gradient formula saved the input for backward, but only the shape is needed.
This PR produces a decomposition (for the non data-dependent control flow case), which does not appear to suffer from this weakness.

Fixes #2189 .

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
