### PR TITLE
add float exception to assertion in jit_ext

### DIFF
--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -1980,7 +1980,9 @@ def process_recorded_modifications(ctx, epilogue_trace):
                         name = k
                         setattr_obj_provenance = modified_object.provenance.inputs[0]
                         if hasattr(setattr_obj_provenance, "proxy"):
-                            assert isinstance(value.value, (Proxy, int, float, tuple, NoneType))  # todo: better criterion
+                            assert isinstance(
+                                value.value, (Proxy, int, float, tuple, NoneType)
+                            )  # todo: better criterion
                             setattr_obj_proxy = setattr_obj_provenance.proxy
                             with tracectx(epilogue_trace):
                                 bsym = prims.pack_attr.bind(setattr_obj_proxy, name, value.value, output=None)

--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -1952,7 +1952,7 @@ def process_recorded_modifications(ctx, epilogue_trace):
                         and modified_object.provenance.inputs[1].inst is PseudoInst.CONSTANT
                         and modified_object.provenance.inputs[1].value == "_buffers"
                     ):
-                        assert isinstance(value.value, (Proxy, int, tuple, NoneType))  # todo: better criterion
+                        assert isinstance(value.value, (Proxy, int, float, tuple, NoneType))  # todo: better criterion
                         if modified_object.provenance.inputs[0].inst is PseudoInst.INPUT_FN:
                             name = [""]
                             root_module_provenance = modified_object.provenance.inputs[0]
@@ -1980,7 +1980,7 @@ def process_recorded_modifications(ctx, epilogue_trace):
                         name = k
                         setattr_obj_provenance = modified_object.provenance.inputs[0]
                         if hasattr(setattr_obj_provenance, "proxy"):
-                            assert isinstance(value.value, (Proxy, int, tuple, NoneType))  # todo: better criterion
+                            assert isinstance(value.value, (Proxy, int, float, tuple, NoneType))  # todo: better criterion
                             setattr_obj_proxy = setattr_obj_provenance.proxy
                             with tracectx(epilogue_trace):
                                 bsym = prims.pack_attr.bind(setattr_obj_proxy, name, value.value, output=None)


### PR DESCRIPTION
Compilation was crashing when running on modules such as `https://github.com/vllm-project/vllm/blob/8b6e1d639c66d5828d03a7df2c3a500030a5c5cd/vllm/attention/layer.py#L27`, in particular due to the `scale: float` argument.
