### PR TITLE
default to hf recipe in thunder.compile for hf models

### DIFF
--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -295,7 +295,12 @@ def compile(
     plugins = plugins_
 
     if recipe is None:
-        recipe = thunder.recipes.BaseRecipe()
+        model_class = getattr(fn, "__class__", None)
+        if model_class is not None and "transformers" in model_class.__module__:
+            recipe = thunder.recipes.HFTransformers()
+        else:
+            recipe = thunder.recipes.BaseRecipe()
+        print(recipe)
 
     if recipe == "auto":
         raise NotImplementedError

--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -268,9 +268,8 @@ CacheEntry = namedtuple(
 )
 
 
-# TODO implement registration + "auto" recipe
 def compile(
-    fn: Callable, recipe: Recipe | str | None = None, plugins: Plugin | list[Plugin] | str | list[str] | None = None
+    fn: Callable, recipe: Recipe | str = "auto", plugins: Plugin | list[Plugin] | str | list[str] | None = None
 ):
     import thunder.recipes
     import thunder.plugins
@@ -294,15 +293,8 @@ def compile(
             plugins_.append(plugin)
     plugins = plugins_
 
-    if recipe is None:
-        model_class = getattr(fn, "__class__", None)
-        if model_class is not None and "transformers" in model_class.__module__:
-            recipe = thunder.recipes.HFTransformers()
-        else:
-            recipe = thunder.recipes.BaseRecipe()
-
     if recipe == "auto":
-        raise NotImplementedError
+        recipe = Recipe.get_for_model(fn)
 
     if isinstance(recipe, str):
         recipe_cls = thunder.recipes.get_recipe_class(recipe)

--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -300,7 +300,6 @@ def compile(
             recipe = thunder.recipes.HFTransformers()
         else:
             recipe = thunder.recipes.BaseRecipe()
-        print(recipe)
 
     if recipe == "auto":
         raise NotImplementedError

--- a/thunder/core/recipe.py
+++ b/thunder/core/recipe.py
@@ -8,6 +8,8 @@ import torch
 from thunder.core.transform_common import Transform
 from thunder.extend import Executor
 
+_RECIPE_REGISTRY: dict[str, type["Recipe"]] = {}
+
 
 @contextmanager
 def pretty_warnings():
@@ -84,6 +86,35 @@ class Recipe:
 
     def setup_config(self) -> dict[str, Any]:
         return {}
+
+    _registry = _RECIPE_REGISTRY  # optional alias for clarity
+
+    @classmethod
+    def register(cls, key: str):
+        def decorator(subcls):
+            cls._registry[key] = subcls
+            return subcls
+
+        return decorator
+
+    @classmethod
+    def get_for_model(cls, model):
+        module_path = f"{model.__class__.__module__}.{model.__class__.__name__}"
+        parts = module_path.split(".")
+        for i in range(len(parts), 0, -1):
+            key = ".".join(parts[:i])
+            recipe_cls = cls._registry.get(key)
+            if recipe_cls and recipe_cls.is_applicable(model):
+                return recipe_cls()
+
+        default_recipe_cls = cls._registry.get("")
+        if default_recipe_cls:
+            return default_recipe_cls()
+        raise RuntimeError("No applicable recipe found and no default registered.")
+
+    @classmethod
+    def is_applicable(cls, model):
+        return True  # override for stricter matching
 
     def apply(self, model):
         with pretty_warnings():

--- a/thunder/core/recipe.py
+++ b/thunder/core/recipe.py
@@ -72,8 +72,7 @@ class Recipe:
 
     @classmethod
     def validate(cls, model):
-        # this is expected to raise if validation fails
-        pass
+        return True
 
     def setup_lookasides(self) -> list[Lookaside] | None:
         return None
@@ -104,17 +103,13 @@ class Recipe:
         for i in range(len(parts), 0, -1):
             key = ".".join(parts[:i])
             recipe_cls = cls._registry.get(key)
-            if recipe_cls and recipe_cls.is_applicable(model):
+            if recipe_cls and recipe_cls.validate(model):
                 return recipe_cls()
 
         default_recipe_cls = cls._registry.get("")
         if default_recipe_cls:
             return default_recipe_cls()
         raise RuntimeError("No applicable recipe found and no default registered.")
-
-    @classmethod
-    def is_applicable(cls, model):
-        return True  # override for stricter matching
 
     def apply(self, model):
         with pretty_warnings():

--- a/thunder/recipes/base.py
+++ b/thunder/recipes/base.py
@@ -50,6 +50,7 @@ Alternatively, switch to the torch.compile fuser with `fuser="torch.compile"`.
 """
 
 
+@Recipe.register("")
 class BaseRecipe(Recipe):
     """
     Compilation recipe with Thunder defaults. The recipe wires a set of executors, transforms

--- a/thunder/recipes/hf_transformers.py
+++ b/thunder/recipes/hf_transformers.py
@@ -4,6 +4,7 @@ import warnings
 
 import thunder
 from thunder.recipes import BaseRecipe
+from thunder import Recipe
 
 
 class InplaceIndexCopyTransform(thunder.Transform):
@@ -37,6 +38,7 @@ class InplaceIndexCopyTransform(thunder.Transform):
         return pro, comp_new, epi
 
 
+@Recipe.register("transformers")
 class HFTransformers(BaseRecipe):
     """
     Recipe tuned for Hugging Face ``transformers`` models.


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

## What does this PR do?

This simply defaults to the `HFTransformers` recipe when `thunder.compile` is called if the model comes from HF transformers.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
