### PR TITLE
skip complex dtype tensor from `aminmax`

### DIFF
--- a/thunder/dynamo/utils.py
+++ b/thunder/dynamo/utils.py
@@ -518,7 +518,12 @@ def _get_storage_shape(t: torch.Tensor):
 
 def _get_min_and_val(t: torch.Tensor) -> tuple[Number | None, Number | None]:
     # We assume that for TensorSubclass, `aminmax` is not supported which is true for FakeTensor and DTensor.
-    if (isinstance(t, torch.Tensor) and type(t) is not torch.Tensor) or t.device.type == "meta" or t.numel() == 0 or t.dtype.is_complex:
+    if (
+        (isinstance(t, torch.Tensor) and type(t) is not torch.Tensor)
+        or t.device.type == "meta"
+        or t.numel() == 0
+        or t.dtype.is_complex
+    ):
         return None, None
     if t.dtype in (torch.float8_e4m3fn, torch.float8_e4m3fnuz, torch.float8_e5m2, torch.float8_e5m2fnuz):
         t = t.to(torch.float32)

--- a/thunder/dynamo/utils.py
+++ b/thunder/dynamo/utils.py
@@ -518,7 +518,7 @@ def _get_storage_shape(t: torch.Tensor):
 
 def _get_min_and_val(t: torch.Tensor) -> tuple[Number | None, Number | None]:
     # We assume that for TensorSubclass, `aminmax` is not supported which is true for FakeTensor and DTensor.
-    if (isinstance(t, torch.Tensor) and type(t) is not torch.Tensor) or t.device.type == "meta" or t.numel() == 0:
+    if (isinstance(t, torch.Tensor) and type(t) is not torch.Tensor) or t.device.type == "meta" or t.numel() == 0 or t.dtype.is_complex:
         return None, None
     if t.dtype in (torch.float8_e4m3fn, torch.float8_e4m3fnuz, torch.float8_e5m2, torch.float8_e5m2fnuz):
         t = t.to(torch.float32)


### PR DESCRIPTION
## What does this PR do?

As per title, since `aminmax` does not support complex dtypes