### PR TITLE
implement partial, avoid tuple addition, test partialmethod

### DIFF
--- a/thunder/core/baseutils.py
+++ b/thunder/core/baseutils.py
@@ -439,7 +439,7 @@ def print_type(typ: type, /, *, with_quotes: bool = True) -> str:
     if with_quotes:
         return f"'{result.group(1)}'"
 
-    return result.group(1).replace(".", "_")
+    return result.group(1).replace(".", "_").replace("<", "_").replace(">", "_")
 
 
 _printable_literals = {

--- a/thunder/core/interpreter.py
+++ b/thunder/core/interpreter.py
@@ -2043,6 +2043,13 @@ def _super_lookaside(cls=Py_NULL(), obj=None):
     return sup
 
 
+def partial_call_lookaside(partial_object, *args, **kwargs):
+    def partial_call_impl(partial_function, /, *args, **kwargs):
+        return partial_function.func(*partial_function.args, *args, **(partial_function.keywords | kwargs))
+
+    return _interpret_call(partial_call_impl, partial_object, *args, **kwargs)
+
+
 @interpreter_needs_wrap
 def _type_lookaside(obj):
     return type(unwrap(obj))
@@ -2831,6 +2838,7 @@ _default_lookaside_map: dict[Callable, Callable] = {
     super: _super_lookaside,
     type: _type_lookaside,
     type.__call__: _type_call_lookaside,
+    functools.partial.__call__: partial_call_lookaside,
     isinstance: _isinstance_lookaside,
     functools.reduce: _functools_reduce_lookaside,
     operator.getitem: _getitem_lookaside,
@@ -6798,13 +6806,11 @@ def _interpret_call(fn: Callable, /, *args, **kwargs) -> Any | INTERPRETER_SIGNA
 #       (1a) The callable is a bound method (implemented in Python), in which case it's canonicalized
 #       (1b) The callable is a builtin method, in which case we try to unbind it
 #   (2) The callable has a lookaside, in which case it's used to execute the operation
-#   (3) The callable is a partial object, in which case it's recursively unwrapped
-#           Note that this case is after (1), which allows for lookasides on partial objects
-#   (4) The callable is opaque, in which case it's executed by the CPython interpreter and its
+#   (3) The callable is opaque, in which case it's executed by the CPython interpreter and its
 #           result returned
-#   (5) The callable is a type object, in which case it is instantiated with __new__ and initialized with __init__
-#   (6) The callable is a callable object, in which case its __call__ attribute is called recursively
-#   (7) The callable is a FunctionType, in which case it's recursively interpretered by the interpreter
+#   (4) The callable is a type object, in which case it is instantiated with __new__ and initialized with __init__
+#   (5) The callable is a callable object, in which case its __call__ attribute is called recursively
+#   (6) The callable is a FunctionType, in which case it's recursively interpretered by the interpreter
 #
 # TODO Consider refactoring this into one function for each case
 def _call_dispatch(
@@ -6944,21 +6950,7 @@ def _call_dispatch(
         res = lookaside_fn(*args, **kwargs)
         return res
 
-    # TODO: disabled as partial is just like any other class
-    # (3) Handles partial objects
-    if isinstance(fn, functools.partial):
-
-        def partial_call_impl(partial_function, /, *args, **kwargs):
-            return partial_function.func(*(partial_function.args + args), **(partial_function.keywords | kwargs))
-
-        return _interpret_call(partial_call_impl, wrapped_fn, *args, **kwargs)
-
-    if isinstance(fn, functools.partialmethod):
-        raise NotImplementedError(
-            "functools.partialmethod objects like {fn} are not currently supported, please file an issue requesting support"
-        )
-
-    # (4) Handles opaque functions
+    # (3) Handles opaque functions
     if is_opaque(fn):
         # TODO: Deeper unwrapping?
         args_ = tuple(unwrap(a) for a in args)
@@ -6978,13 +6970,13 @@ def _call_dispatch(
             opaque_result = wrap(opaque_result, provenance=pr)
         return opaque_result
 
-    # (5) Handle types
+    # (4) Handle types
     if isinstance(fn, type):
         tt = type(fn)  # could be type itself, or a metaclass
         obj = _interpret_call(tt.__call__, wrapped_fn, *args, **kwargs)
         return obj
 
-    # (6) Handles callable objects (with a dunder call method)
+    # (5) Handles callable objects (with a dunder call method)
     if not isinstance(fn, (FunctionType, MethodType)):
         if not hasattr(fn, "__call__"):
             raise NotImplementedError(
@@ -6996,7 +6988,7 @@ def _call_dispatch(
         populate_attribute_wrapper(wrapped_call, "__self__", wrapped_fn)
         return _interpret_call(wrapped_call, *args, **kwargs)
 
-    # (7) interprets into the function
+    # (6) interprets into the function
     assert isinstance(fn, FunctionType), f"{fn=} had an unexpected type ({type(fn)}"
     return _setup_frame_and_run_python_function(compilectx, runtimectx, wrapped_fn, *args, **kwargs)
 

--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -12,6 +12,7 @@ import sys
 import time
 import warnings
 from types import (
+    BuiltinFunctionType,
     BuiltinMethodType,
     CellType,
     FunctionType,

--- a/thunder/tests/test_core.py
+++ b/thunder/tests/test_core.py
@@ -552,10 +552,12 @@ def test_partial_args(executor, device, dtype):
     b = make_tensor((2, 2), device=device, dtype=torch_dtype)
 
     pfoo = partial(foo, a)
+    jpfoo = executor.make_callable(pfoo)
 
-    with pytest.raises(NotImplementedError):
-        cpfoo = executor.make_callable(pfoo)
-        cpfoo(b)
+    res = jpfoo(b)
+    expected = pfoo(b)
+
+    assert_close(res, expected)
 
 
 @instantiate(dtypes=(thunder.float32,))


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [x] n/a Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

## What does this PR do?

This broadens partial support:
- we move the special casing to a more standard lookaside,
- avoiding "+" for tuple concatenation (in favour of `(*t1, *t2)`) avoids breaking prologues in partial, enable the test,
- partialmethod is actually implemented in Python in Python 3.13 (and before), so we can enable it by not failing and adding appropriate tests.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
