### PR TITLE
Remove external logger dependency

### DIFF
--- a/requirements/devel.txt
+++ b/requirements/devel.txt
@@ -2,5 +2,4 @@ packaging
 -r test.txt
 
 datasets>=3.5.0
-loguru>=0.7.3
 peft>=0.15.2

--- a/thunder/benchmarks/benchmark_peft.py
+++ b/thunder/benchmarks/benchmark_peft.py
@@ -35,7 +35,7 @@ os.environ["HF_HUB_ETAG_TIMEOUT"] = "60"  # Increase timeout to 60 seconds
 
 logger: logging.Logger = logging.getLogger("peft_benchmark")
 handler = logging.StreamHandler()
-fmt = logging.Formatter("%(asctime)-8s %(levelname)-4s %(message)s", datefmt="%y-%m-%d %H:%M")
+fmt = logging.Formatter("%(asctime)-8s %(levelname)-4s %(message)s", datefmt="%y-%m-%d %H:%M:%S")
 handler.setFormatter(fmt)
 logger.addHandler(handler)
 

--- a/thunder/benchmarks/benchmark_peft.py
+++ b/thunder/benchmarks/benchmark_peft.py
@@ -3,6 +3,7 @@ import argparse
 import os
 import random
 import time
+import logging
 from contextlib import contextmanager
 from datetime import timedelta
 from looseversion import LooseVersion
@@ -12,7 +13,6 @@ import torch.distributed as torch_dist
 from torch.nn.attention import SDPBackend, sdpa_kernel
 
 from tqdm import tqdm
-from loguru import logger
 
 from transformers import AutoConfig, AutoModel, AutoModelForCausalLM, AutoTokenizer, WordpieceTokenizer
 from peft import LoraConfig, get_peft_model
@@ -33,8 +33,14 @@ if WORLD_SIZE > 1:
 os.environ["HF_HUB_DOWNLOAD_TIMEOUT"] = "60"  # Increase timeout to 60 seconds
 os.environ["HF_HUB_ETAG_TIMEOUT"] = "60"  # Increase timeout to 60 seconds
 
+logger: logging.Logger = logging.getLogger("peft_benchmark")
+handler = logging.StreamHandler()
+fmt = logging.Formatter("%(asctime)-8s %(levelname)-4s %(message)s", datefmt="%y-%m-%d %H:%M")
+handler.setFormatter(fmt)
+logger.addHandler(handler)
 
-# Configure loguru to only log on LOCAL_RANK 0
+
+# Filter to only log on LOCAL_RANK 0
 def rank_filter(record):
     return LOCAL_RANK == 0
 
@@ -366,12 +372,8 @@ def main(args: argparse.Namespace):
     """Main training function."""
 
     # Setup logger and log level
-    logger.remove()  # Remove default handler
-    logger.add(
-        sys.stdout,
-        filter=rank_filter,
-        level="DEBUG" if args.verbose else "INFO",
-    )
+    logger.addFilter(rank_filter)
+    logger.setLevel(logging.DEBUG if args.verbose else logging.INFO)
 
     logger.info(args)
     logger.debug(f"Initialized process group: rank {GLOBAL_RANK}, local rank {LOCAL_RANK}, world size {WORLD_SIZE}")


### PR DESCRIPTION
## What does this PR do?

After discussing with @crcrpar we thought it's better to remove the dependency to loguru and not use #2275. 

The log looks like:

```log
25-07-14 15:42 INFO Global batch size: 1 (mbs: 1, grad_acc_steps: 1, world_size: 1)
25-07-14 15:42 INFO Loading tokenizer
25-07-14 15:42 INFO Loading base model on meta device...
25-07-14 15:42 INFO Base model loaded on meta device
25-07-14 15:42 INFO Configured model for static shapes with sequence length: 4096
25-07-14 15:42 INFO Gradient checkpointing disabled
25-07-14 15:42 INFO Applying LoRA to model
25-07-14 15:42 INFO LoRA applied to model
25-07-14 15:42 INFO Verifying gradient setup...
25-07-14 15:42 INFO Applying compilation: thunder to model
25-07-14 15:42 INFO Resetting cache size for torch.dynamo
25-07-14 15:42 INFO Disabled gradient checkpointing for Thunder compilation
25-07-14 15:42 INFO Thunder used executors: ['cudnn', 'sdpa', 'torchcompile_xentropy', 'nvfuser']
25-07-14 15:42 INFO Applying Thunder compilation with 4 executors
25-07-14 15:42 INFO Using ThunderFX
25-07-14 15:42 INFO Compilation applied to model
25-07-14 15:42 INFO Trainable parameters: 2,883,584
25-07-14 15:42 INFO Total parameters: 1,558,997,504
```


cc @borda