### PR TITLE
Add the support of `uint8` / `Byte` to nvfuser executor

### DIFF
--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -119,6 +119,15 @@ if nvfuser_version() >= LooseVersion("0.2.27"):
         }
     )
 
+# TODO: Need to check the version which has https://github.com/NVIDIA/Fuser/pull/4715
+if nvfuser_version() >= LooseVersion("0.2.28"):
+    _lcdtype_to_nvdtype_map.update(
+        {
+            dtypes.uint8: DataType.Byte,
+            dtypes.uint8_: DataType.Byte,
+        }
+    )
+
 _lcfp8_to_nvfp8_map: dict[dtypes.dtype, DataType] = {
     dtypes.float8_e5m2: DataType.Float8_e5m2,
     dtypes.float8_e5m2_: DataType.Float8_e5m2,


### PR DESCRIPTION
## What does this PR do?

As per title, this PR adds the map of `thunder.core.dtypes.uint8`/`thunder.core.dtypes.uint8_` to `nvfuser.DataType.Byte`.

This depends on https://github.com/NVIDIA/Fuser/pull/4715.