### PR TITLE
Fixes baddbmm() got an unexpected keyword argument 'batch1'

### DIFF
--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -7367,6 +7367,9 @@ def baddbmm_sample_generator(op, device, dtype, requires_grad, **kwargs):
             for alpha, beta in float_constants_cases:
                 yield SampleInput(make(shape_in), make(shape_batch1), make(shape_batch2), alpha=alpha, beta=beta)
 
+    if isinstance(to_dtype(dtype), datatypes.exact):
+        yield SampleInput(make(3, 5, 6), batch1=make(3, 5, 0), batch2=make(3, 0, 6), alpha=2, beta=2)
+
 
 def baddbmm_error_generator(op, device, dtype=torch.int32, **kwargs):
     make = partial(make_tensor, device=device, dtype=dtype)

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -4400,20 +4400,26 @@ def local_response_norm(
 
 @torchsymbol(torch.baddbmm, is_method=True)
 def baddbmm(
-    a: TensorLike, b1: TensorLike, b2: TensorLike, *, beta: float = 1.0, alpha: float = 1.0, out: TensorLike = None
+    a: TensorLike,
+    batch1: TensorLike,
+    batch2: TensorLike,
+    *,
+    beta: float = 1.0,
+    alpha: float = 1.0,
+    out: TensorLike = None,
 ) -> TensorLike:
     utils.check(out is None, lambda: "Non-None out is not supported", NotImplementedError)
 
-    utils.check_same_dtype(a, b1, b2)
-    utils.check_same_device(a, b1, b2)
-    utils.check(b1.ndim == 3, lambda: f"batch1 must be a 3D tensor, found {b1.ndim} instead.")
-    utils.check(b2.ndim == 3, lambda: f"batch2 must be a 3D tensor, found {b2.ndim} instead.")
+    utils.check_same_dtype(a, batch1, batch2)
+    utils.check_same_device(a, batch1, batch2)
+    utils.check(batch1.ndim == 3, lambda: f"batch1 must be a 3D tensor, found {batch1.ndim} instead.")
+    utils.check(batch2.ndim == 3, lambda: f"batch2 must be a 3D tensor, found {batch2.ndim} instead.")
 
     if a.dtype not in dtypes.inexact_dtypes:
         utils.check_type(beta, int)
         utils.check_type(alpha, int)
 
-    t0 = matmul(b1, b2)
+    t0 = matmul(batch1, batch2)
     t1 = alpha * t0
     return t1 + (beta * a)
 


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

related to #2169 , fixes an issue where thunder fails when calling `baddbmm(x, batch1=a, batch2=b)` using keyword arguments.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
