### PR TITLE
add autocast lookaside to hf recipe for tracing on meta device

### DIFF
--- a/thunder/core/recipe.py
+++ b/thunder/core/recipe.py
@@ -110,8 +110,7 @@ class Recipe:
         if lookasides is not None:
             self._lookaside_executor = TemporaryExecutor()
             for lookaside in lookasides:
-                wrapped_replacement_fn = interpreter.interpreter_needs_wrap(lookaside._replace_with)
-                self._lookaside_executor._lookasides[lookaside._fn] = wrapped_replacement_fn
+                self._lookaside_executor._lookasides[lookaside._fn] = lookaside._replace_with
 
         self.lookasides = lookasides
 

--- a/thunder/core/recipe.py
+++ b/thunder/core/recipe.py
@@ -129,7 +129,7 @@ class Recipe:
         executors = []
 
         if self._lookaside_executor is not None:
-            executors.append(_lookaside_executor)
+            executors.append(self._lookaside_executor)
 
         for plugin in pre_plugins:
             executors.extend(plugin.setup_executors() or [])

--- a/thunder/tests/test_recipes.py
+++ b/thunder/tests/test_recipes.py
@@ -122,6 +122,8 @@ def test_recipe_model_with_cache(model_cls, config_cls):
     deregister_executor("inplace_index_copy_ex")
 
 
+@pytest.mark.skipif(not nvfuser_available(), reason="nvFuser is not available")
+@pytest.mark.skipif(IS_WINDOWS, reason="slow on Windows")
 def test_recipe_hf_meta():
     config = LlamaConfig(
         num_hidden_layers=1,


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [x] (n/a) Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

## What does this PR do?

Recent transformers could be traced on the meta device, but an autocast context manager is erroring (from PyTorch).
We add a lookaside to ignore autocast, and tracing works.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
