### PR TITLE
remove W291 from ruff ignore rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,7 +172,6 @@ ignore = [
     "E741",  # https://docs.astral.sh/ruff/rules/ambiguous-variable-name/
     "W293",  # https://docs.astral.sh/ruff/rules/blank-line-with-whitespace/
     "F811",  # https://docs.astral.sh/ruff/rules/redefined-while-unused/
-    "W291",  # https://docs.astral.sh/ruff/rules/trailing-whitespace/
 ]
 
 [tool.ruff.lint.per-file-ignores]


### PR DESCRIPTION
## What does this PR do?

Apparently the trailing white spaces that existed
when ruff check got enabled seem to be removed.

Related:
- #2218 