### PR TITLE
Add missing opinfo for `bitwise_right_shift` to `elementwise_binary_ops`

### DIFF
--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -2885,7 +2885,7 @@ bitwise_right_shift_opinfo = OpInfo(
     dtypes=(datatypes.signedinteger, datatypes.unsignedinteger),
     torch_reference=torch.bitwise_right_shift,
 )
-elementwise_binary_ops.append(bitwise_left_shift_opinfo)
+elementwise_binary_ops.append(bitwise_right_shift_opinfo)
 
 # Puts all opinfos into the "opinfos" list
 opinfos.extend(elementwise_binary_ops)


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/Lightning-AI/lightning-thunder/blob/62d9535bfeab621b571c3cc8aed974b64381aad0/thunder/tests/opinfos.py#L2872-L2878 where I should've append `bitwise_right_shift_opinfo`.

follow-up of #2210