### PR TITLE
register softmax fudge function for stacklevel

### DIFF
--- a/thunder/tests/test_ops.py
+++ b/thunder/tests/test_ops.py
@@ -548,3 +548,12 @@ def test_multi_dot_optimization():
         if bsym.sym.id == "matmul":
             for flat_out in bsym.flat_outs:
                 assert flat_out.shape != (100, 100)
+
+
+def test_softmax_stacklevel():
+    def fn(a):
+        return torch.nn.functional.softmax(a, -1, _stacklevel=5)
+
+    jfn = thunder.jit(fn)
+    a = torch.randn(5, 5, requires_grad=True)  # trigger grad transform
+    assert_close(fn(a), jfn(a))

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -5891,7 +5891,7 @@ def sigmoid(a: TensorLike, /) -> TensorLike:
 
 
 # CompositeImplicitAutograd - don't register decomp
-@torchsymbol(torch.softmax, torch.nn.functional.softmax, is_method=True, id="torch.softmax")
+@torchsymbol(torch.softmax, is_method=True, id="torch.softmax")
 def _softmax(
     a: TensorLike,
     /,
@@ -5922,6 +5922,9 @@ register_method("softmax", _softmax)
 # ref: https://github.com/pytorch/pytorch/blob/8d12ba9acfa20ed7df438a8892c9bf8e6bef5775/torch/nn/modules/activation.py#L1545
 def softmax(a: TensorLike, dim: int, dtype: None | dtypeLike = None, _stacklevel: int = 3) -> TensorLike:
     return _softmax(a, dim=dim, dtype=dtype)
+
+
+register_function(torch.nn.functional.softmax, softmax)
 
 
 @torchsymbol(torch.nn.functional.softmin, is_method=False, id="torch.nn.functional.softmin")


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes the registration of the lookaside for `torch.nn.functional.softmax` to be `thunder.torch.softmax`.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
