### PR TITLE
unxfail passing test

### DIFF
--- a/thunder/tests/test_core.py
+++ b/thunder/tests/test_core.py
@@ -9,6 +9,7 @@ import weakref
 import pytest
 import torch
 from torch.testing import assert_close, make_tensor
+from lightning_utilities import compare_version
 
 import thunder
 from thunder import cache_option, cache_hits, cache_misses
@@ -2816,6 +2817,7 @@ def test_change_default_device_in_jitted_fn():
 
 @requiresCUDA
 @pytest.mark.xfail(
+    compare_version("torch", operator.le, "2.7.1", use_base_version=True),
     reason="When using device as context in PyTorch, it doesn't reflect in torch.get_default_device - see https://github.com/pytorch/pytorch/issues/131328",
     strict=True,
 )


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [x] n/a Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

Recently, @kshitij12345 fixed `get_default_device` appreciating `with device:` .:rocket:
So we unxfail the test for future versions of PyTorch. 

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
