### PR TITLE
Conditionally skip `prims.check_tensor_shape_and_metadata` when thunder is used by `torch.compile(dynamic=False)`

### DIFF
--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -441,6 +441,7 @@ def jit(
                 kwargs,
                 ad_hoc_executor=ad_hoc_executor,
                 sharp_edges=cd.sharp_edges,
+                skip_check_tensor_shape_and_metadata=compile_options.get("skip_check_tensor_shape_and_metadata", False),
             )
             prologue_trc = jit_results.prologue_trace
             computation_trc = jit_results.computation_trace


### PR DESCRIPTION
## What does this PR do?

When `thunder` is a `torch.compile` backend and `example_inputs` have no ambiguity, i.e. no `torch.SymInt`s in `example_inputs`,
then I think we should comfortably skip the prim in prologue. 

I expect this change to be beneficial when we have a number of tensors to check their shape and metadata.

The following three prologue traces are generated in `test_dynamo.py::test_thunderfx` -- https://github.com/Lightning-AI/lightning-thunder/blob/e171edf7bf142d354efb9e2233cd225a13e7fd57/thunder/tests/test_dynamo.py#L1004-L1033.

The test calls `thunderfx` thrice. The first and last call disable `dynamic` and the second enables `dynamic`. The expected behaviour is that the prologues for the first and last do not have `prims.check_tensor_shape_and_metadata` and the other does.
The generated traces seem to meet the expectation.

```python
def prologue(*args, **kwargs):
  # args: "Any"
  prims.check_len(args, 1)
  # kwargs: "Any"
  prims.check_len(kwargs, 0)
  l_x_: "cuda:0 f32[4, 4]" = args[0]
  cache_info: "Any" = thunder._get_cache_info()
  cache_info_default_dtype: "<class 'torch.dtype'>" = cache_info['default_dtype']
  prims.check_literal_like(cache_info_default_dtype, torch.float32)
  cache_info_default_device: "<class 'torch.device'>" = cache_info['default_device']
  prims.check_literal_like(cache_info_default_device, torch.device("cpu"))
  cache_info_is_autocast_enabled: "bool False" = cache_info['is_autocast_enabled']
  prims.check_number_type_and_value(cache_info_is_autocast_enabled, False)
  cache_info_alias_tensor_indices: "str" = cache_info['alias_tensor_indices']
  prims.check_string_value(cache_info_alias_tensor_indices, '')
  cache_info_is_grad_enabled: "bool True" = cache_info['is_grad_enabled']
  prims.check_number_type_and_value(cache_info_is_grad_enabled, True)
  cache_info_no_grad_sync: "bool False" = cache_info['no_grad_sync']
  prims.check_number_type_and_value(cache_info_no_grad_sync, False)
  return ((l_x_,), ())

def prologue(*args, **kwargs):
  # args: "Any"
  prims.check_len(args, 2)
  # kwargs: "Any"
  prims.check_len(kwargs, 0)
  l_x_: "cuda:0 f32[4, 4]" = args[0]
  prims.check_tensor_shape_and_metadata(l_x_, (4, 4), 'cuda:0', torch.float32, True)
  i0: "int 4" = args[1]
  prims.check_number_type_and_value(i0, 4)
  cache_info: "Any" = thunder._get_cache_info()
  cache_info_default_dtype: "<class 'torch.dtype'>" = cache_info['default_dtype']
  prims.check_literal_like(cache_info_default_dtype, torch.float32)
  cache_info_default_device: "<class 'torch.device'>" = cache_info['default_device']
  prims.check_literal_like(cache_info_default_device, torch.device("cpu"))
  cache_info_is_autocast_enabled: "bool False" = cache_info['is_autocast_enabled']
  prims.check_number_type_and_value(cache_info_is_autocast_enabled, False)
  cache_info_alias_tensor_indices: "str" = cache_info['alias_tensor_indices']
  prims.check_string_value(cache_info_alias_tensor_indices, '')
  cache_info_is_grad_enabled: "bool True" = cache_info['is_grad_enabled']
  prims.check_number_type_and_value(cache_info_is_grad_enabled, True)
  cache_info_no_grad_sync: "bool False" = cache_info['no_grad_sync']
  prims.check_number_type_and_value(cache_info_no_grad_sync, False)
  return ((l_x_,), ())

def prologue(*args, **kwargs):
  # args: "Any"
  prims.check_len(args, 2)
  # kwargs: "Any"
  prims.check_len(kwargs, 0)
  l_x_: "cuda:0 f32[4, 4]" = args[0]
  l_w_: "cuda:0 f32[4, 4]" = args[1]
  cache_info: "Any" = thunder._get_cache_info()
  cache_info_default_dtype: "<class 'torch.dtype'>" = cache_info['default_dtype']
  prims.check_literal_like(cache_info_default_dtype, torch.float32)
  cache_info_default_device: "<class 'torch.device'>" = cache_info['default_device']
  prims.check_literal_like(cache_info_default_device, torch.device("cpu"))
  cache_info_is_autocast_enabled: "bool False" = cache_info['is_autocast_enabled']
  prims.check_number_type_and_value(cache_info_is_autocast_enabled, False)
  cache_info_alias_tensor_indices: "str" = cache_info['alias_tensor_indices']
  prims.check_string_value(cache_info_alias_tensor_indices, '')
  cache_info_is_grad_enabled: "bool True" = cache_info['is_grad_enabled']
  prims.check_number_type_and_value(cache_info_is_grad_enabled, True)
  cache_info_no_grad_sync: "bool False" = cache_info['no_grad_sync']
  prims.check_number_type_and_value(cache_info_no_grad_sync, False)
  return ((l_x_, l_w_), ())
```