### PR TITLE
Add support for torch.float4_e2m1fn_x2

### DIFF
--- a/thunder/core/baseutils.py
+++ b/thunder/core/baseutils.py
@@ -368,26 +368,6 @@ def indent(level):
     return f"{tab * level}"
 
 
-_torch_dtype_to_str_map = {
-    torch.bool: "torch.bool",
-    torch.uint8: "torch.uint8",
-    torch.int8: "torch.int8",
-    torch.int16: "torch.int16",
-    torch.int32: "torch.int32",
-    torch.int64: "torch.int64",
-    torch.bfloat16: "torch.bfloat16",
-    torch.float8_e4m3fn: "torch.float8_e4m3fn",
-    torch.float8_e4m3fnuz: "torch.float8_e4m3fnuz",
-    torch.float8_e5m2: "torch.float8_e5m2",
-    torch.float8_e5m2fnuz: "torch.float8_e5m2fnuz",
-    torch.float16: "torch.float16",
-    torch.float32: "torch.float32",
-    torch.float64: "torch.float64",
-    torch.complex32: "torch.complex32",
-    torch.complex64: "torch.complex64",
-    torch.complex128: "torch.complex128",
-}
-
 _type_to_str_map = {
     bool: "bool",
     int: "int",
@@ -451,7 +431,7 @@ _printable_literals = {
 _printable_value_types = {
     str: lambda s: f'"{s}"',
     torch.device: lambda d: f'torch.device("{str(d)}")',
-    torch.dtype: lambda d: _torch_dtype_to_str_map[d],
+    torch.dtype: str,
     bool: lambda b: str(b),
     int: lambda b: str(b),
     float: _print_float_number,

--- a/thunder/core/dtypes.py
+++ b/thunder/core/dtypes.py
@@ -182,6 +182,8 @@ class floating(inexact):
 
 bfloat16 = floating("bfloat", "bf", bytes=2, is_weak=False)
 bfloat16_ = floating("bfloat", "bf", bytes=2, is_weak=True)
+float4_e2m1fn_x2 = floating("float", "f", bytes=1, is_weak=False, variant="e2m1fn_x2")
+float4_e2m1fn_x2_ = floating("float", "f", bytes=1, is_weak=True, variant="e2m1fn_x2")
 float8_e5m2 = floating("float", "f", bytes=1, is_weak=False, variant="e5m2")
 float8_e5m2_ = floating("float", "f", bytes=1, is_weak=True, variant="e5m2")
 float8_e5m2fnuz = floating("float", "f", bytes=1, is_weak=False, variant="e5m2fnuz")

--- a/thunder/core/dtypes.py
+++ b/thunder/core/dtypes.py
@@ -48,6 +48,8 @@ from thunder.core.baseutils import NumberProxyInterface, TensorProxyInterface
 
 _abstract_classes = set()
 
+all_dtypes = set()
+
 
 # TODO consider bytes per element to better identify low precision dtypes
 class dtype:
@@ -66,6 +68,7 @@ class dtype:
         self._shortname = shortname
         self._bytes = bytes
         self._is_weak = is_weak
+        all_dtypes.add(self)
 
     # NOTE: these are properties so they appear as read-only
     @property
@@ -211,43 +214,6 @@ complex128_ = complexfloating("complex", "c", bytes=16, is_weak=True)
 
 
 _abstract_classes.update((dtype, exact, inexact))
-
-all_dtypes = {
-    bool8,
-    bool8_,
-    uint8,
-    uint8_,
-    int8,
-    int8_,
-    int16,
-    int16_,
-    int32,
-    int32_,
-    int64,
-    int64_,
-    bfloat16,
-    bfloat16_,
-    float8_e5m2,
-    float8_e5m2_,
-    float8_e5m2fnuz,
-    float8_e5m2fnuz_,
-    float8_e4m3fn,
-    float8_e4m3fn_,
-    float8_e4m3fnuz,
-    float8_e4m3fnuz_,
-    float16,
-    float16_,
-    float32,
-    float32_,
-    float64,
-    float64_,
-    complex32,
-    complex32_,
-    complex64,
-    complex64_,
-    complex128,
-    complex128_,
-}
 
 all_numbertypes = {bool, int, float, complex}
 

--- a/thunder/core/dtypes.py
+++ b/thunder/core/dtypes.py
@@ -499,41 +499,13 @@ _thunder_to_torch_dtype_map = {
     int: torch.int32,
     float: torch.float32,
     complex: torch.complex64,
-    bool8_: torch.bool,
-    bool8: torch.bool,
-    uint8_: torch.uint8,
-    uint8: torch.uint8,
-    int8_: torch.int8,
-    int8: torch.int8,
-    int16_: torch.int16,
-    int16: torch.int16,
-    int32_: torch.int32,
-    int32: torch.int32,
-    int64_: torch.int64,
-    int64: torch.int64,
-    bfloat16_: torch.bfloat16,
-    bfloat16: torch.bfloat16,
-    float8_e5m2: torch.float8_e5m2,
-    float8_e5m2_: torch.float8_e5m2,
-    float8_e5m2fnuz: torch.float8_e5m2fnuz,
-    float8_e5m2fnuz_: torch.float8_e5m2fnuz,
-    float8_e4m3fn: torch.float8_e4m3fn,
-    float8_e4m3fn_: torch.float8_e4m3fn,
-    float8_e4m3fnuz: torch.float8_e4m3fnuz,
-    float8_e4m3fnuz_: torch.float8_e4m3fnuz,
-    float16_: torch.float16,
-    float16: torch.float16,
-    float32_: torch.float32,
-    float32: torch.float32,
-    float64_: torch.float64,
-    float64: torch.float64,
-    complex32_: torch.complex32,
-    complex32: torch.complex32,
-    complex64_: torch.complex64,
-    complex64: torch.complex64,
-    complex128_: torch.complex128,
-    complex128: torch.complex128,
 }
+
+_thunder_to_torch_dtype_map.update({
+    dtype: getattr(torch, dtype.full_name.rstrip('_'))
+    for dtype in all_dtypes
+    if hasattr(torch, dtype.full_name.rstrip('_'))
+})
 
 _torch_to_thunder_dtype_map = {
     v: k

--- a/thunder/core/dtypes.py
+++ b/thunder/core/dtypes.py
@@ -372,26 +372,7 @@ def corresponding_complex_dtype(dtype):
     return _real_to_complex_dtype_map[dtype]
 
 
-_strong_dtype_to_weak_dtype_map = {
-    bool8: bool8_,
-    uint8: uint8_,
-    uint64: uint64_,
-    int8: int8_,
-    int16: int16_,
-    int32: int32_,
-    int64: int64_,
-    bfloat16: bfloat16_,
-    float8_e5m2: float8_e5m2_,
-    float8_e5m2fnuz: float8_e5m2fnuz_,
-    float8_e4m3fn: float8_e4m3fn_,
-    float8_e4m3fnuz: float8_e4m3fnuz_,
-    float16: float16_,
-    float32: float32_,
-    float64: float64_,
-    complex32: complex32_,
-    complex64: complex64_,
-    complex128: complex128_,
-}
+_strong_dtype_to_weak_dtype_map = {dtype: eval(f"{dtype.full_name}_") for dtype in all_dtypes if not dtype.is_weak}
 
 _weak_dtype_to_strong_dtype_map = {v: k for k, v in _strong_dtype_to_weak_dtype_map.items()}
 _weak_dtype_to_strong_dtype_map.update(

--- a/thunder/tests/test_core.py
+++ b/thunder/tests/test_core.py
@@ -3225,6 +3225,14 @@ def test_apply_autograd_memory(thunderfx_disable_split_autograd):
     assert not any(wr() for wr in foo())
 
 
+def test_float4_e2m1fn_x2():
+    x = torch.ones(2, 2, dtype=torch.uint8).view(torch.float4_e2m1fn_x2)
+    @thunder.jit
+    def f(x): return x
+    y = f(x)
+    assert y.dtype == torch.float4_e2m1fn_x2
+
+
 def test_thunder_jit_parts():
     m = torch.nn.Sequential(
         torch.nn.Linear(64, 128),


### PR DESCRIPTION
Adds ability to specify `float4_e2m1fn_x2` dtype for TensorProxies.

I've updated various dictionaries and sets to be autopopulated when a new dtype is added.