### PR TITLE
Support `torch.Tensor.view(dtype)`

### DIFF
--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -279,6 +279,7 @@ class PrimIDs(Enum):
     # Memory access methods
     ITEM = auto()
     COPY_ = auto()
+    BITCAST = auto()
     #
     SINK = auto()
 
@@ -4332,6 +4333,27 @@ def copy__meta(
 
 
 copy_ = make_prim(PrimIDs.COPY_, "copy_", meta=copy__meta, tags=(OpTags.DONT_DCE,))
+
+
+def bitcast_meta(
+    src: TensorProxy,
+    dtype: dtypes.dtype,
+) -> TensorProxy:
+    shape = list(src.shape)
+    src_itemsize = src.dtype.bytes
+    dst_itemsize = dtype.bytes
+    if src_itemsize != dst_itemsize:
+        factor = dst_itemsize / src_itemsize
+        if factor > 1:
+            utils.check(
+                shape[-1] > factor and shape[-1] % factor == 0,
+                lambda: f"{src.shape[-1]=} is not divisible by {factor=}. Viewing {src.dtype=} as {dtype=}",
+            )
+        shape[-1] = int(shape[-1] / factor)
+    return TensorProxy(shape=tuple(shape), device=src.device, dtype=dtype)
+
+
+bitcast = make_prim(PrimIDs.BITCAST, "bitcast", meta=bitcast_meta)
 
 
 def sink_meta(*args, **kwargs):

--- a/thunder/core/trace_interpreter.py
+++ b/thunder/core/trace_interpreter.py
@@ -270,7 +270,6 @@ class TraceSubstitutionProcessor:
 
     def read(self, x: VariableInterface | Any) -> Any:
         if isinstance(x, VariableInterface):
-            print(f"{self.env = }, {x=}")
             return self.env[x.name]
         else:
             return x

--- a/thunder/core/trace_interpreter.py
+++ b/thunder/core/trace_interpreter.py
@@ -270,6 +270,7 @@ class TraceSubstitutionProcessor:
 
     def read(self, x: VariableInterface | Any) -> Any:
         if isinstance(x, VariableInterface):
+            print(f"{self.env = }, {x=}")
             return self.env[x.name]
         else:
             return x

--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -2548,7 +2548,6 @@ def _bitcast_prim_grad(src: TensorProxy, dtype: dtypes.dtype) -> TensorProxy:
     g = get_grad(fwd)
     src_grad = prims.bitcast(g, src.dtype)
     put_grad(src, src_grad)
-    # put_grad((src, dtype), (src_grad, None))
 
     return fwd
 

--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -1649,6 +1649,7 @@ augmented_forward_impls = {
     prims.PrimIDs.FMOD: lambda x, y: (prims.fmod(x, y), (x, y)),
     prims.PrimIDs.COPY_: lambda x, y, grad_enabled: (prims.copy_(x, y, grad_enabled=grad_enabled), tuple()),
     prims.PrimIDs.CLONE: lambda x: (prims.clone(x), tuple()),
+    prims.PrimIDs.BITCAST: lambda x, dtype: (prims.bitcast(x, dtype), (x.dtype,)),
 }
 
 
@@ -1679,6 +1680,7 @@ backward_impls = {
     prims.PrimIDs.FMOD: lambda x, y, g: (g, -g * prims.trunc(x / y)),
     prims.PrimIDs.COPY_: lambda g: (g, None),
     prims.PrimIDs.CLONE: lambda g: g,
+    prims.PrimIDs.BITCAST: lambda x_dtype, g: (prims.bitcast(g, x_dtype), None),
 }
 
 
@@ -2540,19 +2542,6 @@ def index_put_backward(indices: Sequence[TensorProxy], values: TensorProxy, accu
     if accumulate:
         return g, g_values
     return clang.index_put(g, indices, ltorch.zeros_like(values), False), g_values
-
-
-def _bitcast_prim_grad(src: TensorProxy, dtype: dtypes.dtype) -> TensorProxy:
-    fwd = prims.bitcast(src, dtype)
-
-    g = get_grad(fwd)
-    src_grad = prims.bitcast(g, src.dtype)
-    put_grad(src, src_grad)
-
-    return fwd
-
-
-register_grad(pids.BITCAST, _bitcast_prim_grad)
 
 
 def uniform_aug_fwd(shape, minval, maxval, *, device, dtype):

--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -2542,6 +2542,20 @@ def index_put_backward(indices: Sequence[TensorProxy], values: TensorProxy, accu
     return clang.index_put(g, indices, ltorch.zeros_like(values), False), g_values
 
 
+def _bitcast_prim_grad(src: TensorProxy, dtype: dtypes.dtype) -> TensorProxy:
+    fwd = prims.bitcast(src, dtype)
+
+    g = get_grad(fwd)
+    src_grad = prims.bitcast(g, src.dtype)
+    put_grad(src, src_grad)
+    # put_grad((src, dtype), (src_grad, None))
+
+    return fwd
+
+
+register_grad(pids.BITCAST, _bitcast_prim_grad)
+
+
 def uniform_aug_fwd(shape, minval, maxval, *, device, dtype):
     primal = prims.uniform(shape, minval, maxval, device=device, dtype=dtype)
     return VJPDual(primal, (primal, minval, maxval))

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -970,6 +970,25 @@ def convert_element_type(
 
 register_supported(PrimIDs.CONVERT_ELEMENT_TYPE, convert_element_type, _convert_element_type_check)
 
+
+def _bitcast_check(src: TensorProxy, dtype: dtypes.dtype) -> bool:
+    return (
+        nvfuser_version() > LooseVersion("0.29.0")
+        and _convert_element_type_check(src, dtype)
+        and src.dtype.bytes == dtype.bytes
+    )
+
+
+# TODO: Expose bitcast in nvfuser to Python.
+# def bitcast(src: TensorProxy, dtype: dtypes.dtype, *, fd: FusionDefinition, lc_to_nv_map: dict):
+#     nva = getnv(src, fd, lc_to_nv_map)
+#     nvdtype = lcdtype_to_nvdtype(dtype)
+#
+#     return fd.ops.bitcast(nva, nvdtype)
+#
+#
+# register_supported(PrimIDs.BITCAST, bitcast, _bitcast_check)
+
 #
 # Tensor creation operations
 #

--- a/thunder/executors/torchex.py
+++ b/thunder/executors/torchex.py
@@ -2376,6 +2376,14 @@ shape = ex.register_operator("shape", meta=prims.shape_meta, fn=_shape_impl)
 _register_implementation(prims.shape, shape, checker=_always_executable)
 
 
+def _bitcast_impl(src, dtype):
+    return src.view(dtypes.to_torch_dtype(dtype))
+
+
+bitcast = ex.register_operator("bitcast", meta=prims.bitcast, fn=_bitcast_impl)
+_register_implementation(prims.bitcast, bitcast, checker=_always_executable)
+
+
 shallow_copy = ex.register_operator("shallow_copy", meta=prims.shallow_copy, fn=lambda x: x)
 _register_implementation(prims.shallow_copy, shallow_copy, checker=_always_executable)
 

--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -3513,6 +3513,20 @@ to_opinfo = OpInfo(
 data_movement_ops.append(to_opinfo)
 
 
+def view_with_dtype_sample_generator(op, device, dtype, requires_grad, **kwargs):
+    make = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)
+
+    for dst_dtype in {torch.float32, torch.bfloat16, torch.float64} - {dtype}:
+        yield SampleInput(make((8, 8)), dtype)
+
+
+view_with_dtype_opinfo = OpInfo(
+    ltorch.view,
+    sample_input_generator=view_with_dtype_sample_generator,
+    torch_reference=torch.Tensor.view,
+)
+
+
 def cuda_sample_generator(op, device, dtype, requires_grad, **kwargs):
     make = partial(make_tensor, device=device, dtype=dtype, requires_grad=requires_grad)
 

--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -3525,6 +3525,7 @@ view_with_dtype_opinfo = OpInfo(
     sample_input_generator=view_with_dtype_sample_generator,
     torch_reference=torch.Tensor.view,
 )
+data_movement_ops.append(view_with_dtype_opinfo)
 
 
 def cuda_sample_generator(op, device, dtype, requires_grad, **kwargs):

--- a/thunder/tests/test_grad.py
+++ b/thunder/tests/test_grad.py
@@ -407,7 +407,11 @@ def test_vjp_correctness(op, device, dtype, executor, comp):
         # sample.thunder() line below attempts to approximate those conversions
         # for non-differentiable arguments like dtypes so that the test will
         # execute properly.
-        sample = sample.thunder()  # converts torch.dtype to thunder.dtype
+        # NOTE: While `convert_element_type` is skipeed as of https://github.com/Lightning-AI/lightning-thunder/pull/2213
+        # as in https://github.com/Lightning-AI/lightning-thunder/blob/dbf6bad3/thunder/tests/opinfos.py#L3324-L3346,
+        # `torch.Tensor.view(dtype)` seems to require `torch.dtype` to be kept as is, opposite to `convert_element_type`.
+        if op.name != "view":
+            sample = sample.thunder()  # converts torch.dtype to thunder.dtype
         sample = sample.remove_singularities(op, eps)
 
         flat_op, flat_args, spec = flatten_func(op.op, sample.args, sample.kwargs)

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -1498,6 +1498,8 @@ def unsqueeze(a: TensorLike, /, dim: int) -> TensorLike:
 @torchsymbol(torch.Tensor.view, is_method=True)
 def view(a: TensorLike, /, *shape) -> TensorLike:
     shape = utils.extract_shape_from_varargs(shape)
+    if len(shape) == 1 and isinstance(shape[0], torch.dtype):
+        return to(a, dtype=shape[0])
     return reshape(a, shape)
 
 

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -1500,6 +1500,13 @@ def unsqueeze(a: TensorLike, /, dim: int) -> TensorLike:
 def view(a: TensorLike, /, *shape) -> TensorLike:
     shape = utils.extract_shape_from_varargs(shape)
     if len(shape) == 1 and isinstance(shape[0], torch.dtype):
+        dst_dtype = to_dtype(shape[0])
+        src_dtype = to_dtype(a.dtype)
+        utils.check(
+            dst_dtype.bytes == src_dtype.bytes,
+            lambda: f"`a.view({shape[0]})` is not supported as a's itemsize is {src_dtype.bytes} but target dtype itemsize is {dst_dtype.bytes}",
+            exception_type=NotImplementedError,
+        )
         return to(a, dtype=shape[0])
     return reshape(a, shape)
 

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -1507,7 +1507,7 @@ def view(a: TensorLike, /, *shape) -> TensorLike:
             lambda: f"`a.view({shape[0]})` is not supported as a's itemsize is {src_dtype.bytes} but target dtype itemsize is {dst_dtype.bytes}",
             exception_type=NotImplementedError,
         )
-        return to(a, dtype=shape[0])
+        return prims.bitcast(a, dtype=to_dtype(shape[0]))
     return reshape(a, shape)
 
 

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -1500,13 +1500,6 @@ def unsqueeze(a: TensorLike, /, dim: int) -> TensorLike:
 def view(a: TensorLike, /, *shape) -> TensorLike:
     shape = utils.extract_shape_from_varargs(shape)
     if len(shape) == 1 and isinstance(shape[0], (torch.dtype, dtypes.dtype)):
-        dst_dtype = to_dtype(shape[0])
-        src_dtype = to_dtype(a.dtype)
-        utils.check(
-            dst_dtype.bytes == src_dtype.bytes,
-            lambda: f"`a.view({shape[0]})` is not supported as a's itemsize is {src_dtype.bytes} but target dtype itemsize is {dst_dtype.bytes}",
-            exception_type=NotImplementedError,
-        )
         return prims.bitcast(a, dtype=to_dtype(shape[0]))
     return reshape(a, shape)
 

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -1499,7 +1499,7 @@ def unsqueeze(a: TensorLike, /, dim: int) -> TensorLike:
 @torchsymbol(torch.Tensor.view, is_method=True)
 def view(a: TensorLike, /, *shape) -> TensorLike:
     shape = utils.extract_shape_from_varargs(shape)
-    if len(shape) == 1 and isinstance(shape[0], torch.dtype):
+    if len(shape) == 1 and isinstance(shape[0], (torch.dtype, dtypes.dtype)):
         dst_dtype = to_dtype(shape[0])
         src_dtype = to_dtype(a.dtype)
         utils.check(

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -1495,6 +1495,7 @@ def unsqueeze(a: TensorLike, /, dim: int) -> TensorLike:
 
 
 # TODO Add type annotations
+# TODO(crcrpar): see [Return value of view creation ops]
 @torchsymbol(torch.Tensor.view, is_method=True)
 def view(a: TensorLike, /, *shape) -> TensorLike:
     shape = utils.extract_shape_from_varargs(shape)
@@ -6812,6 +6813,11 @@ _syms_that_may_return_views: set[Symbol] = {
     _torch_to_thunder_function_map[torch.Tensor.reshape_as],
 }
 
+# TODO(crcrpar): [Return value of view creation ops]
+# Review what's more appropriate return value from the ops below.
+# Currently they return a new tensor, which obscures the nature of these ops, i.e.,
+# outputs share underlying storage with inputs. For more stable and improved in-place support
+# it'd be necessary to think about e.g. extending TensorProxy and/or DCE.
 _syms_returning_views: set[Symbol] = {
     diagonal,
     expand,


### PR DESCRIPTION
## What does this PR do?

Adding `bitcast` primitive as nvfuser's bitcast op would be used once it's exposed to Python
Fixes #2212