### PR TITLE
[TE] catch different error for xfail test

### DIFF
--- a/thunder/tests/test_transformer_engine_executor.py
+++ b/thunder/tests/test_transformer_engine_executor.py
@@ -208,8 +208,11 @@ def test_te_with_autocast():
 
 
 # NOTE: strict=False as it passes on Blackwell.
+# NOTE: Type of the error is different in different versions.
 @pytest.mark.xfail(
-    strict=False, raises=(ValueError), reason="See https://github.com/Lightning-AI/lightning-thunder/issues/2221"
+    strict=False,
+    raises=(ValueError, TypeError),
+    reason="See https://github.com/Lightning-AI/lightning-thunder/issues/2221",
 )
 @requiresCUDA
 def test_te_with_retain_graph():


### PR DESCRIPTION
This xfail test is failing with different error.

Happens only on H100 (or devices) where default recipe is DelayedScaling.

```python
E       TypeError: 'NoneType' object is not iterable                                                                                                                                                                                                                                                                                                                                                    /usr/local/lib/python3.12/dist-packages/transformer_engine/pytorch/tensor/quantized_tensor.py:116: TypeError                                                  

===================================================================================== short test summary info ======================================================================================

FAILED thunder/tests/test_transformer_engine_executor.py::test_te_with_retain_graph - TypeError: 'NoneType' object is not iterable

======================================================================= 1 failed, 8 passed, 2 skipped, 43 warnings in 5.76s ========================================================================
```


Tested on H100 (default recipe delayed scaling), B200 (default recipe mxfp8 scaling)