### PR TITLE
Fix `bitsandbytes` dependency conditions to use `platform_machine` instead of `sys_platform`

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -17,8 +17,8 @@ absl-py # thunder/benchmarks/test_benchmark_litgpt.py
 pandas # thunder/benchmarks/test_benchmark_litgpt.py
 xlsxwriter # thunder/benchmarks/test_benchmark_litgpt.py
 jsonargparse # thunder/benchmarks/benchmark_litgpt.py
-bitsandbytes>=0.44,<0.45; sys_platform!='darwin'
-bitsandbytes>=0.42,<0.43; sys_platform=='darwin'
+bitsandbytes>=0.44,<0.45; 'arm' not in platform_machine
+bitsandbytes>=0.42,<0.43; 'arm' in platform_machine
 transformers==4.52.4 # for test_networks.py
 
 # Installs JAX on Linux and MacOS


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Fix for https://github.com/Lightning-AI/lightning-thunder/pull/2122/files#r2154942171

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
