### PR TITLE
make test_networks.py not rely on HF downloads

### DIFF
--- a/thunder/tests/test_networks.py
+++ b/thunder/tests/test_networks.py
@@ -421,7 +421,7 @@ def _get_model_config_pairs():
 
 @thunder.tests.framework.requiresCUDA
 @pytest.mark.parametrize("model_cls, config_cls", _get_model_config_pairs())
-def test_recipe_model_hf_for_nemo(model_cls, config_cls):
+def test_hf_for_nemo(model_cls, config_cls):
     from thunder.dynamo import thunderfx
 
     config = config_cls(

--- a/thunder/tests/test_networks.py
+++ b/thunder/tests/test_networks.py
@@ -416,7 +416,7 @@ def _get_model_config_pairs():
         from transformers.models.qwen2 import Qwen2ForCausalLM, Qwen2Config
         return Qwen2ForCausalLM, Qwen2Config
 
-    return [qwen2(), phi3()]
+    return [phi3(), qwen2()]
 
 
 @thunder.tests.framework.requiresCUDA
@@ -434,10 +434,8 @@ def test_recipe_model_hf_for_nemo(model_cls, config_cls):
         max_position_embeddings=128,
         use_cache=True,
         tie_word_embeddings=False,
+        pad_token_id=15
     )
-
-    if "phi" in model_cls.__name__.lower():
-        config.pad_token_id = 15
 
     with torch.device("cuda"):
         model = model_cls(config).to(torch.bfloat16)
@@ -472,8 +470,7 @@ def test_recipe_model_hf_for_nemo(model_cls, config_cls):
     grads_compiled = torch.autograd.grad(compiled_loss, model.parameters(), grad_outputs=loss_grad)
     torch.testing.assert_close(grads_ref, grads_compiled, rtol=1e-2, atol=1e-2)
 
-    if hasattr(torch, 'compile'):
-        torch.compile.reset()  # torch 2.3+
+    torch._dynamo.reset()
 
 
 LLAMA_3_2_1B_CFG = {


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

## What does this PR do?

Robustifies tests by making them not download anything from HF.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
