### PR TITLE
[ruff linter] Enable isort for consistent import order

### DIFF
--- a/.github/run-benchmark-as-lit-jobs.py
+++ b/.github/run-benchmark-as-lit-jobs.py
@@ -4,7 +4,7 @@ import sys
 import time
 from datetime import datetime
 
-from lightning_sdk import Studio, Job, Machine, Status
+from lightning_sdk import Job, Machine, Status, Studio
 
 
 def main(gh_run_id: str = ""):

--- a/.github/run-jit-coverage-as-lit-studios.py
+++ b/.github/run-jit-coverage-as-lit-studios.py
@@ -1,10 +1,10 @@
+import glob
+import json
+import os
 import sys
 from datetime import datetime
-import glob
-import os
-import json
 
-from lightning_sdk import Studio, Machine
+from lightning_sdk import Machine, Studio
 from tqdm import tqdm
 
 

--- a/.github/run-quickstart-as-lit-jobs.py
+++ b/.github/run-quickstart-as-lit-jobs.py
@@ -1,10 +1,10 @@
+import glob
 import json
+import os.path
 import sys
 from datetime import datetime
-import glob
-import os.path
 
-from lightning_sdk import Studio, Job, Machine, Status
+from lightning_sdk import Job, Machine, Status, Studio
 
 
 def main(gh_run_id: str = ""):

--- a/.github/run-transformer-engine-tests-as-lit-jobs.py
+++ b/.github/run-transformer-engine-tests-as-lit-jobs.py
@@ -1,10 +1,10 @@
+import glob
 import json
+import os.path
 import sys
 from datetime import datetime
-import glob
-import os.path
 
-from lightning_sdk import Studio, Job, Machine, Status
+from lightning_sdk import Job, Machine, Status, Studio
 
 
 def main(gh_run_id: str = ""):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,7 @@ select = [
     "F",  # see: https://pypi.org/project/pyflakes
 #    "D",  # see: https://pypi.org/project/pydocstyle
 #    "N",  # see: https://pypi.org/project/pep8-naming
+    "I",  # isort
 ]
 ignore = [
     "E731",  # Do not assign a lambda expression, use a def

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,6 @@ from importlib.util import module_from_spec, spec_from_file_location
 from packaging.requirements import Requirement as parse_requirements
 from setuptools import find_packages, setup
 
-
 _PATH_ROOT = os.path.dirname(__file__)
 _PATH_REQUIRES = os.path.join(_PATH_ROOT, "requirements")
 # check if os env. variable is set to convert version to nightly

--- a/thunder/benchmarks/__init__.py
+++ b/thunder/benchmarks/__init__.py
@@ -4,13 +4,12 @@ import tempfile
 import textwrap
 import time
 from collections import UserDict
-from collections.abc import Callable
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
+from contextlib import contextmanager
 from dataclasses import dataclass
 from functools import partial
 from numbers import Number
 from typing import Any
-from contextlib import contextmanager
 
 import torch
 import torch.multiprocessing as mp
@@ -18,21 +17,21 @@ import torch.nn as nn
 from lightning_utilities.core.imports import package_available
 
 import thunder
-import thunder.dynamo
 import thunder.core.devices as Devices
 import thunder.core.dtypes as dtypes
+import thunder.dynamo
 import thunder.executors as executors
 import thunder.torch as ltorch
-from thunder.core.transforms import grad, clear_grads, populate_grads
-from thunder.executors.apexex import apex_ex, apex_entropy_available
+from thunder.core.transforms import clear_grads, grad, populate_grads
+from thunder.executors.apexex import apex_entropy_available, apex_ex
 from thunder.executors.cudnn_layernormex import cudnn_layernorm_ex
-from thunder.executors.cudnnex import cudnn_ex, cudnn_available
-from thunder.executors.transformer_engineex import transformer_engine_ex, TE_AVAILABLE
+from thunder.executors.cudnnex import cudnn_available, cudnn_ex
 from thunder.executors.sdpaex import sdpa_ex
 from thunder.executors.torch_compile import torch_compile_cat_ex, torch_compile_ex
-from thunder.transforms.cudagraph import CUDAGraphTransform
-from thunder.tests import nanogpt_model, hf_bart_self_attn
+from thunder.executors.transformer_engineex import TE_AVAILABLE, transformer_engine_ex
+from thunder.tests import hf_bart_self_attn, nanogpt_model
 from thunder.tests.make_tensor import make_tensor, make_tensor_like
+from thunder.transforms.cudagraph import CUDAGraphTransform
 
 MAX_ALLOCATED_MEMORY_KEYWORD = "max_allocated_memory_MB"
 
@@ -865,8 +864,7 @@ class get_default_thunder_ddp_dynamic_strides_executor:
 
 @dataclass(frozen=True)
 class get_default_thunder_fsdp_dynamic_strides_executor:
-    from thunder.distributed import FSDPBucketingStrategy
-    from thunder.distributed import FSDPType
+    from thunder.distributed import FSDPBucketingStrategy, FSDPType
 
     bucketing_strategy: FSDPBucketingStrategy
     sharding_strategy: FSDPType
@@ -2940,8 +2938,8 @@ class GPTBlockBenchmark(Benchmark, metaclass=UserFacingBenchmarkMeta):
         dtype: thunder.dtypes.dtype | torch.dtype | str = thunder.bfloat16,
         requires_grad: bool = True,
     ) -> None:
-        from litgpt.model import build_rope_cache
         from litgpt.config import Config as LitGPTConfig
+        from litgpt.model import build_rope_cache
 
         super().__init__()
 
@@ -3321,8 +3319,8 @@ class LinearLoRABenchmark(Benchmark, metaclass=UserFacingBenchmarkMeta):
                 self.lora_cls = partial(get_peft_model, peft_config=peft_config, autocast_adapter_dtype=False)
 
             case "NeMo":
-                from nemo.collections.llm.peft import LoRA
                 from nemo.collections.llm.fn import FNMixin
+                from nemo.collections.llm.peft import LoRA
 
                 base_cls += [FNMixin]
 

--- a/thunder/benchmarks/benchmark_hf.py
+++ b/thunder/benchmarks/benchmark_hf.py
@@ -1,13 +1,13 @@
-from pathlib import Path
 from datetime import datetime
+from pathlib import Path
+
 import torch
 import transformers
+from torch.profiler import ProfilerActivity, profile, record_function
 
 import thunder
 from thunder.dev_utils.benchmark import benchmark_n
 from thunder.recipes.base import BaseRecipe
-
-from torch.profiler import profile, record_function, ProfilerActivity
 
 
 class DebugRecipe(BaseRecipe):

--- a/thunder/benchmarks/benchmark_peft.py
+++ b/thunder/benchmarks/benchmark_peft.py
@@ -1,22 +1,20 @@
-import sys
 import argparse
 import os
 import random
+import sys
 import time
 from contextlib import contextmanager
 from datetime import timedelta
-from looseversion import LooseVersion
 
 import torch
 import torch.distributed as torch_dist
-from torch.nn.attention import SDPBackend, sdpa_kernel
-
-from tqdm import tqdm
-from loguru import logger
-
-from transformers import AutoConfig, AutoModel, AutoModelForCausalLM, AutoTokenizer, WordpieceTokenizer
-from peft import LoraConfig, get_peft_model
 from datasets import Dataset
+from loguru import logger
+from looseversion import LooseVersion
+from peft import LoraConfig, get_peft_model
+from torch.nn.attention import SDPBackend, sdpa_kernel
+from tqdm import tqdm
+from transformers import AutoConfig, AutoModel, AutoModelForCausalLM, AutoTokenizer, WordpieceTokenizer
 
 # Set up distributed training variables
 WORLD_SIZE = int(os.environ.get("WORLD_SIZE", 1))
@@ -185,8 +183,9 @@ def setup_fsdp2(model: torch.nn.Module) -> torch.nn.Module:
     # Apply FSDP2 with ZeRO-3 style sharding
     # reference: https://github.com/pytorch/torchtitan/blob/6e7a183/docs/fsdp.md
     from functools import partial
+
+    from torch.distributed._composable.fsdp import MixedPrecisionPolicy, fully_shard
     from torch.distributed.device_mesh import init_device_mesh
-    from torch.distributed._composable.fsdp import fully_shard, MixedPrecisionPolicy
 
     device = torch.device("cuda", LOCAL_RANK)
     torch.cuda.set_device(device)

--- a/thunder/benchmarks/conftest.py
+++ b/thunder/benchmarks/conftest.py
@@ -1,13 +1,14 @@
-import os
-from os import path
-import platform
-import psutil
-from typing import Any
-import warnings
 import importlib.util
-from pytest import hookimpl, TestReport, Item, Parser
 import multiprocessing as mp
+import os
+import platform
 import subprocess
+import warnings
+from os import path
+from typing import Any
+
+import psutil
+from pytest import Item, Parser, TestReport, hookimpl
 
 BENCHMARK_JSON_DIR = "benchmarks_reports"
 FAILED_BENCHMARK_LOGS_DIR = "failed_benchmarks_logs"
@@ -138,7 +139,7 @@ def save_benchmark_results_asv(config):
         warnings.warn("asv_bench_dir' is not set. Results won't be saved in asv format.")
         return
 
-    from asvdb import utils, ASVDb, BenchmarkResult, BenchmarkInfo
+    from asvdb import ASVDb, BenchmarkInfo, BenchmarkResult, utils
 
     benchmarks = config._benchmarksession.benchmarks
 

--- a/thunder/benchmarks/distributed.py
+++ b/thunder/benchmarks/distributed.py
@@ -1,22 +1,21 @@
 import argparse
-from dataclasses import dataclass
 import json
 import os
+from dataclasses import dataclass
 
 import torch
 
 from thunder.benchmarks import (
-    run_multiprocess_benchmark,
     BenchmarkRunStatistics,
-    _nanogpt_configs,
-    NanoGPTConfig,
-    NanoGPTBenchmark,
     LitGPTBenchmark,
+    NanoGPTBenchmark,
+    NanoGPTConfig,
+    _nanogpt_configs,
+    run_multiprocess_benchmark,
 )
-from thunder.tests.litgpt_model import name_to_config, Config as LitGPTConfig
-from thunder.distributed import FSDPBucketingStrategy
-from thunder.distributed import FSDPType
-
+from thunder.distributed import FSDPBucketingStrategy, FSDPType
+from thunder.tests.litgpt_model import Config as LitGPTConfig
+from thunder.tests.litgpt_model import name_to_config
 
 _nanogpt_model_names: tuple[str, ...] = tuple(_nanogpt_configs.keys())
 _llama_model_names: tuple[str, ...] = tuple(name_to_config.keys())
@@ -294,11 +293,13 @@ if __name__ == "__main__":
                     )
             else:
                 import functools
+
                 from torch.distributed.fsdp import ShardingStrategy
                 from torch.distributed.fsdp.wrap import transformer_auto_wrap_policy
+
                 from thunder.benchmarks import get_default_torch_fsdp_executor
-                from thunder.tests.nanogpt_model import Block as NanoGPTBlock
                 from thunder.tests.litgpt_model import Block as GPTBlock
+                from thunder.tests.nanogpt_model import Block as NanoGPTBlock
 
                 sharding_strategy = ShardingStrategy.SHARD_GRAD_OP
                 auto_wrap_policies = (
@@ -396,6 +397,7 @@ if __name__ == "__main__":
                 )
         else:
             from itertools import product
+
             from thunder.benchmarks import get_default_thunder_fsdp_dynamic_strides_executor
 
             bucketing_strategies = [fsdp_bucketing_strategies[s] for s in args.bucketing_strategies]

--- a/thunder/benchmarks/einsum.py
+++ b/thunder/benchmarks/einsum.py
@@ -1,16 +1,15 @@
-from collections.abc import Callable
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 
 import pytest
-import thunder
 
+import thunder
 from thunder.benchmarks import EinsumBenchmark
 from thunder.benchmarks.targets import (
-    make_setup,
-    fwd_executors,
     fwd_executor_ids,
+    fwd_executors,
     grad_executors,
     grad_executors_ids,
+    make_setup,
     thunder_gradv1,
     thunder_torchcompile_gradv1,
 )

--- a/thunder/benchmarks/targets.py
+++ b/thunder/benchmarks/targets.py
@@ -1,54 +1,49 @@
 import importlib
-import warnings
 import os
-from collections.abc import Callable
-from enum import auto, Enum
-from collections.abc import Sequence
+import warnings
+from collections.abc import Callable, Sequence
 from contextlib import nullcontext
+from enum import Enum, auto
 
 import pytest
 import torch
-
 from lightning_utilities.core.imports import package_available
-
 from litgpt.config import configs
 
 import thunder
-
 from thunder.benchmarks import (
-    OptimBenchmark,
     BatchNormBenchmark,
     Benchmark,
-    LitGPTBenchmark,
-    LitGPTCausalSelfAttentionBenchmark,
-    LitGPTSDPABenchmark,
-    LitGPTSwigluBenchmark,
-    LitGPTMLPBenchmark,
-    NanoGPTBenchmark,
-    NanoGPTCrossEntropyBenchmark,
-    LitGPTGeluBenchmark,
-    NanoGPTLayerNormBenchmark,
-    ResNet50Benchmark,
-    TorchbenchBenchmark,
+    DeepSeekSGLangMoEBenchmark,
     HFBenchmark,
     LinearLoRABenchmark,
-    DeepSeekSGLangMoEBenchmark,
+    LitGPTBenchmark,
+    LitGPTCausalSelfAttentionBenchmark,
+    LitGPTGeluBenchmark,
+    LitGPTMLPBenchmark,
+    LitGPTSDPABenchmark,
+    LitGPTSwigluBenchmark,
+    NanoGPTBenchmark,
+    NanoGPTCrossEntropyBenchmark,
+    NanoGPTLayerNormBenchmark,
+    OptimBenchmark,
+    ResNet50Benchmark,
+    TorchbenchBenchmark,
+    record_peak_allocated_memory,
     thunder_apex_executor,
     thunder_apex_nvfuser_executor,
     thunder_cudnn_executor,
     thunder_cudnn_nvfuser_executor,
     thunder_executor,
-    thunderfx_executor,
     thunder_sdpa_torch_compile_nvfuser_executor,
+    thunder_transformerengine_executor,
+    thunderfx_executor,
     torch_compile_executor,
     torch_executor,
-    thunder_transformerengine_executor,
-    record_peak_allocated_memory,
 )
-from thunder.core.interpreter import interpret
-
-from thunder.tests.litgpt_model import Config as LitGPTConfig
 from thunder.benchmarks.utils import backward_only
+from thunder.core.interpreter import interpret
+from thunder.tests.litgpt_model import Config as LitGPTConfig
 
 LIGER_FUSED_SWIGLU_AVAILABLE: bool = package_available("liger_kernel.ops.swiglu")
 APEX_FUSED_ROPE_AVAILABLE: bool = package_available("fused_rotary_positional_embedding")

--- a/thunder/benchmarks/test_benchmark_litgpt.py
+++ b/thunder/benchmarks/test_benchmark_litgpt.py
@@ -10,15 +10,15 @@ BENCHMARK_OUT_FORMAT - use this env variable to control the format in which the 
                     Uses 'xlsx' by default. Supported: 'none', 'print', 'xlsx'.
 """
 
-import torch
-from absl.testing import parameterized
-from absl.testing import absltest
-from collections import defaultdict
+import json
 import os
 import subprocess
-import json
-import pandas as pd
+from collections import defaultdict
 from datetime import datetime
+
+import pandas as pd
+import torch
+from absl.testing import absltest, parameterized
 
 
 class Runner:

--- a/thunder/benchmarks/utils.py
+++ b/thunder/benchmarks/utils.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 import torch
+
 import thunder
 from thunder.tests.make_tensor import make_tensor
 

--- a/thunder/clang/__init__.py
+++ b/thunder/clang/__init__.py
@@ -1,21 +1,22 @@
 from __future__ import annotations
+
+import math
+import operator
+import warnings
 from collections import namedtuple
 from collections.abc import Callable, Sequence
 from functools import partial, reduce
 from numbers import Number
 from types import EllipsisType, NoneType
 from typing import Any, Union
-import math
-import operator
-import warnings
 
-from thunder.clang.langctx import register_method
-from thunder.core import utils
-from thunder.core.baseutils import run_once
-from thunder.core.langctxs import langctx, Languages
 import thunder.core.devices as devices
 import thunder.core.dtypes as dtypes
 import thunder.core.prims as prims
+from thunder.clang.langctx import register_method
+from thunder.core import utils
+from thunder.core.baseutils import run_once
+from thunder.core.langctxs import Languages, langctx
 from thunder.core.proxies import (
     AnyProxy,
     IntegerProxy,

--- a/thunder/clang/langctx.py
+++ b/thunder/clang/langctx.py
@@ -1,8 +1,8 @@
 from collections.abc import Callable
 
-from thunder.core.langctxs import LanguageContext, register_langctx, Languages, resolve_language
+from thunder.core.langctxs import LanguageContext, Languages, register_langctx, resolve_language
+from thunder.core.proxies import NumberProxy, TensorProxy
 from thunder.core.pytree import tree_flatten
-from thunder.core.proxies import TensorProxy, NumberProxy
 
 #
 # Creates and registers the torch language context

--- a/thunder/common.py
+++ b/thunder/common.py
@@ -1,48 +1,47 @@
 import dis
-from typing import Any
+from collections import defaultdict, deque
 from collections.abc import Callable, Generator, Hashable, Sequence
-from collections import deque, defaultdict
 from io import StringIO
+from typing import Any
 from weakref import WeakValueDictionary
 
+import numpy as np
+import torch as torch
+
+import thunder
+import thunder.core.langctxs as langctxs
+import thunder.core.prims as prims
+import thunder.distributed as dist
+import thunder.executors as executors
+from thunder.core.codeutils import get_siginfo
+from thunder.core.dtypes import to_dtype
+from thunder.core.langctxs import LanguageContext, Languages, reset_langctx, resolve_language, set_langctx
 from thunder.core.options import (
     CACHE_OPTIONS,
-    resolve_cache_option,
     SHARP_EDGES_OPTIONS,
-    resolve_sharp_edges_option,
     DebugOptions,
+    resolve_cache_option,
+    resolve_sharp_edges_option,
 )
-from thunder.core.utils import is_collection, AutocastStack
+from thunder.core.proxies import (
+    CollectionProxy,
+    DistParallelType,
+    FutureTensorProxy,
+    Proxy,
+    TensorProxy,
+    is_proxyable,
+    proxy,
+)
 from thunder.core.pytree import tree_map
-import thunder.core.langctxs as langctxs
-from thunder.core.langctxs import set_langctx, reset_langctx, LanguageContext, resolve_language, Languages
-from thunder.core.codeutils import get_siginfo
 from thunder.core.trace import (
     TraceCtx,
     get_tracectx,
-    set_tracectx,
     reset_tracectx,
+    set_tracectx,
 )
 from thunder.core.transform_common import dce
-from thunder.core.proxies import (
-    is_proxyable,
-    proxy,
-    Proxy,
-    CollectionProxy,
-    TensorProxy,
-    DistParallelType,
-    FutureTensorProxy,
-)
-import thunder.core.prims as prims
-import thunder.distributed as dist
-from thunder.extend import Executor, get_default_executors, get_always_executors, add_executor_lists
-import thunder.executors as executors
-from thunder.core.dtypes import to_dtype
-
-import torch as torch
-import numpy as np
-import thunder
-
+from thunder.core.utils import AutocastStack, is_collection
+from thunder.extend import Executor, add_executor_lists, get_always_executors, get_default_executors
 
 __all__ = [
     "CompileStats",

--- a/thunder/core/baseutils.py
+++ b/thunder/core/baseutils.py
@@ -2,10 +2,7 @@
 #   This feature is available in Python 3.7 and later.
 #   This import (like all __future__ imports) must be at the beginning of the file.
 from __future__ import annotations
-from collections.abc import Sequence
-from enum import Enum
-from types import MappingProxyType, CodeType, EllipsisType, FunctionType, MethodType
-from typing import TYPE_CHECKING
+
 import collections.abc
 import dis
 import functools
@@ -13,9 +10,13 @@ import inspect
 import os
 import re
 import sys
+from collections.abc import Sequence
+from enum import Enum
+from types import CodeType, EllipsisType, FunctionType, MappingProxyType, MethodType
+from typing import TYPE_CHECKING
 
-import torch
 import numpy as np
+import torch
 
 if TYPE_CHECKING:
     from collections.abc import Callable

--- a/thunder/core/codeutils.py
+++ b/thunder/core/codeutils.py
@@ -1,23 +1,25 @@
 from __future__ import annotations
-from functools import partial
-from inspect import Parameter
-from typing import TYPE_CHECKING, NamedTuple
+
 import dataclasses
 import dis
 import functools
 import inspect
 import linecache
 import sys
+from functools import partial
+from inspect import Parameter
+from typing import TYPE_CHECKING, NamedTuple
 
 import thunder.core.baseutils as baseutils
-from thunder.core.baseutils import ProxyInterface, check
-import thunder.core.dtypes as dtypes
 import thunder.core.devices as devices
+import thunder.core.dtypes as dtypes
+from thunder.core.baseutils import ProxyInterface, check
 from thunder.core.pytree import tree_flatten, tree_unflatten
 
 if TYPE_CHECKING:
-    from typing import Any
     from collections.abc import Callable, Sequence
+    from typing import Any
+
     from thunder.core.trace import TraceCtx
 
 

--- a/thunder/core/devices.py
+++ b/thunder/core/devices.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from enum import Enum, auto
 
 import torch
+
 import thunder.core.baseutils as baseutils
 
 

--- a/thunder/core/dtypes.py
+++ b/thunder/core/dtypes.py
@@ -1,9 +1,9 @@
-from typing import Any
 from collections.abc import Iterable
 from numbers import Number
+from typing import Any
 
-import torch
 import numpy as np
+import torch
 
 import thunder.core.baseutils as baseutils
 from thunder.core.baseutils import NumberProxyInterface, TensorProxyInterface

--- a/thunder/core/functionalization.py
+++ b/thunder/core/functionalization.py
@@ -1,14 +1,16 @@
 from __future__ import annotations
+
 from collections import defaultdict
 from typing import TYPE_CHECKING
 
-from thunder.core.compile_data import get_compile_data
 import thunder.core.prims as prims
-from thunder.core.proxies import variableify, TensorProxy, unvariableify, ProxyInterface
+from thunder.core.compile_data import get_compile_data
+from thunder.core.proxies import ProxyInterface, TensorProxy, unvariableify, variableify
 from thunder.core.pytree import tree_flatten, tree_unflatten
 from thunder.core.symbol import BoundSymbol
-from thunder.core.trace import from_trace, TraceProvenance, TraceCtx as Trace, tracectx
-from thunder.core.utils import ProxyDict, producers, check, consumers
+from thunder.core.trace import TraceCtx as Trace
+from thunder.core.trace import TraceProvenance, from_trace, tracectx
+from thunder.core.utils import ProxyDict, check, consumers, producers
 
 if TYPE_CHECKING:
     from thunder.core.trace import VariableInterface
@@ -135,8 +137,7 @@ def _get_prod_bsym_with_arg(
     orig_bsym_of_in_tensor: BoundSymbol,
     in_tensor: TensorProxy,
 ) -> BoundSymbol | None:
-    from thunder.torch import _syms_returning_views
-    from thunder.torch import _syms_that_may_return_views
+    from thunder.torch import _syms_returning_views, _syms_that_may_return_views
 
     def inplace_or_view(bsym) -> bool:
         import thunder.torch as ltorch
@@ -317,7 +318,7 @@ def canonicalize_bsym_args(
 
 
 def create_functional_bsym_from(inplace_bsym: BoundSymbol) -> BoundSymbol:
-    from thunder.torch import _inplace_to_out_of_place, polygamma_, setitem_, setitem
+    from thunder.torch import _inplace_to_out_of_place, polygamma_, setitem, setitem_
 
     functional_sym, optional_inplace_arg_index = _inplace_to_out_of_place[inplace_bsym.sym]
     args, kwargs = inplace_bsym.args, inplace_bsym.kwargs

--- a/thunder/core/interpreter.py
+++ b/thunder/core/interpreter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import builtins
+import collections
 import contextlib
 import contextvars
 import dataclasses
@@ -8,40 +9,36 @@ import datetime
 import dis
 import enum
 import functools
-import linecache
 import inspect
+import linecache
+import operator
 import os
 import re
 import sys
 import traceback
 import weakref
-from typing import Any, Literal, TypedDict
 from collections.abc import Callable, Iterable, Iterator, Mapping, MutableMapping, Sequence, Sized
-import collections
-import operator
-
 from io import StringIO
-
 from types import (
+    BuiltinFunctionType,
+    BuiltinMethodType,
     CellType,
     CodeType,
     CoroutineType,
     FrameType,
     FunctionType,
+    MethodDescriptorType,
     MethodType,
+    MethodWrapperType,
     ModuleType,
     NoneType,
-    BuiltinFunctionType,
-    BuiltinMethodType,
-    MethodDescriptorType,
-    MethodWrapperType,
-    WrapperDescriptorType,
     TracebackType,
+    WrapperDescriptorType,
 )
+from typing import Any, Literal, TypedDict
 
-from thunder.core.baseutils import Singleton, init_colors, extract_callable_name, is_likely_from_collections_namedtuple
+from thunder.core.baseutils import Singleton, extract_callable_name, init_colors, is_likely_from_collections_namedtuple
 from thunder.core.codeutils import Positions
-
 
 #
 # interpreter.py implements a Python interpreter in Python.

--- a/thunder/core/langctxs.py
+++ b/thunder/core/langctxs.py
@@ -1,8 +1,8 @@
-from contextvars import ContextVar
-from typing import Any
 from collections.abc import Callable
-from functools import wraps
+from contextvars import ContextVar
 from enum import Enum, auto
+from functools import wraps
+from typing import Any
 
 #
 # Context variables, context managers, and helpers related to setting the language context.

--- a/thunder/core/module.py
+++ b/thunder/core/module.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
-from contextlib import contextmanager
-import itertools
-from typing import TYPE_CHECKING
+
 import collections
+import itertools
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
 
 import torch as pytorch
 from torch.utils.weak import WeakTensorKeyDictionary
@@ -13,6 +14,7 @@ from thunder.core.compile_data import get_compile_data
 if TYPE_CHECKING:
     from collections.abc import Mapping
     from typing import Any
+
     from thunder.core.transform_common import Transform
 
 
@@ -369,9 +371,9 @@ class ThunderModule(pytorch.nn.Module):
 
         """
         from thunder.distributed import (
-            set_skip_data_parallel_grad_sync,
-            reset_skip_data_parallel_grad_sync,
             _sync_grads,
+            reset_skip_data_parallel_grad_sync,
+            set_skip_data_parallel_grad_sync,
         )
 
         token = set_skip_data_parallel_grad_sync(True)

--- a/thunder/core/options.py
+++ b/thunder/core/options.py
@@ -1,7 +1,7 @@
-from typing import Any
+import warnings
 from collections.abc import Sequence
 from enum import Enum, auto
-import warnings
+from typing import Any
 
 #
 # Options that can be accessed by all parts of the system

--- a/thunder/core/patterns.py
+++ b/thunder/core/patterns.py
@@ -1,10 +1,10 @@
-from typing import Any
 from collections.abc import Callable
 from functools import partial
+from typing import Any
 
-from thunder.core.trace import TraceCtx
-from thunder.core.symbol import BoundSymbol
 from thunder.core.codeutils import get_siginfo
+from thunder.core.symbol import BoundSymbol
+from thunder.core.trace import TraceCtx
 from thunder.core.utils import ProxyDict, producers
 
 #

--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -1,17 +1,16 @@
-from enum import auto, Enum
-from numbers import Number
-from functools import reduce
-import operator
 import builtins
 import math
+import operator
+from collections.abc import Callable, Hashable, Sequence
+from enum import Enum, auto
+from functools import reduce
+from numbers import Number
 from types import NoneType
 from typing import Any
-from collections.abc import Callable
-from collections.abc import Hashable, Sequence
 
 import torch
 
-from thunder.core.langctxs import LanguageContext, register_langctx, Languages, langctx
+from thunder.core.langctxs import LanguageContext, Languages, langctx, register_langctx
 
 #
 # Creates and registers the torch language context
@@ -61,30 +60,30 @@ def register_method(method_name: str, method: Callable, /) -> None:
     _method_name_to_fn_map[method_name] = method
 
 
-from thunder.core.symbol import Symbol, BoundSymbol, default_python_printer
-from thunder.core.proxies import (
-    CollectionProxy,
-    ListProxy,
-    TensorProxy,
-    NumberProxy,
-    proxy,
-    numberproxy,
-    pytype,
-    pyval,
-    Proxy,
-    StringProxy,
-    TupleProxy,
-    AnyProxy,
-    IntegerProxy,
-)
-import thunder.core.codeutils as codeutils
-from thunder.core.codeutils import Printable
-import thunder.core.utils as utils
 import thunder.core.baseutils as baseutils
+import thunder.core.codeutils as codeutils
 import thunder.core.devices as devices
 import thunder.core.dtypes as dtypes
+import thunder.core.utils as utils
+from thunder.core.codeutils import Printable
+from thunder.core.langctxs import LanguageContext, Languages, register_langctx
+from thunder.core.proxies import (
+    AnyProxy,
+    CollectionProxy,
+    IntegerProxy,
+    ListProxy,
+    NumberProxy,
+    Proxy,
+    StringProxy,
+    TensorProxy,
+    TupleProxy,
+    numberproxy,
+    proxy,
+    pytype,
+    pyval,
+)
 from thunder.core.pytree import tree_flatten
-from thunder.core.langctxs import LanguageContext, register_langctx, Languages
+from thunder.core.symbol import BoundSymbol, Symbol, default_python_printer
 
 #
 # Primitives and helpers for defining them

--- a/thunder/core/profile.py
+++ b/thunder/core/profile.py
@@ -1,11 +1,10 @@
-from collections.abc import Callable
 import contextlib
 import functools
 import os
 import warnings
+from collections.abc import Callable
 
 import torch
-
 
 _ENABLED = os.getenv("THUNDER_ANNOTATE_TRACES") in ("1", "y", "Y")
 

--- a/thunder/core/proxies.py
+++ b/thunder/core/proxies.py
@@ -1,38 +1,36 @@
 from __future__ import annotations
 
+import builtins
 import copy
-from enum import auto, Enum
+import math
+import operator
+from collections.abc import Callable, Sequence
+from enum import Enum, auto
+from functools import partial, reduce
 from numbers import Number
 from typing import Any
-from collections.abc import Callable
-from collections.abc import Sequence
-
-from functools import reduce, partial
-import operator
-import builtins
-import math
 
 import torch
 
-from thunder.core.compile_data import using_symbolic_values, get_cache_option, CACHE_OPTIONS
-from thunder.core.interpreter import is_jitting, ProvenanceRecord, PseudoInst
+import thunder.core.baseutils as baseutils
+import thunder.core.devices as devices
+import thunder.core.dtypes as dtypes
+from thunder.core.baseutils import (
+    NumberProxyInterface,
+    ProxyInterface,
+    TagBase,
+    TensorProxyInterface,
+    TorchAutogradFunctionCtxProxyInterface,
+)
+from thunder.core.compile_data import CACHE_OPTIONS, get_cache_option, using_symbolic_values
+from thunder.core.interpreter import ProvenanceRecord, PseudoInst, is_jitting
+from thunder.core.langctxs import get_langctx, resolve_method
 from thunder.core.trace import (
+    TraceCtx,
     VariableInterface,
     get_tracectx,
     is_tracing,
-    TraceCtx,
 )
-from thunder.core.baseutils import (
-    ProxyInterface,
-    NumberProxyInterface,
-    TensorProxyInterface,
-    TorchAutogradFunctionCtxProxyInterface,
-    TagBase,
-)
-import thunder.core.baseutils as baseutils
-from thunder.core.langctxs import resolve_method, get_langctx
-import thunder.core.devices as devices
-import thunder.core.dtypes as dtypes
 
 ShapeLike = Sequence[int]
 

--- a/thunder/core/pytree.py
+++ b/thunder/core/pytree.py
@@ -1,12 +1,13 @@
+import dataclasses
 from functools import partial
 from types import FunctionType
-import dataclasses
 
 import optree
 import torch
 from torch.fx.immutable_collections import immutable_list
-import thunder.core.dtypes as dtypes
+
 import thunder.core.devices as devices
+import thunder.core.dtypes as dtypes
 from thunder.core.baseutils import ProxyInterface, is_likely_from_collections_namedtuple
 
 OPTREE_NAMESPACE = "thunder"

--- a/thunder/core/recipe.py
+++ b/thunder/core/recipe.py
@@ -1,7 +1,7 @@
+import warnings
 from contextlib import contextmanager
 from enum import Enum, auto
 from typing import Any
-import warnings
 
 import torch
 
@@ -131,7 +131,7 @@ class Recipe:
         for plugin in post_plugins:
             lookasides.extend(plugin.setup_lookasides() or [])
 
-        from thunder.core import jit_ext, interpreter
+        from thunder.core import interpreter, jit_ext
 
         if lookasides is not None:
             self._lookaside_executor = TemporaryExecutor()

--- a/thunder/core/rematerialization.py
+++ b/thunder/core/rematerialization.py
@@ -1,22 +1,21 @@
+import time
+from collections import defaultdict
+from collections.abc import Callable, Sequence
 from dataclasses import replace
 from functools import partial
 from itertools import chain, takewhile
-from collections.abc import Callable
-from collections.abc import Sequence
-from collections import defaultdict
-import time
 
 import networkx as nx
 
 from thunder.core import prims, utils
 from thunder.core.baseutils import BoundSymbolInterface, ProxyInterface
 from thunder.core.prims import PrimIDs
-from thunder.core.proxies import TensorProxy, variableify, NumberProxy, Proxy
+from thunder.core.proxies import NumberProxy, Proxy, TensorProxy, variableify
 from thunder.core.pytree import tree_flatten
 from thunder.core.symbol import has_tags
-from thunder.core.trace import from_trace, TraceCtx, TraceProvenance
-from thunder.core.transforms import bsym_list_to_dag, toposort_bsym_dag, TOPOSORT_ORDER
+from thunder.core.trace import TraceCtx, TraceProvenance, from_trace
 from thunder.core.transform_common import dce, order_proxies
+from thunder.core.transforms import TOPOSORT_ORDER, bsym_list_to_dag, toposort_bsym_dag
 from thunder.executors.passes import update_fusion_call_ctx
 
 
@@ -627,11 +626,11 @@ def rematerialize_forward_and_backward(fw_trace: TraceCtx, bw_trace: TraceCtx) -
         tuple[TraceCtx, TraceCtx]: Rematerialized forward and backward traces.
     """
     # Circular dependency
+    from thunder.core.trace import tracectx
     from thunder.core.transforms import (
         _update_backward_with_new_saved_for_backward,
         _update_forward_with_new_saved_for_backward,
     )
-    from thunder.core.trace import tracectx
 
     def joint_fn(args, kwargs, cotangents):
         pass
@@ -757,9 +756,9 @@ def replace_uniform(trace: TraceCtx) -> TraceCtx:
         return trace
 
     start_time_ns = time.perf_counter_ns()
-    from thunder.core.trace import VariableInterface
-    from thunder.core.proxies import Proxy
     from thunder.core.devices import Device
+    from thunder.core.proxies import Proxy
+    from thunder.core.trace import VariableInterface
     from thunder.core.transforms import VISIT_TYPE, visitor_transform
 
     swapmap: dict[VariableInterface, Proxy] = {}

--- a/thunder/core/symbol.py
+++ b/thunder/core/symbol.py
@@ -3,29 +3,26 @@ from __future__ import annotations
 import functools
 import inspect
 import sys
-from contextvars import ContextVar
+from collections.abc import Callable, Hashable, Iterable, Sequence
 from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, field
 from itertools import chain
 from types import ModuleType
-
-from dataclasses import dataclass, field
-from typing import Any, TYPE_CHECKING
-from collections.abc import Callable, Hashable, Iterable
-from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any
 
 import thunder.core.baseutils as baseutils
 import thunder.core.codeutils as codeutils
-from thunder.core.codeutils import Printable, Positions
 from thunder.core.baseutils import BoundSymbolInterface, TagBase
-from thunder.core.utils import FrozenDict, make_hashable
-from thunder.core.pytree import tree_flatten_with_dataclass, tree_unflatten, tree_map
-from thunder.core.proxies import Proxy, TensorProxy, variableify, CollectionProxy, ProxyTag
+from thunder.core.codeutils import Positions, Printable
 from thunder.core.compile_data import get_compile_data
-
+from thunder.core.proxies import CollectionProxy, Proxy, ProxyTag, TensorProxy, variableify
+from thunder.core.pytree import tree_flatten_with_dataclass, tree_map, tree_unflatten
 from thunder.core.trace import (
-    get_tracectx,
     VariableInterface,
+    get_tracectx,
 )
+from thunder.core.utils import FrozenDict, make_hashable
 
 #
 # Support for querying "traceable" functions

--- a/thunder/core/trace.py
+++ b/thunder/core/trace.py
@@ -1,18 +1,19 @@
 from __future__ import annotations
+
 import os
-from contextvars import ContextVar
-from contextlib import contextmanager
 import pathlib
-from typing import Any
-from enum import Enum
 from collections.abc import Callable
+from contextlib import contextmanager
+from contextvars import ContextVar
+from enum import Enum
 from types import ModuleType
+from typing import Any
 
 import thunder
-import thunder.core.codeutils as codeutils
 import thunder.core.baseutils as baseutils
-from thunder.core.baseutils import ProxyInterface, BoundSymbolInterface, TagBase
-from thunder.core.codeutils import ContextObject, get_source_line, Positions
+import thunder.core.codeutils as codeutils
+from thunder.core.baseutils import BoundSymbolInterface, ProxyInterface, TagBase
+from thunder.core.codeutils import ContextObject, Positions, get_source_line
 
 
 # TODO see issue "Improve TraceProvenance"
@@ -413,7 +414,7 @@ class TraceCtx:
                 # NOTE: For TE v1.6 onwards, `fp8_autocast` checks if `torch.is_grad_enabled` for updating
                 # the FP8 scales/inverses. So this decorator should be applied before `torch.no_grad` (so that
                 # it is in grad enabled part).
-                from thunder.executors.transformer_engineex import _is_te_linear_enabled, _get_te_wrapper_string
+                from thunder.executors.transformer_engineex import _get_te_wrapper_string, _is_te_linear_enabled
 
                 if TraceTag.AUGMENTED_FORWARD and _is_te_linear_enabled(import_ctx, object_ctx):
                     program.append(_get_te_wrapper_string())

--- a/thunder/core/trace_interpreter.py
+++ b/thunder/core/trace_interpreter.py
@@ -2,15 +2,14 @@ from functools import partial
 from typing import Any
 
 from thunder.core import prims
-from thunder.core.pytree import tree_map
-from thunder.core.trace import VariableInterface, from_trace, tracectx
 from thunder.core.baseutils import ProxyInterface, TensorProxyInterface
-from thunder.core.utils import safe_map_flat, sequencify
-from thunder.core.proxies import variableify, ProxyTag
-from thunder.core.transform_common import VJPDual
-from thunder.core.symbol import has_tags
 from thunder.core.compile_data import get_compile_option
-
+from thunder.core.proxies import ProxyTag, variableify
+from thunder.core.pytree import tree_map
+from thunder.core.symbol import has_tags
+from thunder.core.trace import VariableInterface, from_trace, tracectx
+from thunder.core.transform_common import VJPDual
+from thunder.core.utils import safe_map_flat, sequencify
 
 # TODO: Currently we use trace.args and trace.kwargs to get the arguments
 # Maybe we should use these instead

--- a/thunder/core/transform_common.py
+++ b/thunder/core/transform_common.py
@@ -1,24 +1,27 @@
 from __future__ import annotations
+
+import dataclasses
 import time
-from typing import TYPE_CHECKING
 from abc import ABC
 from collections.abc import Sequence
-import dataclasses
-from itertools import filterfalse
 from functools import partial
+from itertools import filterfalse
+from typing import TYPE_CHECKING
 
 import thunder
 import thunder.core.prims as prims
 from thunder.core.baseutils import BoundSymbolInterface, NumberProxyInterface
-from thunder.core.proxies import Proxy, variableify, Variable
+from thunder.core.proxies import Proxy, Variable, variableify
 from thunder.core.pytree import tree_flatten, tree_iter, tree_map
 from thunder.core.symbol import BoundSymbol, BoundSymbolRHS, has_tags
-from thunder.core.trace import from_trace, TraceProvenance, TraceCtx as Trace
-from thunder.core.utils import ProxyDict, producers, check
+from thunder.core.trace import TraceCtx as Trace
+from thunder.core.trace import TraceProvenance, from_trace
+from thunder.core.utils import ProxyDict, check, producers
 
 if TYPE_CHECKING:
     from numbers import Number
     from typing import Any
+
     from thunder.core.module import ThunderModule
 
 

--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -1,26 +1,37 @@
 from __future__ import annotations
-from collections import namedtuple
-from enum import auto, Enum
-from itertools import chain, compress
-from functools import lru_cache, partial, wraps
-import math
-from numbers import Number
-from typing import Any, TYPE_CHECKING
-from collections.abc import Callable
-from collections.abc import Sequence
-import copy
-import inspect
-import time
-import dataclasses
 
+import copy
+import dataclasses
+import inspect
+import math
+import time
+from collections import namedtuple
+from collections.abc import Callable, Sequence
+from enum import Enum, auto
+from functools import lru_cache, partial, wraps
+from itertools import chain, compress
+from numbers import Number
+from typing import TYPE_CHECKING, Any
+
+# from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
+import numpy as np
+import torch
+
+import thunder.clang as clang
 import thunder.core.utils as utils
-from thunder.core import dtypes, prims
-from thunder.core.devices import Device
-from thunder.core.trace_interpreter import (
-    interpret_trace as eval_trace,
-    interpret_trace_to_trace,
-    trace_interpreter_skip_list,
+import thunder.torch as ltorch
+from thunder.clang import (
+    convolution,
+    full_like,
+    reciprocal,
+    slice_in_dim,
+    squeeze,
+    unsqueeze,
 )
+from thunder.core import dtypes, prims
+from thunder.core.compile_data import get_compile_data
+from thunder.core.devices import Device
+from thunder.core.langctxs import Languages, langctx
 from thunder.core.proxies import (
     FloatProxy,
     FutureTensorProxy,
@@ -31,56 +42,46 @@ from thunder.core.proxies import (
     unvariableify,
     variableify,
 )
-from thunder.core.compile_data import get_compile_data
-from thunder.core.langctxs import langctx, Languages
-from thunder.core.pytree import tree_flatten, tree_map, tree_unflatten, tree_flatten_with_dataclass
+from thunder.core.pytree import tree_flatten, tree_flatten_with_dataclass, tree_map, tree_unflatten
 from thunder.core.symbol import BoundSymbol, BoundSymbolInterface, Symbol, has_tags
-from thunder.core.trace import TraceCtx as Trace, get_tracectx
-from thunder.core.trace import VariableInterface as Variable
+from thunder.core.trace import TraceCtx as Trace
 from thunder.core.trace import (
-    detached_trace,
-    tracectx,
-    set_tracectx,
-    reset_tracectx,
-    from_trace,
     TraceProvenance,
     TraceTag,
+    detached_trace,
+    from_trace,
+    get_tracectx,
+    reset_tracectx,
+    set_tracectx,
+    tracectx,
+)
+from thunder.core.trace import VariableInterface as Variable
+from thunder.core.trace_interpreter import (
+    interpret_trace as eval_trace,
+)
+from thunder.core.trace_interpreter import (
+    interpret_trace_to_trace,
+    trace_interpreter_skip_list,
+)
+from thunder.core.transform_common import (
+    Transform,
+    VJPDual,
+    dce,
+    unwrap_return_value,
+    wrap_return_value_together_with_arguments,
 )
 from thunder.core.utils import (
+    OrderedSet,
+    ProxyDict,
     check,
+    const_as,
     flatten_func,
     safe_map,
     safe_map_flat,
-    const_as,
     sequencify,
-    OrderedSet,
-    ProxyDict,
 )
-import thunder.clang as clang
-from thunder.clang import (
-    full_like,
-    unsqueeze,
-    squeeze,
-    slice_in_dim,
-    reciprocal,
-    convolution,
-)
-from thunder.core.transform_common import (
-    dce,
-    Transform,
-    wrap_return_value_together_with_arguments,
-    unwrap_return_value,
-    VJPDual,
-)
-from thunder.core.vjp_utils import make_aug_forward_and_backward, get_saved_for_backward_tensors
+from thunder.core.vjp_utils import get_saved_for_backward_tensors, make_aug_forward_and_backward
 from thunder.extend import Executor
-import thunder.torch as ltorch
-
-import torch
-
-# from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
-import numpy as np
-
 
 TraceTag.register_tag("AUGMENTED_FORWARD")
 ProxyTag.register_tag("RECOMPUTE_IN_BACKWARD")
@@ -638,7 +639,8 @@ def register_grad(sym_or_id: Symbol | Any, gradfn: Callable) -> None:
 
 
 # Grad functions for prims
-from thunder.core.prims import PrimIDs as pids, get_grad, put_grad
+from thunder.core.prims import PrimIDs as pids
+from thunder.core.prims import get_grad, put_grad
 
 
 # A generalization of prims.put_grad to pytrees
@@ -1466,7 +1468,7 @@ register_grad(pids.COPY_WITH_SETITEM, _copy_with_setitem_grad)
 def _log_sigmoid_grad(
     a: TensorProxy,
 ) -> TensorProxy:
-    from thunder.torch import where, exp, logsigmoid
+    from thunder.torch import exp, logsigmoid, where
 
     fwd = logsigmoid(a)
     g = get_grad(fwd)
@@ -2493,11 +2495,12 @@ def index_put_aug_fwd(
 
 
 if torch.distributed.is_available():
-    from torch.distributed import ReduceOp
     from torch._C._distributed_c10d import _resolve_process_group
+    from torch.distributed import ReduceOp
 
     if TYPE_CHECKING:
         from torch.distributed import ProcessGroup
+
         from thunder.distributed.prims import DistributedReduceOps
 
     @register_augmented_forward("torch.ops._c10d_functional.all_reduce")

--- a/thunder/core/update_aliases.py
+++ b/thunder/core/update_aliases.py
@@ -1,9 +1,10 @@
-from functools import reduce, partial
+from functools import partial, reduce
 
-from thunder.core.functionalization import replace_args_with_alias_map
 import thunder.core.prims as prims
-from thunder.core.proxies import TensorProxy, variableify, unvariableify
-from thunder.core.trace import from_trace, tracectx, TraceCtx as Trace, TraceProvenance
+from thunder.core.functionalization import replace_args_with_alias_map
+from thunder.core.proxies import TensorProxy, unvariableify, variableify
+from thunder.core.trace import TraceCtx as Trace
+from thunder.core.trace import TraceProvenance, from_trace, tracectx
 
 
 def _update_swap_map(swap_map, old_alias, new_alias):

--- a/thunder/core/utils.py
+++ b/thunder/core/utils.py
@@ -1,24 +1,25 @@
 from __future__ import annotations
-from collections import defaultdict, deque, UserDict
-from collections.abc import Callable, Hashable, Iterable, Iterator, Sequence, Mapping
+
+import itertools
+import os
+from collections import UserDict, defaultdict, deque
+from collections.abc import Callable, Hashable, Iterable, Iterator, Mapping, Sequence
 from enum import Enum
 from functools import reduce
 from numbers import Number
 from types import MappingProxyType
-from typing import overload, Generic, TypeVar, TYPE_CHECKING
-import itertools
-import os
+from typing import TYPE_CHECKING, Generic, TypeVar, overload
 
-from typing_extensions import Self
 import torch
+from typing_extensions import Self
 
 import thunder.core.dtypes as dtypes
-from thunder.core.pytree import tree_flatten, tree_unflatten, tree_map
-from thunder.core.proxies import Proxy, NumberProxy, TensorProxy, variableify, CONSTRAINT, Variable
+import thunder.core.prims as prims
 from thunder.core.baseutils import *
 from thunder.core.codeutils import *
+from thunder.core.proxies import CONSTRAINT, NumberProxy, Proxy, TensorProxy, Variable, variableify
+from thunder.core.pytree import tree_flatten, tree_map, tree_unflatten
 from thunder.core.trace import TraceCtx, tracectx
-import thunder.core.prims as prims
 
 if TYPE_CHECKING:
     from typing import Any

--- a/thunder/core/vjp_utils.py
+++ b/thunder/core/vjp_utils.py
@@ -6,12 +6,11 @@ from itertools import chain
 
 from thunder.core import prims, utils
 from thunder.core.prims import PrimIDs
-from thunder.core.proxies import Proxy, variableify, TensorProxy
+from thunder.core.proxies import Proxy, TensorProxy, variableify
 from thunder.core.pytree import tree_flatten, tree_map
 from thunder.core.symbol import BoundSymbol
-from thunder.core.trace import from_trace, TraceCtx, TraceTag
+from thunder.core.trace import TraceCtx, TraceTag, from_trace
 from thunder.core.transform_common import dce
-
 
 _cache = {}
 

--- a/thunder/dev_utils/debug_transform.py
+++ b/thunder/dev_utils/debug_transform.py
@@ -1,10 +1,10 @@
+import time
 from collections.abc import Callable
 from functools import partial
-import time
 
-from thunder.core.trace import TraceCtx, from_trace, TraceProvenance
 import thunder
-from thunder.core.symbol import Symbol, BoundSymbol
+from thunder.core.symbol import BoundSymbol, Symbol
+from thunder.core.trace import TraceCtx, TraceProvenance, from_trace
 from thunder.dev_utils.utils import NON_COMPUTATION_PRIMS
 
 

--- a/thunder/dev_utils/nvtx_profile_transform.py
+++ b/thunder/dev_utils/nvtx_profile_transform.py
@@ -1,9 +1,12 @@
-from thunder.core.trace import TraceCtx as Trace, from_trace, TraceProvenance
+import time
+
+import torch
+
+import thunder
+from thunder.core.trace import TraceCtx as Trace
+from thunder.core.trace import TraceProvenance, from_trace
 from thunder.dev_utils.utils import NON_COMPUTATION_PRIMS
 from thunder.extend import OperatorExecutor
-import time
-import torch
-import thunder
 
 
 class Timer:

--- a/thunder/dev_utils/utils.py
+++ b/thunder/dev_utils/utils.py
@@ -1,6 +1,7 @@
 import collections
 
 from torch.utils.benchmark import Timer
+
 from thunder.core.prims import PrimIDs
 from thunder.core.symbol import BoundSymbol
 from thunder.executors.torch_compile import make_compiled as make_torch_compile_callable

--- a/thunder/distributed/__init__.py
+++ b/thunder/distributed/__init__.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
-import os
 
-from itertools import chain
+import os
+from collections.abc import Generator
 from contextlib import contextmanager
 from contextvars import ContextVar, Token
-from enum import auto, Enum
-from typing import TYPE_CHECKING, Any
-from collections.abc import Generator
+from enum import Enum, auto
 from functools import partial
-
+from itertools import chain
+from typing import TYPE_CHECKING, Any
 
 import torch
 import torch.distributed as tdist
@@ -16,11 +15,11 @@ from torch.utils.weak import WeakTensorKeyDictionary
 
 import thunder.core.utils as utils
 from thunder.core.proxies import DistParallelType
-from thunder.distributed.tensor_parallel import column_parallel
-from thunder.distributed.tensor_parallel import row_parallel
+from thunder.distributed.tensor_parallel import column_parallel, row_parallel
 
 if TYPE_CHECKING:
     from torch.distributed import ProcessGroup
+
     from thunder.core.module import ThunderModule
 
 
@@ -144,6 +143,7 @@ def _sync_grads(module: torch.nn.Module) -> None:
         cm.wait()
     elif getattr(module, "use_fsdp", False):
         from typing import cast
+
         from thunder.core.module import ThunderModule
 
         module = cast(ThunderModule, module)
@@ -308,8 +308,8 @@ def ddp(
 
     if not isinstance(model, ThunderModule):
         raise TypeError(f"Thunder DDP only works on ThunderModule, got {type(model)}")
-    from thunder.distributed.transforms.ddp_v2 import DDPTransform
     from thunder.core.transforms import add_transform
+    from thunder.distributed.transforms.ddp_v2 import DDPTransform
 
     process_group = copy_default_process_group()
     utils.check(process_group is not None, lambda: "The default process group is None")

--- a/thunder/distributed/bucketing.py
+++ b/thunder/distributed/bucketing.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
+
 from typing import TYPE_CHECKING
-from thunder.core import devices
-from thunder.core import dtypes
-from thunder.core import utils
-from thunder.core.proxies import TensorProxy, FutureTensorProxy
+
+from thunder.core import devices, dtypes, utils
+from thunder.core.proxies import FutureTensorProxy, TensorProxy
 from thunder.distributed import prims as dist_prims
 
 if TYPE_CHECKING:

--- a/thunder/distributed/checkpoint.py
+++ b/thunder/distributed/checkpoint.py
@@ -1,8 +1,7 @@
 import operator
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Union
-from typing import TypeGuard
+from typing import Any, TypeGuard, Union
 
 import torch
 from lightning_utilities import compare_version

--- a/thunder/distributed/prims.py
+++ b/thunder/distributed/prims.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
-from enum import auto, Enum
+
+from abc import ABC, abstractmethod
+from enum import Enum, auto
 from numbers import Number
 from typing import TYPE_CHECKING
-from abc import ABC, abstractmethod
 
 import torch.distributed
 
 import thunder.core.utils as utils
 from thunder.core.prims import make_prim
-
-from thunder.core.proxies import DistParallelType, FutureTensorProxy, pytype, TensorProxy
+from thunder.core.proxies import DistParallelType, FutureTensorProxy, TensorProxy, pytype
 from thunder.core.transforms import register_augmented_forward, register_backward
 from thunder.distributed import get_skip_data_parallel_grad_sync
 
@@ -445,6 +445,7 @@ class FwdGatherBwdSplitAlongLastDim(_TensorParallelOutputPostProcessFwdBwdInterf
     def backward(grad: TensorProxy, group: torch.distributed.ProcessGroup) -> TensorProxy:
         """Split along last dim"""
         from torch.distributed import distributed_c10d as c10d
+
         import thunder.torch as ltorch
 
         local_grad = ltorch.chunk(grad, c10d.get_world_size(group), dim=grad.ndim - 1)[c10d.get_rank(group)]
@@ -516,6 +517,7 @@ def synchronize_tensor_parallel_input_forward_rule(
             return t, (group, layer_type)
         case TensorParallelLayerType.ROW_PARALLEL_LINEAR:
             from torch.distributed import distributed_c10d as c10d
+
             from thunder import clang
 
             chunk_size = t.shape[t.ndim - 1] // group.size()

--- a/thunder/distributed/tensor_parallel/column_wise.py
+++ b/thunder/distributed/tensor_parallel/column_wise.py
@@ -1,29 +1,30 @@
 from __future__ import annotations
-from dataclasses import dataclass
-from dataclasses import field
-from typing import TYPE_CHECKING
-from typing import ClassVar
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, ClassVar
 
 import torch
 import torch.nn as nn
 from torch.distributed import distributed_c10d
 
 from thunder.core import utils
-from thunder.core.proxies import TensorProxy
-from thunder.core.proxies import DistParallelType
-from thunder.distributed.tensor_parallel.common import PrePostProcessInterface
-from thunder.distributed.tensor_parallel.common import ComputationTraceTransformVisitorForTensorParallel
-from thunder.distributed.tensor_parallel.common import TransformForTensorParallel
-from thunder.distributed.tensor_parallel.common import TensorParallelLayerType
+from thunder.core.proxies import DistParallelType, TensorProxy
+from thunder.distributed.tensor_parallel.common import (
+    ComputationTraceTransformVisitorForTensorParallel,
+    PrePostProcessInterface,
+    TensorParallelLayerType,
+    TransformForTensorParallel,
+)
 
 if TYPE_CHECKING:
-    from typing import Any
     from collections.abc import Sequence
+    from typing import Any
+
     from torch.distributed import ProcessGroup
-    from thunder.core.trace import TraceCtx
-    from thunder.core.trace import TraceProvenance
-    from thunder.core.symbol import BoundSymbol
+
     from thunder.core.module import ThunderModule
+    from thunder.core.symbol import BoundSymbol
+    from thunder.core.trace import TraceCtx, TraceProvenance
 
 
 __all__ = [
@@ -81,8 +82,8 @@ class ColumnParallelEmbeddingPrePostProcess(PrePostProcessInterface):
         return masked2, (mask1, mask2)
 
     def postprocess(self, y: TensorProxy, masks: Any) -> TensorProxy:
-        from thunder.distributed import prims as dist_prims
         import thunder.torch as ltorch
+        from thunder.distributed import prims as dist_prims
 
         utils.check(len(masks) == 2, lambda: f"Expected 2 masks but {len(masks)=}")
         for mask in masks:
@@ -217,8 +218,8 @@ def column_parallel(
             x = torch.randn(4, n_in, device=device)
             out = tp_model(x)  # shape: [4, n_out]
     """
-    from thunder.core.transforms import add_transform
     from thunder.core.module import ThunderModule
+    from thunder.core.transforms import add_transform
     from thunder.distributed import copy_default_process_group
     from thunder.transforms import MaterializationTransform
 

--- a/thunder/distributed/tensor_parallel/common.py
+++ b/thunder/distributed/tensor_parallel/common.py
@@ -1,31 +1,27 @@
 from __future__ import annotations
-from abc import ABC
-from abc import abstractmethod
-from enum import Enum
-from enum import auto
-from dataclasses import dataclass
-from dataclasses import field
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from enum import Enum, auto
 from typing import TYPE_CHECKING
 
 import torch
 
 from thunder.core.module import ThunderModule
-from thunder.core.proxies import DistParallelType
-from thunder.core.proxies import TensorProxy
-from thunder.core.proxies import variableify
-from thunder.core.transform_common import Transform
+from thunder.core.proxies import DistParallelType, TensorProxy, variableify
 from thunder.core.trace_interpreter import rerun_trace
+from thunder.core.transform_common import Transform
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
     from typing import Any
+
     from torch.distributed import ProcessGroup
+
     from thunder.core.module import ThunderModule
     from thunder.core.proxies import ProxyInterface
     from thunder.core.symbol import BoundSymbol
-    from thunder.core.trace import TraceCtx
-    from thunder.core.trace import TraceProvenance
-    from thunder.core.trace import VariableInterface
+    from thunder.core.trace import TraceCtx, TraceProvenance, VariableInterface
     from thunder.core.transforms import VISIT_TYPE
 
 
@@ -115,8 +111,8 @@ class ComputationTraceTransformVisitorForTensorParallel:
 
     def __call__(self, bsym: BoundSymbol) -> VISIT_TYPE:
         from thunder.core.prims import PrimIDs
-        from thunder.core.transforms import VISIT_TYPE
         from thunder.core.proxies import variableify
+        from thunder.core.transforms import VISIT_TYPE
 
         if bsym.sym.id in {
             PrimIDs.UNPACK_TRIVIAL,
@@ -202,8 +198,7 @@ class TransformForTensorParallel(Transform):
         epilogue_trace: TraceCtx,
         **kwargs,
     ) -> tuple[TraceCtx, TraceCtx, TraceCtx]:
-        from thunder.core import prims
-        from thunder.core import utils
+        from thunder.core import prims, utils
         from thunder.core.transforms import visitor_transform
 
         modules_and_thunder_modules = [
@@ -275,6 +270,7 @@ class TransformForTensorParallel(Transform):
 
     def transform_module(self, model: ThunderModule) -> None:
         import torch.nn as nn
+
         from thunder.core import utils
         from thunder.distributed import _shard_tensor
 

--- a/thunder/distributed/tensor_parallel/optimize_comm.py
+++ b/thunder/distributed/tensor_parallel/optimize_comm.py
@@ -1,17 +1,16 @@
 from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from thunder.core import utils
-from thunder.core.proxies import TensorProxy
-from thunder.core.proxies import variableify
+from thunder.core.proxies import TensorProxy, variableify
 from thunder.core.trace import from_trace
 from thunder.distributed.tensor_parallel.common import TensorParallelLayerType
 
 if TYPE_CHECKING:
-    from thunder.core.trace import TraceCtx
-    from thunder.core.symbol import BoundSymbol
     from thunder.core.proxies import ProxyInterface
-    from thunder.core.trace import VariableInterface
+    from thunder.core.symbol import BoundSymbol
+    from thunder.core.trace import TraceCtx, VariableInterface
 
 
 __all__ = [

--- a/thunder/distributed/tensor_parallel/row_wise.py
+++ b/thunder/distributed/tensor_parallel/row_wise.py
@@ -1,30 +1,30 @@
 from __future__ import annotations
-from dataclasses import dataclass
-from dataclasses import field
-from typing import TYPE_CHECKING
-from typing import ClassVar
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, ClassVar
 
 import torch
 import torch.nn as nn
 from torch.distributed import distributed_c10d
 
 from thunder.core import utils
-from thunder.core.proxies import DistParallelType
-from thunder.core.proxies import TensorProxy
-from thunder.core.proxies import variableify
-from thunder.distributed.tensor_parallel.common import PrePostProcessInterface
-from thunder.distributed.tensor_parallel.common import ComputationTraceTransformVisitorForTensorParallel
-from thunder.distributed.tensor_parallel.common import TransformForTensorParallel
-from thunder.distributed.tensor_parallel.common import TensorParallelLayerType
+from thunder.core.proxies import DistParallelType, TensorProxy, variableify
+from thunder.distributed.tensor_parallel.common import (
+    ComputationTraceTransformVisitorForTensorParallel,
+    PrePostProcessInterface,
+    TensorParallelLayerType,
+    TransformForTensorParallel,
+)
 
 if TYPE_CHECKING:
-    from typing import Any
     from collections.abc import Sequence
+    from typing import Any
+
     from torch.distributed import ProcessGroup
+
     from thunder.core.module import ThunderModule
     from thunder.core.symbol import BoundSymbol
-    from thunder.core.trace import TraceCtx
-    from thunder.core.trace import TraceProvenance
+    from thunder.core.trace import TraceCtx, TraceProvenance
 
 
 __all__ = [
@@ -221,8 +221,8 @@ def row_parallel(
             x = torch.randn(4, n_in, device=device)
             out = tp_model(x)  # shape: [4, n_out]
     """
-    from thunder.core.transforms import add_transform
     from thunder.core.module import ThunderModule
+    from thunder.core.transforms import add_transform
     from thunder.distributed import copy_default_process_group
     from thunder.transforms import MaterializationTransform
 

--- a/thunder/distributed/transforms/ddp.py
+++ b/thunder/distributed/transforms/ddp.py
@@ -1,34 +1,27 @@
 from __future__ import annotations
+
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from thunder.common import CompileData
-from thunder.core import dtypes
-from thunder.core import devices
-from thunder.core import prims
+from thunder.core import devices, dtypes, prims, utils
 from thunder.core.prims import PrimIDs
-from thunder.core.proxies import FutureTensorProxy
-from thunder.core.proxies import TensorProxy
-from thunder.core.proxies import variableify
-from thunder.core.pytree import tree_flatten
-from thunder.core.pytree import tree_unflatten
-from thunder.core.trace import from_trace
-from thunder.core.trace import TraceProvenance, TraceTag
-from thunder.core.transforms import visitor_transform
-from thunder.core.transforms import VISIT_TYPE
-from thunder.core import utils
+from thunder.core.proxies import FutureTensorProxy, TensorProxy, variableify
+from thunder.core.pytree import tree_flatten, tree_unflatten
+from thunder.core.trace import TraceProvenance, TraceTag, from_trace
+from thunder.core.transforms import VISIT_TYPE, visitor_transform
 from thunder.distributed import get_skip_data_parallel_grad_sync
-from thunder.distributed.bucketing import GradBuckets
 from thunder.distributed import prims as dist_prims
+from thunder.distributed.bucketing import GradBuckets
 
 if TYPE_CHECKING:
     from typing import Any
+
     from torch.distributed import ProcessGroup
-    from thunder.core.symbol import Symbol
-    from thunder.core.symbol import BoundSymbol
-    from thunder.core.trace import TraceCtx
-    from thunder.core.trace import VariableInterface
+
+    from thunder.core.symbol import BoundSymbol, Symbol
+    from thunder.core.trace import TraceCtx, VariableInterface
 
 
 __all__ = [
@@ -94,6 +87,7 @@ class MakeAllReduceInplace:
 
     def __call__(self, bsym: BoundSymbol) -> VISIT_TYPE:
         from dataclasses import replace
+
         from thunder.core.trace import get_tracectx
 
         if bsym in self.allreduce_bsyms:
@@ -267,6 +261,7 @@ def apply_bucketing_to_grad_allreduce(trace: TraceCtx) -> TraceCtx:
     """
 
     from torch.distributed import ProcessGroup
+
     from thunder.core.compile_data import get_compile_data
 
     if get_skip_data_parallel_grad_sync():

--- a/thunder/distributed/transforms/ddp_v2.py
+++ b/thunder/distributed/transforms/ddp_v2.py
@@ -1,23 +1,22 @@
 from __future__ import annotations
+
+import copy
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from thunder.core import devices
-from thunder.core import prims
-from thunder.core import utils
-from thunder.core.proxies import DistParallelType, TensorProxy, variableify
-from thunder.core.trace import from_trace
-from thunder.core.trace import tracectx
-from thunder.core.trace import TraceProvenance
-from thunder.core.transform_common import Transform
-from thunder.core.module import ThunderModule
 import torch
-from torch.utils.weak import WeakTensorKeyDictionary
 import torch.distributed as tdist
-import copy
+from torch.utils.weak import WeakTensorKeyDictionary
+
+from thunder.core import devices, prims, utils
+from thunder.core.module import ThunderModule
+from thunder.core.proxies import DistParallelType, TensorProxy, variableify
+from thunder.core.trace import TraceProvenance, from_trace, tracectx
+from thunder.core.transform_common import Transform
 
 if TYPE_CHECKING:
     from torch.distributed import ProcessGroup
+
     from thunder.core.trace import TraceCtx
 
 

--- a/thunder/distributed/transforms/fsdp.py
+++ b/thunder/distributed/transforms/fsdp.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from collections import defaultdict
 from collections.abc import Sequence
 from dataclasses import dataclass
@@ -7,38 +8,34 @@ from typing import TYPE_CHECKING
 
 from torch.distributed import ProcessGroup
 
-from thunder.core import prims
-from thunder.core import utils
+from thunder.core import prims, utils
 from thunder.core.prims import PrimIDs
-from thunder.core.proxies import variableify
-from thunder.core.proxies import Proxy
-from thunder.core.proxies import TensorProxy
-from thunder.core.proxies import FutureTensorProxy
-from thunder.core.pytree import tree_flatten
-from thunder.core.pytree import tree_unflatten
+from thunder.core.proxies import FutureTensorProxy, Proxy, TensorProxy, variableify
+from thunder.core.pytree import tree_flatten, tree_unflatten
 from thunder.core.symbol import BoundSymbol
-from thunder.core.trace import VariableInterface
-from thunder.core.trace import from_trace
-from thunder.core.trace import TraceCtx
-from thunder.core.transforms import VISIT_TYPE
-from thunder.core.transforms import visitor_transform
-from thunder.distributed import FSDPBucketingStrategy
-from thunder.distributed import FSDPType
-from thunder.distributed import get_extract_bucket_name_from_tensor_proxy
-from thunder.distributed import get_skip_data_parallel_grad_sync
-from thunder.distributed.bucketing import FSDPBackwardBucket
-from thunder.distributed.bucketing import FSDPForwardBucket
+from thunder.core.trace import TraceCtx, VariableInterface, from_trace
+from thunder.core.transforms import VISIT_TYPE, visitor_transform
+from thunder.distributed import (
+    FSDPBucketingStrategy,
+    FSDPType,
+    get_extract_bucket_name_from_tensor_proxy,
+    get_skip_data_parallel_grad_sync,
+)
 from thunder.distributed import prims as dist_prims
-from thunder.executors.torchex import all_gather_prim_impl
-from thunder.executors.torchex import pack_prim_impl
-from thunder.executors.torchex import pack_for_fsdp_prim_impl
-from thunder.executors.torchex import reduce_scatter_prim_impl
-from thunder.executors.torchex import unpack_prim_impl
-from thunder.executors.torchex import unpack_for_fsdp_prim_impl
-from thunder.executors.torchex import wait_prim_impl
+from thunder.distributed.bucketing import FSDPBackwardBucket, FSDPForwardBucket
+from thunder.executors.torchex import (
+    all_gather_prim_impl,
+    pack_for_fsdp_prim_impl,
+    pack_prim_impl,
+    reduce_scatter_prim_impl,
+    unpack_for_fsdp_prim_impl,
+    unpack_prim_impl,
+    wait_prim_impl,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
     from thunder import CompileData
     from thunder.distributed.bucketing import Bucket
 

--- a/thunder/distributed/transforms/fsdp_v2.py
+++ b/thunder/distributed/transforms/fsdp_v2.py
@@ -1,37 +1,32 @@
 """Transform for `fsdp(jit(model))` to convert a model to use fsdp."""
 
 from __future__ import annotations
-from dataclasses import dataclass
-from dataclasses import field
-from itertools import chain
+
 import os
+from dataclasses import dataclass, field
+from itertools import chain
 from typing import TYPE_CHECKING
 
 import torch
 import torch.distributed as tdist
 
-from thunder.core import devices
-from thunder.core import prims
-from thunder.core import utils
-from thunder.core.proxies import DistParallelType
-from thunder.core.proxies import TensorProxy
-from thunder.core.proxies import variableify, unvariableify
-from thunder.core.trace import from_trace
-from thunder.core.trace import tracectx
-from thunder.core.trace import TraceProvenance
-from thunder.core.transforms import VISIT_TYPE
-from thunder.core.transforms import visitor_transform
+from thunder.core import devices, prims, utils
+from thunder.core.proxies import DistParallelType, TensorProxy, unvariableify, variableify
+from thunder.core.trace import TraceProvenance, from_trace, tracectx
 from thunder.core.transform_common import Transform
+from thunder.core.transforms import VISIT_TYPE, visitor_transform
 from thunder.distributed import (
-    copy_default_process_group,
-    FSDPType,
     FSDPBucketingStrategy,
+    FSDPType,
     _shard_tensor,
+    copy_default_process_group,
 )
 
 if TYPE_CHECKING:
     from typing import Any
+
     from torch.distributed import ProcessGroup
+
     from thunder.core.module import ThunderModule
     from thunder.core.symbol import BoundSymbol
     from thunder.core.trace import VariableInterface

--- a/thunder/distributed/utils.py
+++ b/thunder/distributed/utils.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 import thunder
 from thunder.core.trace import from_trace
-from thunder.core.transforms import bsym_list_to_dag, Node, toposort_bsym_dag, TOPOSORT_ORDER
+from thunder.core.transforms import TOPOSORT_ORDER, Node, bsym_list_to_dag, toposort_bsym_dag
 from thunder.core.utils import check
 from thunder.distributed.prims import PrimIDs
 
@@ -71,11 +72,11 @@ def sort_communication_ops(execution_trace):
         TraceCtx: The sorted execution trace.
     """
     from thunder.executors.torchex import (
-        wait_prim_impl,
-        reduce_scatter_prim_impl,
-        all_reduce_prim_impl,
         all_gather_prim_impl,
+        all_reduce_prim_impl,
+        reduce_scatter_prim_impl,
         unpack_for_fsdp_prim_impl,
+        wait_prim_impl,
     )
 
     if not has_wait_prims(execution_trace):
@@ -131,10 +132,10 @@ def sort_waits(execution_trace):
     """
     from thunder.core import prims
     from thunder.executors.torchex import (
-        wait_prim_impl,
-        reduce_scatter_prim_impl,
-        all_reduce_prim_impl,
         all_gather_prim_impl,
+        all_reduce_prim_impl,
+        reduce_scatter_prim_impl,
+        wait_prim_impl,
     )
 
     if not has_wait_prims(execution_trace):
@@ -184,6 +185,7 @@ def maybe_sort_waits(trace: TraceCtx) -> tuple[bool, TraceCtx]:
     is available and at least :func:`thunder.distributed.prims.wait` is in ``trace``.
     """
     from torch.distributed import is_available
+
     from thunder.core.trace import TraceProvenance
 
     if is_available() and has_wait_prims(trace):

--- a/thunder/dynamo/__init__.py
+++ b/thunder/dynamo/__init__.py
@@ -1,4 +1,3 @@
-from thunder.dynamo.compiler import ThunderCompiler, thunderfx, thunder_profile, thunder_optimize
-
+from thunder.dynamo.compiler import ThunderCompiler, thunder_optimize, thunder_profile, thunderfx
 
 __all__ = ["ThunderCompiler", "thunderfx", "thunder_profile", "thunder_optimize"]

--- a/thunder/dynamo/benchmark_utils.py
+++ b/thunder/dynamo/benchmark_utils.py
@@ -1,18 +1,22 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING
-import sys
+
 import inspect
+import sys
 from pathlib import Path
+from typing import TYPE_CHECKING
+
 import torch
+from torch.profiler import ProfilerActivity, profile
 from torch.utils.benchmark import Timer as TorchBenchmarkTimer
-from torch.profiler import profile, ProfilerActivity
-from thunder.dynamo.utils import thunder_options_to_str
-from thunder.core.utils import check
 from torch.utils.benchmark.utils.common import select_unit as select_time_unit
 
+from thunder.core.utils import check
+from thunder.dynamo.utils import thunder_options_to_str
+
 if TYPE_CHECKING:
-    from typing import TextIO
     from collections.abc import Callable
+    from typing import TextIO
+
     from torch.utils.benchmark.utils.common import Measurement
 
 
@@ -457,8 +461,8 @@ def check_timing(a: float, b: float, a_name: str, b_name: str, test_name: str, t
 
 
 def is_report_using_cuda(report):
-    from thunder.dynamo.utils import ExampleInputMetaData
     from thunder.core.pytree import tree_map
+    from thunder.dynamo.utils import ExampleInputMetaData
 
     def _check_tensor(x):
         return isinstance(x, ExampleInputMetaData) and x.device.type == "cuda"

--- a/thunder/dynamo/compiler.py
+++ b/thunder/dynamo/compiler.py
@@ -1,35 +1,37 @@
 from __future__ import annotations
-from functools import partial
-from looseversion import LooseVersion
-from typing import TYPE_CHECKING
-import warnings
-from pathlib import Path
+
 import copy
+import warnings
+from functools import partial
+from pathlib import Path
+from typing import TYPE_CHECKING
 
 import torch
+from looseversion import LooseVersion
 
+from thunder.dynamo.benchmark_utils import ThunderCompileSpecification
+from thunder.dynamo.splitter import _splitter
 from thunder.dynamo.utils import (
-    recompile_graph,
-    remove_empty_autocast,
     CompilerType,
-    get_split_reasons_string,
-    thunder_options_to_str,
     ProfileStats,
     ThunderAoTOptimizer,
     default_filter,
     default_optimizer,
+    get_split_reasons_string,
     input_to_example_input_meta,
+    recompile_graph,
+    remove_empty_autocast,
+    thunder_options_to_str,
 )
-from thunder.dynamo.splitter import _splitter
-from thunder.dynamo.benchmark_utils import ThunderCompileSpecification
 from thunder.transforms.extraction_only_prologue_transform import ExtractionOnlyPrologueTransform
 
 if TYPE_CHECKING:
-    from thunder.dynamo.utils import SubgraphInfo
-    from thunder.core.transform_common import Transform
-    from thunder.core.trace import TraceCtx as Trace
-    from os import PathLike
     from collections.abc import Callable
+    from os import PathLike
+
+    from thunder.core.trace import TraceCtx as Trace
+    from thunder.core.transform_common import Transform
+    from thunder.dynamo.utils import SubgraphInfo
 
 
 _DEFAULT_THUNDER_FUSION_TYPE = "dataflow"
@@ -216,7 +218,6 @@ def thunderfx(fn: Callable, /, **kwargs) -> Callable:
         The compiled callable
     """
     import thunder
-
     from thunder.dynamo.utils import get_torch_compile_kwargs
 
     torch_compile_kwargs = get_torch_compile_kwargs(**kwargs)

--- a/thunder/dynamo/compiler_graph_benchmark.py
+++ b/thunder/dynamo/compiler_graph_benchmark.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
-from pytest_benchmark.fixture import BenchmarkFixture
+
 from typing import TYPE_CHECKING
-from looseversion import LooseVersion
 
 import torch
+from looseversion import LooseVersion
+from pytest_benchmark.fixture import BenchmarkFixture
+
+from thunder.core.utils import check
 from thunder.dynamo import ThunderCompiler
 from thunder.dynamo.utils import _get_example_inputs_from_placeholder
-from thunder.core.utils import check
-
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -89,7 +90,7 @@ class ThunderCompilerGraphBenchmarking(ThunderCompiler):
         self.post_graph = debug_options.get("post_graph", False)
 
     def run_bench(self, gm: torch.fx.GraphModule, name: str, *sample_args):
-        from thunder.benchmarks import record_peak_allocated_memory, MAX_ALLOCATED_MEMORY_KEYWORD
+        from thunder.benchmarks import MAX_ALLOCATED_MEMORY_KEYWORD, record_peak_allocated_memory
 
         for ex_name, ex in self.executors.items():
             if ex is None:

--- a/thunder/dynamo/report.py
+++ b/thunder/dynamo/report.py
@@ -1,70 +1,69 @@
 from __future__ import annotations
 
+import copy
 import json
 import subprocess
 import sys
+import textwrap
 from functools import partial
+from itertools import chain
 from pathlib import Path
 from typing import TYPE_CHECKING
-import textwrap
-import copy
-from itertools import chain
-from looseversion import LooseVersion
 
 import torch
-from thunder.core.pytree import tree_flatten
-from thunder.core.utils import sequencify, create_python_callable_from_bsym
-from thunder.dynamo.compiler import thunderfx
-from thunder.dynamo.utils import (
-    _get_example_inputs_from_placeholder,
-    _readable,
-    arg_like,
-    get_env,
-    get_split_reasons_string,
-    CompilerType,
-    recompile_graph,
-    has_higher_order_operator,
-    input_to_example_input_meta,
-    example_input_meta_to_input,
-    format_python_file,
-)
+from looseversion import LooseVersion
 
-from thunder.dynamo.repro_script_template import (
-    pytest_benchmark_multi_exe_code_template,
-    bsym_torch_compile_repro_template,
-    main_code,
-    comment_str_template,
-    FXGRAPH_CLASS_NAME,
-    INPUTS_NAME,
-    CALLABLE_NAME,
-    COMPILED_CALLABLE_NAME,
-)
-from thunder import last_traces, last_backward_traces, compile_stats
+from thunder import compile_stats, last_backward_traces, last_traces
 from thunder.benchmarks.utils import backward_only
+from thunder.core.pytree import tree_flatten
+from thunder.core.utils import create_python_callable_from_bsym, sequencify
 from thunder.dynamo.benchmark_utils import (
-    TorchCompileSpecification,
+    KernelTime,
     ThunderCompileSpecification,
+    TorchCompileSpecification,
     TorchEagerSpecification,
     TorchInductorSpecification,
     WallTime,
-    KernelTime,
     WallTimeWithMemoryUsage,
     check_metrics,
     check_nvfusion_timing,
 )
-
+from thunder.dynamo.compiler import thunderfx
+from thunder.dynamo.repro_script_template import (
+    CALLABLE_NAME,
+    COMPILED_CALLABLE_NAME,
+    FXGRAPH_CLASS_NAME,
+    INPUTS_NAME,
+    bsym_torch_compile_repro_template,
+    comment_str_template,
+    main_code,
+    pytest_benchmark_multi_exe_code_template,
+)
+from thunder.dynamo.utils import (
+    CompilerType,
+    _get_example_inputs_from_placeholder,
+    _readable,
+    arg_like,
+    example_input_meta_to_input,
+    format_python_file,
+    get_env,
+    get_split_reasons_string,
+    has_higher_order_operator,
+    input_to_example_input_meta,
+    recompile_graph,
+)
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Sequence
     from os import PathLike
-    from collections.abc import Sequence
     from typing import TextIO
 
     from torch._dynamo.output_graph import GraphCompileReason
-    from thunder.dynamo.utils import ExampleInputMetaData
-    from thunder.core.trace import TraceCtx
+
     from thunder.core.symbol import BoundSymbol
+    from thunder.core.trace import TraceCtx
     from thunder.dynamo.benchmark_utils import CompileSpecificationInterface, TimerInterface
+    from thunder.dynamo.utils import ExampleInputMetaData
 
 
 def run_forward_backward(fn, *args, benchmark=False, **kwargs):
@@ -1089,9 +1088,9 @@ def analyze_thunder_splits(
                         nvfusion_report.write_inductor_repro(split_folder / "nvfusion")
 
     """
-    from thunder.dynamo.utils import remove_empty_autocast, get_thunder_module_names
-    from thunder.dynamo.splitter import _splitter
     from thunder import jit
+    from thunder.dynamo.splitter import _splitter
+    from thunder.dynamo.utils import get_thunder_module_names, remove_empty_autocast
 
     # Splits the FX graph module using Thunder splitter
     gm = remove_empty_autocast(report.graph)

--- a/thunder/dynamo/splitter.py
+++ b/thunder/dynamo/splitter.py
@@ -1,24 +1,25 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING
+
 import copy
 from functools import partial
+from typing import TYPE_CHECKING
 
 import torch
 from torch.fx.passes.split_module import split_module
 
 from thunder.dynamo.utils import (
-    SubgraphInfo,
     CompiledFunction,
     CompilerType,
     SplitReason,
     SplitReasonType,
-    is_node_supported_by_thunder,
-    get_nodes_in_unsupported_ctx_regions,
-    update_node_and_submodule,
-    recompile_graph,
-    checkpoint_converter,
+    SubgraphInfo,
     _get_example_inputs_from_placeholder,
     _ThunderSplitGraphModule,
+    checkpoint_converter,
+    get_nodes_in_unsupported_ctx_regions,
+    is_node_supported_by_thunder,
+    recompile_graph,
+    update_node_and_submodule,
 )
 
 if TYPE_CHECKING:

--- a/thunder/dynamo/utils.py
+++ b/thunder/dynamo/utils.py
@@ -1,18 +1,18 @@
 from __future__ import annotations
-from collections.abc import Callable, Sequence
-from enum import Enum, auto
-from typing import TYPE_CHECKING
+
+import copy
 import dataclasses
 import inspect
 import itertools
-import copy
+from collections import defaultdict, namedtuple
+from collections.abc import Callable, Sequence
+from enum import Enum, auto
 from types import NoneType
-from collections import defaultdict
-from collections import namedtuple
+from typing import TYPE_CHECKING
 
 import torch
-from torch.nn.modules.module import _addindent
 from torch._subclasses.fake_tensor import FakeTensor
+from torch.nn.modules.module import _addindent
 from torch.utils.weak import TensorWeakRef
 
 if torch.distributed.is_available():
@@ -20,17 +20,18 @@ if torch.distributed.is_available():
 else:
     DTensor = NoneType
 
-from thunder.torch.default_torch_ops import torch_auto_registered_ops
-from thunder.torch import _torch_to_thunder_function_map
-from thunder.torch.langctx import torchctx
-from thunder.core.utils import check
 from thunder.core.pytree import tree_flatten
+from thunder.core.utils import check
+from thunder.torch import _torch_to_thunder_function_map
+from thunder.torch.default_torch_ops import torch_auto_registered_ops
+from thunder.torch.langctx import torchctx
 
 if TYPE_CHECKING:
-    from numbers import Number
-    from thunder.core.symbol import Symbol
-    from typing import Any
     from collections.abc import Sequence
+    from numbers import Number
+    from typing import Any
+
+    from thunder.core.symbol import Symbol
 
 auto_register_ops = set(itertools.chain(*torch_auto_registered_ops.values()))
 
@@ -193,8 +194,8 @@ def get_proxy_inputs_from_node(node: torch.fx.Node) -> tuple[tuple, dict]:
         node (torch.fx.Node): The FX graph node to create proxy inputs for.
     """
     import thunder
-    from thunder.core.trace import TraceCtx
     from thunder.core.proxies import proxy
+    from thunder.core.trace import TraceCtx
 
     # We need to be under trace context to generate proxies.
     with thunder.core.trace.tracectx(TraceCtx()):
@@ -263,9 +264,9 @@ def try_execute_thunder_symbol(thunder_symbol: Symbol, node: torch.fx.Node) -> t
             The second element is a `SplitReason` object if an error occurred, or `None` if the execution was successful.
     """
     import thunder
-    from thunder.core.trace import TraceCtx
-    from thunder.core.compile_data import compile_data_and_stats
     from thunder.common import CompileData, CompileStats
+    from thunder.core.compile_data import compile_data_and_stats
+    from thunder.core.trace import TraceCtx
     from thunder.core.transforms import value_and_grad
 
     # This is required for verifying `_enter_autocast`
@@ -816,7 +817,7 @@ def get_env() -> tuple[str, str]:
     Additionally, include the installed versions of Thunder and NvFuser (if available via pip).
     """
 
-    from torch.utils.collect_env import run, get_pip_packages
+    from torch.utils.collect_env import get_pip_packages, run
 
     torch_env = "CUDA devices:\n"
     for i in range(torch.cuda.device_count()):
@@ -1005,13 +1006,13 @@ def default_optimizer(gm: torch.fx.GraphModule, stats: ProfileStats) -> Callable
     Returns:
         The optimized GraphModule
     """
-    from thunder.dynamo.report import FXGraphReport
     from thunder.dynamo.benchmark_utils import (
-        TorchInductorSpecification,
-        TorchEagerSpecification,
         ThunderCompilerOnGraphModuleSpecification,
+        TorchEagerSpecification,
+        TorchInductorSpecification,
         WallTime,
     )
+    from thunder.dynamo.report import FXGraphReport
 
     if has_symbolic_input(stats.gm):
         raise NotImplementedError("Optimizing graph module with symbolic inputs is not supported yet.")

--- a/thunder/examine/__init__.py
+++ b/thunder/examine/__init__.py
@@ -1,20 +1,21 @@
-from typing import Any
-from collections.abc import Callable
 import collections
+import importlib
 import traceback
+from collections.abc import Callable
+from itertools import chain
+from typing import Any
+from warnings import warn
+
+import torch
 
 import thunder
-from thunder.core.trace import TraceCtx
-from thunder.core.transforms import bsym_list_to_dag, Node
-from thunder.core.proxies import TensorProxy, CollectionProxy
+from thunder.core.langctxs import LanguageContext, Languages, resolve_language
+from thunder.core.proxies import CollectionProxy, TensorProxy
 from thunder.core.symbol import BoundSymbol
+from thunder.core.trace import TraceCtx
+from thunder.core.transforms import Node, bsym_list_to_dag
 from thunder.torch import _torch_to_thunder_function_map
 from thunder.torch.default_torch_ops import torch_auto_registered_ops
-from thunder.core.langctxs import resolve_language, LanguageContext, Languages
-import torch
-from warnings import warn
-from itertools import chain
-import importlib
 
 
 # TODO Maybe make collect_into a set?

--- a/thunder/examine/memory_calculation.py
+++ b/thunder/examine/memory_calculation.py
@@ -1,12 +1,12 @@
-from collections.abc import Callable, MutableSequence, MutableMapping, MutableSet
+from collections.abc import Callable, MutableMapping, MutableSequence, MutableSet
 from functools import partial
 
 from thunder.core.prims import PrimIDs
 from thunder.core.proxies import FutureTensorProxy, Proxy, TensorProxy
+from thunder.core.pytree import tree_iter
 from thunder.core.symbol import BoundSymbol, Symbol
 from thunder.core.trace import TraceCtx
-from thunder.core.utils import check_type, ProxyDict
-from thunder.core.pytree import tree_iter
+from thunder.core.utils import ProxyDict, check_type
 from thunder.executors import pythonex
 
 # Arguments are considered independently, so we ignore all unpacking operations on them

--- a/thunder/executors/__init__.py
+++ b/thunder/executors/__init__.py
@@ -1,10 +1,8 @@
-from typing import Optional, Any, List, Tuple
 from collections.abc import Sequence
+from typing import Any, List, Optional, Tuple
 
 import thunder.executors.passes as passes
-
 import thunder.extend as extend
-
 
 # NOTE The executors submodule depends on the extend submodule
 

--- a/thunder/executors/apex_entropyex_impl.py
+++ b/thunder/executors/apex_entropyex_impl.py
@@ -1,16 +1,14 @@
 from typing import Any
 
 import torch
-
 from lightning_utilities.core.imports import package_available
 
 import thunder.torch as ltorch
+from thunder.core.compile_data import get_compile_option
 from thunder.core.devices import DeviceType, to_device
 from thunder.core.proxies import TensorProxy
+from thunder.core.transforms import get_grad, mean_backward, put_grad, restore_reduced_dims
 from thunder.core.utils import check, same_shape
-from thunder.core.transforms import get_grad, put_grad, mean_backward, restore_reduced_dims
-from thunder.core.compile_data import get_compile_option
-
 from thunder.executors.apexex import apex_ex
 
 APEX_CROSS_ENTROPY_AVAILABLE: bool = package_available("xentropy_cuda")

--- a/thunder/executors/apex_fused_rms_norm_impl.py
+++ b/thunder/executors/apex_fused_rms_norm_impl.py
@@ -1,11 +1,9 @@
-from collections.abc import Sequence
 import math
-
+from collections.abc import Sequence
 
 from thunder.core.proxies import TensorProxy
-from thunder.torch import TensorLike
 from thunder.executors.apexex import apex_ex
-
+from thunder.torch import TensorLike
 
 APEX_FUSED_NORMS_AVAILABLE = True
 try:

--- a/thunder/executors/apexex.py
+++ b/thunder/executors/apexex.py
@@ -1,6 +1,5 @@
 from thunder.extend import OperatorExecutor, register_executor
 
-
 # TODO Does apex have a version this should use?
 apex_ex = OperatorExecutor("apex", version="0.1")
 register_executor(apex_ex)

--- a/thunder/executors/cudnn_layernormex.py
+++ b/thunder/executors/cudnn_layernormex.py
@@ -1,13 +1,10 @@
-from typing import Any
-
-import torch
-import numpy as np
-
-
 # WARNING: cudnn layernorm executor is experimental. Tests that use cudnn might fail.
 from dataclasses import dataclass
 from functools import lru_cache
+from typing import Any
 
+import numpy as np
+import torch
 
 from thunder.executors.cudnnex import cudnn_available, torch_to_cudnn_dtype
 from thunder.extend import OperatorExecutor
@@ -122,8 +119,9 @@ def layer_norm_checker(a, normalized_shape, weight=None, bias=None, eps=1e-5):
 cudnn_layernorm_ex: None | OperatorExecutor = None
 
 if cudnn_available():
-    from thunder.extend import register_executor
     import cudnn
+
+    from thunder.extend import register_executor
 
     cudnn_layernorm_ex: OperatorExecutor = OperatorExecutor("cudnn_layernorm", version=cudnn.backend_version())
     register_executor(cudnn_layernorm_ex)

--- a/thunder/executors/cudnn_sdpa.py
+++ b/thunder/executors/cudnn_sdpa.py
@@ -1,20 +1,18 @@
+import random
 from collections import OrderedDict
 from itertools import accumulate
-import random
-import torch
-
-from thunder.torch import TensorLike
-from thunder.core.proxies import TensorProxy
-from thunder.core.compile_data import get_compile_option
-from thunder.core.prims import OpTags
-from thunder.core.transforms import get_grad, put_grad, put_grads
-import thunder.core.dtypes as dtypes
-import thunder.torch as ltorch
-from thunder.core.proxies import pyval
-
-from thunder.extend import OperatorExecutor, register_executor
 
 import cudnn
+import torch
+
+import thunder.core.dtypes as dtypes
+import thunder.torch as ltorch
+from thunder.core.compile_data import get_compile_option
+from thunder.core.prims import OpTags
+from thunder.core.proxies import TensorProxy, pyval
+from thunder.core.transforms import get_grad, put_grad, put_grads
+from thunder.extend import OperatorExecutor, register_executor
+from thunder.torch import TensorLike
 
 cudnn_backend_version = cudnn.backend_version()
 

--- a/thunder/executors/cudnnex.py
+++ b/thunder/executors/cudnnex.py
@@ -2,6 +2,7 @@ from collections.abc import Callable
 
 from lightning_utilities.core.imports import package_available
 from looseversion import LooseVersion
+
 from thunder.extend import OperatorExecutor
 
 __all__ = ["cudnn_version", "required_cudnn_version", "cudnn_available", "cudnn_ex", "torch_to_cudnn_dtype"]

--- a/thunder/executors/data_dependent_partition.py
+++ b/thunder/executors/data_dependent_partition.py
@@ -5,11 +5,10 @@ from copy import copy
 
 import thunder.core.utils as utils
 from thunder.core.compile_data import get_compile_option
-from thunder.core.trace import TraceCtx
-from thunder.core.symbol import BoundSymbol, BoundSymbolTag
-from thunder.core.proxies import variableify, Proxy
 from thunder.core.prims import PrimIDs
-
+from thunder.core.proxies import Proxy, variableify
+from thunder.core.symbol import BoundSymbol, BoundSymbolTag
+from thunder.core.trace import TraceCtx
 
 _DEFAULT_FUSION_TYPE = "consecutive"
 

--- a/thunder/executors/fa3ex.py
+++ b/thunder/executors/fa3ex.py
@@ -4,13 +4,14 @@
 # is hopper and fa3 has been built
 
 try:
-    from flash_attn_interface import _flash_attn_forward, _flash_attn_backward, flash_attn_func
+    from flash_attn_interface import _flash_attn_backward, _flash_attn_forward, flash_attn_func
 
     HAS_FA3 = True
 except ImportError:
     HAS_FA3 = False
 
 import torch
+
 import thunder
 from thunder.core.transforms import get_grad, put_grads
 from thunder.extend import OperatorExecutor, register_executor

--- a/thunder/executors/passes.py
+++ b/thunder/executors/passes.py
@@ -1,24 +1,25 @@
 from __future__ import annotations
+
+import time
 from collections import deque
 from dataclasses import dataclass
 from itertools import chain
 from typing import TYPE_CHECKING
-import time
 
-from thunder.core.proxies import Proxy, variableify, CollectionProxy
+import thunder.core.prims as prims
+import thunder.core.utils as cutils
+from thunder.core.proxies import CollectionProxy, Proxy, variableify
 from thunder.core.pytree import tree_flatten
-from thunder.core.trace import from_trace, TraceProvenance
+from thunder.core.trace import TraceProvenance, from_trace
 from thunder.core.trace_interpreter import TraceSubstitutionProcessor
 from thunder.core.transform_common import dce
 from thunder.core.utils import ProxyDict
 from thunder.executors.pythonex import clear_mutable_collection
-from thunder.extend import Executor, get_always_executors, OperatorExecutor, FusionExecutor
-import thunder.core.prims as prims
-import thunder.core.utils as cutils
+from thunder.extend import Executor, FusionExecutor, OperatorExecutor, get_always_executors
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-    from collections.abc import Sequence
+    from collections.abc import Callable, Sequence
+
     from thunder.core.symbol import BoundSymbol
     from thunder.core.trace import TraceCtx
 

--- a/thunder/executors/pythonex.py
+++ b/thunder/executors/pythonex.py
@@ -1,20 +1,19 @@
-from typing import Any
-from collections.abc import Sequence, Collection, MutableSet, MutableMapping, MutableSequence
-from numbers import Number
+import builtins
 import math
 import operator
-import builtins
 import platform
+from collections.abc import Collection, MutableMapping, MutableSequence, MutableSet, Sequence
+from numbers import Number
+from typing import Any
 
 import torch
 
-import thunder.core.prims as prims
-from thunder.core.proxies import NumberProxy, NumberLike, TensorProxy, CollectionProxy
-from thunder.core import baseutils
 import thunder.core.dtypes as dtypes
+import thunder.core.prims as prims
 import thunder.core.utils as utils
-
-from thunder.extend import OperatorExecutor, register_executor, add_always_executor
+from thunder.core import baseutils
+from thunder.core.proxies import CollectionProxy, NumberLike, NumberProxy, TensorProxy
+from thunder.extend import OperatorExecutor, add_always_executor, register_executor
 
 # NOTE The criterion for being an "always" executor is that this does not introduce symbols that
 #   it does not execute in its execution transforms

--- a/thunder/executors/sdpaex.py
+++ b/thunder/executors/sdpaex.py
@@ -2,29 +2,25 @@ import math
 
 import torch
 
-import thunder.core.dtypes as dtypes
-from thunder.core.proxies import Proxy, TensorProxy
-import thunder.core.utils as utils
 import thunder.core.devices as devices
-from thunder.core.prims import OpTags
-
+import thunder.core.dtypes as dtypes
+import thunder.core.utils as utils
 import thunder.torch as ltorch
-from thunder.torch import TensorLike
-
+from thunder.core.prims import OpTags
+from thunder.core.proxies import Proxy, TensorProxy
 from thunder.core.transforms import (
     get_grad,
     put_grad,
     put_grads,
 )
-from thunder.extend import OperatorExecutor, register_executor
-
-
 from thunder.executors.utils import (
+    SpdaBackend,
+    _fused_sdp_choice,
     _input_dtype_check_fused_scaled_dot_product_attention,
     _input_shape_check_fused_scaled_dot_product_attention,
-    _fused_sdp_choice,
-    SpdaBackend,
 )
+from thunder.extend import OperatorExecutor, register_executor
+from thunder.torch import TensorLike
 
 sdpa_ex: OperatorExecutor = OperatorExecutor("sdpa", version="0.1")
 register_executor(sdpa_ex)

--- a/thunder/executors/torchex.py
+++ b/thunder/executors/torchex.py
@@ -1,34 +1,31 @@
 from __future__ import annotations
-import operator
+
 import importlib
+import operator
+from collections.abc import Callable, Hashable, Sequence
 from functools import partial, wraps
 from numbers import Number
-from typing import TYPE_CHECKING
-from collections.abc import Callable
-from collections.abc import Hashable, Sequence
 from types import ModuleType
+from typing import TYPE_CHECKING
 
 import torch
 
-import thunder.core.dtypes as dtypes
-from thunder.core.dtypes import to_torch_dtype, to_dtype
 import thunder.core.devices as devices
-from thunder.core.devices import to_torch_device, to_device
+import thunder.core.dtypes as dtypes
 import thunder.core.prims as prims
+import thunder.core.utils as utils
+import thunder.distributed.prims as dist_prims
+import thunder.torch as ltorch
+from thunder.core.devices import to_device, to_torch_device
+from thunder.core.dtypes import to_dtype, to_torch_dtype
 from thunder.core.proxies import NumberProxy, TensorProxy, pytype
 from thunder.core.symbol import Symbol
-from thunder.distributed.prims import DistributedReduceOps
-import thunder.distributed.prims as dist_prims
-import thunder.core.utils as utils
-
-import thunder.torch as ltorch
-
-from thunder.extend import OperatorExecutor, register_executor, add_always_executor
-
 from thunder.core.transforms import (
     get_grad,
     put_grad,
 )
+from thunder.distributed.prims import DistributedReduceOps
+from thunder.extend import OperatorExecutor, add_always_executor, register_executor
 
 if TYPE_CHECKING:
     from thunder.common import CompileData

--- a/thunder/executors/transformer_engine_v2ex_impl.py
+++ b/thunder/executors/transformer_engine_v2ex_impl.py
@@ -1,40 +1,38 @@
 import time
 from typing import TYPE_CHECKING
 
-from thunder.core.prims import linear as linear_prim
-from thunder.core.prims import get_grad, put_grad
-from thunder.core.proxies import AnyProxy, TensorProxy
-from thunder.extend import StatefulExecutor, register_executor
-from thunder.executors.transformer_engineex import _linear_checker
+import thunder.core.utils as utils
 import thunder.torch as ltorch
 from thunder import Transform
 from thunder.core import prims
-from thunder.core.proxies import Proxy, Variable, unvariableify, variableify
-from thunder.core.trace import from_trace, TraceProvenance, TraceTag
-from thunder.core.transforms import (
-    _update_forward_with_new_saved_for_backward,
-    _update_backward_with_new_saved_for_backward,
-)
+from thunder.core.prims import get_grad, put_grad
+from thunder.core.prims import linear as linear_prim
+from thunder.core.proxies import AnyProxy, Proxy, TensorProxy, Variable, unvariableify, variableify
+from thunder.core.trace import TraceProvenance, TraceTag, from_trace
 from thunder.core.transform_common import cse_single_bsym
+from thunder.core.transforms import (
+    _update_backward_with_new_saved_for_backward,
+    _update_forward_with_new_saved_for_backward,
+)
 from thunder.executors.passes import del_last_used
-import thunder.core.utils as utils
+from thunder.executors.transformer_engineex import _linear_checker
+from thunder.extend import StatefulExecutor, register_executor
 
 if TYPE_CHECKING:
-    from thunder.core.trace import VariableInterface
-    from thunder.core.symbol import BoundSymbolRHS, BoundSymbol
     from thunder.core.proxies import TensorProxy
+    from thunder.core.symbol import BoundSymbol, BoundSymbolRHS
+    from thunder.core.trace import VariableInterface
 
 import transformer_engine.pytorch as te
-from transformer_engine.pytorch.tensor import Quantizer
-from transformer_engine.pytorch.ops import BasicLinear
 from transformer_engine.pytorch.fp8 import (
-    _amax_and_scale_update,
-    get_fp8_max,
+    FP8GlobalStateManager,
     Recipe,
     RecipeState,
-    FP8GlobalStateManager,
+    _amax_and_scale_update,
+    get_fp8_max,
 )
-
+from transformer_engine.pytorch.ops import BasicLinear
+from transformer_engine.pytorch.tensor import Quantizer
 
 transformer_engine_v2_ex = StatefulExecutor("transformer_engine_v2")
 register_executor(transformer_engine_v2_ex)

--- a/thunder/executors/transformer_engineex.py
+++ b/thunder/executors/transformer_engineex.py
@@ -1,30 +1,26 @@
+import warnings
+from collections import deque
+from collections.abc import Callable, Sequence
+from contextlib import contextmanager, nullcontext
 from functools import partial
+from importlib.metadata import version
 from itertools import chain
 from typing import Any
-from collections.abc import Sequence
-from collections.abc import Callable
-from contextlib import contextmanager, nullcontext
-from collections import deque
-from importlib.metadata import version
-from looseversion import LooseVersion
-import warnings
 
 import torch
-
 from lightning_utilities.core.imports import package_available
+from looseversion import LooseVersion
 
-from thunder.core.proxies import TensorProxy
-from thunder.core.trace import get_tracectx
-from thunder.core.symbol import Symbol, BoundSymbol
 import thunder.core.devices as devices
 import thunder.core.prims as prims
-from thunder.core.proxies import AnyProxy
+from thunder.core.compile_data import get_compile_data, get_compile_option
+from thunder.core.proxies import AnyProxy, TensorProxy
+from thunder.core.symbol import BoundSymbol, Symbol
+from thunder.core.trace import get_tracectx
 from thunder.core.vjp_utils import disable_caching_split_forward_and_backward
-from thunder.extend import OperatorExecutor, register_executor
-from thunder.core.compile_data import get_compile_option, get_compile_data
 from thunder.distributed import FSDPType
 from thunder.executors.utils import Context, set_saved_tensors
-
+from thunder.extend import OperatorExecutor, register_executor
 
 __all__ = [
     "transformer_engine_ex",
@@ -42,14 +38,14 @@ te: None | Any = None
 if TE_AVAILABLE:
     try:
         import transformer_engine.pytorch as te
-        from transformer_engine.common.recipe import MXFP8BlockScaling, DelayedScaling
-        from transformer_engine.pytorch.constants import MXFP8_BLOCK_SCALING_SIZE
-        from transformer_engine.pytorch.module.linear import _Linear
-        from transformer_engine.pytorch.module.base import TransformerEngineBaseModule
-        from transformer_engine.pytorch.fp8 import FP8GlobalStateManager, get_default_fp8_recipe
-        from transformer_engine.pytorch.utils import check_dim_for_fp8_exec
-        from transformer_engine.pytorch.cpu_offload import CPUOffloadEnabled
         import transformer_engine_torch as tex
+        from transformer_engine.common.recipe import DelayedScaling, MXFP8BlockScaling
+        from transformer_engine.pytorch.constants import MXFP8_BLOCK_SCALING_SIZE
+        from transformer_engine.pytorch.cpu_offload import CPUOffloadEnabled
+        from transformer_engine.pytorch.fp8 import FP8GlobalStateManager, get_default_fp8_recipe
+        from transformer_engine.pytorch.module.base import TransformerEngineBaseModule
+        from transformer_engine.pytorch.module.linear import _Linear
+        from transformer_engine.pytorch.utils import check_dim_for_fp8_exec
     except Exception as ex:
         warnings.warn(f"transformer_engine failed to import with exception {ex}")
         TE_AVAILABLE = False

--- a/thunder/executors/triton_crossentropy_impl.py
+++ b/thunder/executors/triton_crossentropy_impl.py
@@ -3,8 +3,8 @@ from enum import Enum
 
 import torch
 
-from thunder.extend import OperatorExecutor, register_executor
 from thunder.executors import triton_utils
+from thunder.extend import OperatorExecutor, register_executor
 
 # Requires triton 2.1 or greater
 min_triton_version = "2.1"

--- a/thunder/executors/triton_utils.py
+++ b/thunder/executors/triton_utils.py
@@ -1,5 +1,5 @@
-from looseversion import LooseVersion
 from lightning_utilities.core.imports import package_available
+from looseversion import LooseVersion
 
 
 def triton_version() -> None | str:

--- a/thunder/executors/utils.py
+++ b/thunder/executors/utils.py
@@ -1,19 +1,18 @@
 from __future__ import annotations
 
-from enum import Enum
 from contextlib import contextmanager
+from enum import Enum
 
 import torch
 from looseversion import LooseVersion
+from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
 
 import thunder.core.utils as utils
-from thunder.core.symbol import BoundSymbol
-from thunder.core.proxies import variableify, Proxy, unvariableify
-from thunder.core.prims import PrimIDs
-from thunder.core.transform_common import order_proxies
-from torch._subclasses.fake_tensor import FakeTensor, FakeTensorMode
 from thunder.core.compile_data import get_compile_option
-
+from thunder.core.prims import PrimIDs
+from thunder.core.proxies import Proxy, unvariableify, variableify
+from thunder.core.symbol import BoundSymbol
+from thunder.core.transform_common import order_proxies
 
 try:
     torch.cuda.graphs.is_current_stream_capturing()

--- a/thunder/extend/__init__.py
+++ b/thunder/extend/__init__.py
@@ -1,8 +1,8 @@
-from collections.abc import Callable, Sequence, Hashable
 import enum
 import itertools
 import os
 import sys
+from collections.abc import Callable, Hashable, Sequence
 from types import ModuleType
 from typing import Any
 
@@ -12,7 +12,7 @@ from thunder.core.devices import to_torch_device
 from thunder.core.dtypes import to_torch_dtype
 from thunder.core.proxies import Proxy, TensorProxy, proxy
 from thunder.core.pytree import tree_map
-from thunder.core.symbol import Symbol, BoundSymbol, default_python_printer
+from thunder.core.symbol import BoundSymbol, Symbol, default_python_printer
 from thunder.core.trace import TraceCtx
 from thunder.core.vjp_utils import disable_caching_split_forward_and_backward
 
@@ -533,14 +533,14 @@ def get_all_executors() -> tuple[Executor, ...]:
         apexex,
         cudnn_layernormex,
         cudnnex,
+        fa3ex,
         nvfuserex,
         pythonex,
         sdpaex,
-        fa3ex,
         torch_compile,
         torchex,
-        transformer_engineex,
         transformer_engine_v2ex,
+        transformer_engineex,
         triton_crossentropy,
     )
 

--- a/thunder/numpy/__init__.py
+++ b/thunder/numpy/__init__.py
@@ -1,16 +1,14 @@
+from collections.abc import Callable
 from numbers import Number
 from typing import Any
-from collections.abc import Callable
 
 import numpy as np
 
-from thunder.core.langctx import langctx, Languages
-from thunder.numpy.langctx import register_method
-
+import thunder.clang as clang
+from thunder.core.langctx import Languages, langctx
 from thunder.core.proxies import TensorProxy
 from thunder.core.symbol import Symbol
-import thunder.clang as clang
-
+from thunder.numpy.langctx import register_method
 
 #
 # NumPy operator definitions

--- a/thunder/numpy/langctx.py
+++ b/thunder/numpy/langctx.py
@@ -1,8 +1,8 @@
 from collections.abc import Callable
 
-from thunder.core.langctxs import LanguageContext, register_langctx, Languages, resolve_language
-from thunder.core.pytree import tree_flatten
+from thunder.core.langctxs import LanguageContext, Languages, register_langctx, resolve_language
 from thunder.core.proxies import TensorProxy
+from thunder.core.pytree import tree_flatten
 
 #
 # Creates and registers the torch language context

--- a/thunder/plugins/__init__.py
+++ b/thunder/plugins/__init__.py
@@ -1,6 +1,6 @@
 from thunder.plugins.distributed import DDP, FSDP
-from thunder.plugins.quantization import QuantizeInt4
 from thunder.plugins.fp8 import FP8
+from thunder.plugins.quantization import QuantizeInt4
 from thunder.plugins.reduce_overhead import ReduceOverhead
 
 names_to_plugins = {

--- a/thunder/plugins/distributed.py
+++ b/thunder/plugins/distributed.py
@@ -1,13 +1,12 @@
 import torch
-
 from torch.distributed.device_mesh import DeviceMesh
-from thunder import Plugin
-import thunder.core.utils as utils
-from thunder.distributed import FSDPType, FSDPBucketingStrategy, copy_default_process_group
 
-from thunder.transforms import MaterializationTransform
+import thunder.core.utils as utils
+from thunder import Plugin
+from thunder.distributed import FSDPBucketingStrategy, FSDPType, copy_default_process_group
 from thunder.distributed.transforms.ddp_v2 import DDPTransform
 from thunder.distributed.transforms.fsdp_v2 import FSDPTransform
+from thunder.transforms import MaterializationTransform
 
 
 class DDP(Plugin):

--- a/thunder/recipes/__init__.py
+++ b/thunder/recipes/__init__.py
@@ -3,7 +3,6 @@ from typing import Any, Type
 from thunder.recipes.base import BaseRecipe
 from thunder.recipes.hf_transformers import HFTransformers
 
-
 names_to_recipes: dict[str : type[Any]] = {
     "default": BaseRecipe,
     "hf-transformers": HFTransformers,

--- a/thunder/recipes/base.py
+++ b/thunder/recipes/base.py
@@ -1,8 +1,10 @@
-import torch
-from thunder import Recipe, DebugOptions, Transform, Executor
-from thunder.transforms.prune_prologue_checks import PrunePrologueChecks
-from thunder.extend import get_executor
 from typing import Any
+
+import torch
+
+from thunder import DebugOptions, Executor, Recipe, Transform
+from thunder.extend import get_executor
+from thunder.transforms.prune_prologue_checks import PrunePrologueChecks
 
 
 def get_nvfuser_package_hint() -> str:

--- a/thunder/recipes/hf_transformers.py
+++ b/thunder/recipes/hf_transformers.py
@@ -1,10 +1,10 @@
+import warnings
 from distutils.version import LooseVersion
 from functools import partial
-import warnings
 
 import thunder
-from thunder.recipes import BaseRecipe
 from thunder import Recipe
+from thunder.recipes import BaseRecipe
 
 
 class InplaceIndexCopyTransform(thunder.Transform):

--- a/thunder/tests/bf16.py
+++ b/thunder/tests/bf16.py
@@ -1,5 +1,6 @@
-import thunder.core
 import torch
+
+import thunder.core
 
 
 def device_supports_bf16(device: None | str | torch.device | thunder.core.devices.Device, /) -> bool:

--- a/thunder/tests/conftest.py
+++ b/thunder/tests/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 import pytest_benchmark
+
 from thunder.dynamo.compiler_graph_benchmark import GRAPH_BY_GRAPH_BENCHMARK_PARAMS_KEYS
 
 

--- a/thunder/tests/distributed/helper.py
+++ b/thunder/tests/distributed/helper.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
-from functools import partial
-from functools import wraps
-from typing import ClassVar, TYPE_CHECKING
+
 import math
 import os
 import sys
+from functools import partial, wraps
+from typing import TYPE_CHECKING, ClassVar
 
 import torch
 import torch.nn as nn
@@ -24,8 +24,7 @@ except ImportError:
 
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-    from collections.abc import Sequence
+    from collections.abc import Callable, Sequence
 
 
 __all__ = [
@@ -242,6 +241,7 @@ if torch.distributed.is_available():
         def __call__(self, test_stub):
             import multiprocessing as mp
             import tempfile
+
             import pytest
 
             if not torch.distributed.is_available():
@@ -330,6 +330,7 @@ if torch.distributed.is_available():
     ):
         from collections import defaultdict
         from contextlib import nullcontext
+
         from thunder.distributed import get_skip_data_parallel_grad_sync
 
         device = torch.device("cuda", test_case.rank)

--- a/thunder/tests/distributed/modules.py
+++ b/thunder/tests/distributed/modules.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
-from typing import ClassVar, TYPE_CHECKING
+
+from typing import TYPE_CHECKING, ClassVar
 
 import torch.nn as nn
 

--- a/thunder/tests/distributed/test_checkpoint.py
+++ b/thunder/tests/distributed/test_checkpoint.py
@@ -15,13 +15,13 @@ from torch.testing._internal import common_utils
 import thunder
 from thunder.distributed import _unshard_params
 from thunder.distributed.checkpoint import (
+    _TORCH_GREATER_EQUAL_2_3,
+    StateDictOptions,
     _split_state_dict,
+    get_model_state_dict,
     has_fsdp_modules,
     load_model_state_dict,
-    StateDictOptions,
     save,
-    get_model_state_dict,
-    _TORCH_GREATER_EQUAL_2_3,
 )
 from thunder.tests.distributed.helper import DistributedParallelTestCase
 
@@ -63,8 +63,8 @@ def test_split_state_dict():
 
 def distributed_ckpt_to_regular(path):
     """From ``torch.distributed.checkpoint.format_utils.dcp_to_torch_save``."""
-    from torch.distributed.checkpoint.state_dict_loader import _load_state_dict
     from torch.distributed.checkpoint import FileSystemReader
+    from torch.distributed.checkpoint.state_dict_loader import _load_state_dict
 
     if _TORCH_GREATER_EQUAL_2_3:
         from torch.distributed.checkpoint.format_utils import _EmptyStateDictLoadPlanner

--- a/thunder/tests/distributed/test_ddp.py
+++ b/thunder/tests/distributed/test_ddp.py
@@ -17,42 +17,41 @@ import thunder.executors
 import thunder.torch as ltorch
 from thunder.core import devices
 from thunder.distributed import ddp
-from thunder.tests.framework import instantiate, TorchExecutor
-
 from thunder.executors.transformer_engineex import (
-    transformer_engine_ex,
     TE_AVAILABLE,
     te_sync_fp8_meta_bwd,
+    transformer_engine_ex,
 )
-
+from thunder.tests.framework import TorchExecutor, instantiate
 
 is_fp8_supported: bool = False
 # This will be correctly updated below when TE Engine is installed
 # and if the current environment doesn't support FP8.
 fp8_support_reason: str = ""
 if TE_AVAILABLE:
-    from transformer_engine.pytorch import fp8_autocast
+    from transformer_engine.common.recipe import MXFP8BlockScaling
     from transformer_engine.pytorch import Linear as TELinear
+    from transformer_engine.pytorch import fp8_autocast
     from transformer_engine.pytorch.fp8 import (
-        check_fp8_support,
         FP8GlobalStateManager,
+        check_fp8_support,
         get_default_fp8_recipe,
     )
-    from transformer_engine.common.recipe import MXFP8BlockScaling
 
     is_fp8_supported, fp8_support_reason = check_fp8_support()
 
-from thunder.tests.distributed.helper import (
-    ToyModel,
-    DistributedParallelTestCase,
-    executors_map,
-    SmallModel,
-    create_per_process_dataloader,
-    run_test_no_sync_grad_accumulation,
-    distributed_wrapper,
-    init_per_process_distributed,
-)
 from torch.testing._internal import common_utils
+
+from thunder.tests.distributed.helper import (
+    DistributedParallelTestCase,
+    SmallModel,
+    ToyModel,
+    create_per_process_dataloader,
+    distributed_wrapper,
+    executors_map,
+    init_per_process_distributed,
+    run_test_no_sync_grad_accumulation,
+)
 
 
 @unittest.skipUnless(
@@ -109,10 +108,10 @@ class DDPTest(DistributedParallelTestCase):
     def test_ddp_grad_bucketing(self, executor, bucket_size_in_mb: int):
         from thunder.distributed import ddp
         from thunder.executors.torchex import (
+            all_reduce_prim_impl,
             pack_prim_impl,
             unpack_prim_impl,
             update_bucket_view_prim_impl,
-            all_reduce_prim_impl,
         )
 
         device = torch.device("cuda", self.rank)
@@ -509,7 +508,7 @@ def _test_ddp_transformer_engine_llama_sanity(input_data):
     # due to reordering of forward and backward operators.
     # (This test will fail without `_rearrange_transformer_engine_linear` in `torch_autograd.py`)
     # For more details, see docstring for `_rearrange_transformer_engine_linear` in transformer_engine_ex.py.
-    from thunder.tests.llama2_model import Transformer, ModelArgs
+    from thunder.tests.llama2_model import ModelArgs, Transformer
 
     init_method, world_size, rank, executor, device, dtype, _unused_kwargs = input_data
     devicetype = devices.device_from_string(device).devicetype

--- a/thunder/tests/distributed/test_dtensor.py
+++ b/thunder/tests/distributed/test_dtensor.py
@@ -7,17 +7,13 @@ import torch
 if not torch.distributed.is_available():
     pytest.skip(allow_module_level=True)
 
-from thunder.dynamo import thunderfx
-import thunder
-
-from thunder.tests.distributed.helper import DistributedParallelTestCase
 from torch.distributed._tensor import DeviceMesh, distribute_tensor
-from torch.distributed.tensor.placement_types import Placement, Shard, Replicate
-
+from torch.distributed.tensor.placement_types import Placement, Replicate, Shard
 from torch.testing._internal import common_utils
 
-from thunder.tests.distributed.helper import executors_map
-
+import thunder
+from thunder.dynamo import thunderfx
+from thunder.tests.distributed.helper import DistributedParallelTestCase, executors_map
 
 # NOTE: We run all these similar functions seperately
 #       as we want to avoid nvfuser issue (https://github.com/NVIDIA/Fuser/issues/4507)

--- a/thunder/tests/distributed/test_fsdp.py
+++ b/thunder/tests/distributed/test_fsdp.py
@@ -19,45 +19,43 @@ import thunder
 import thunder.executors
 import thunder.torch as ltorch
 from thunder.core import devices
-from thunder.distributed import FSDPBucketingStrategy, FSDPType
-from thunder.distributed import fsdp
-from thunder.tests.framework import instantiate, TorchExecutor
-
+from thunder.distributed import FSDPBucketingStrategy, FSDPType, fsdp
 from thunder.executors.transformer_engineex import (
-    transformer_engine_ex,
     TE_AVAILABLE,
+    transformer_engine_ex,
 )
-
+from thunder.tests.framework import TorchExecutor, instantiate
 
 is_fp8_supported: bool = False
 # This will be correctly updated below when TE Engine is installed
 # and if the current environment doesn't support FP8.
 fp8_support_reason: str = ""
 if TE_AVAILABLE:
-    from transformer_engine.pytorch import fp8_autocast
+    import transformer_engine
+    from transformer_engine.common.recipe import MXFP8BlockScaling
     from transformer_engine.pytorch import Linear as TELinear
+    from transformer_engine.pytorch import fp8_autocast
     from transformer_engine.pytorch.fp8 import (
-        check_fp8_support,
         FP8GlobalStateManager,
+        check_fp8_support,
         get_default_fp8_recipe,
     )
-    from transformer_engine.common.recipe import MXFP8BlockScaling
-    import transformer_engine
 
     is_fp8_supported, fp8_support_reason = check_fp8_support()
 
-from thunder.tests.distributed.helper import (
-    ToyModel,
-    DistributedParallelTestCase,
-    new_gelu,
-    executors_map,
-    distributed_wrapper,
-    create_per_process_dataloader,
-    SmallModel,
-    run_test_no_sync_grad_accumulation,
-    init_per_process_distributed,
-)
 from torch.testing._internal import common_utils
+
+from thunder.tests.distributed.helper import (
+    DistributedParallelTestCase,
+    SmallModel,
+    ToyModel,
+    create_per_process_dataloader,
+    distributed_wrapper,
+    executors_map,
+    init_per_process_distributed,
+    new_gelu,
+    run_test_no_sync_grad_accumulation,
+)
 
 
 @unittest.skipUnless(
@@ -233,8 +231,8 @@ class FSDPTest(DistributedParallelTestCase):
                 self.assertEqual(tuple(p.grad for p in cm.parameters() if p.grad is not None), gradients)
 
                 # Make sure that at least one of "pack" takes multiple tensors.
-                from thunder.executors.torchex import pack_for_fsdp_prim_impl
                 from thunder.distributed.prims import PrimIDs as DistPrimIDs
+                from thunder.executors.torchex import pack_for_fsdp_prim_impl
 
                 for ex_trace in (thunder.last_traces(cm)[-1], thunder.last_backward_traces(cm)[-1]):
                     pack_bsyms = list(
@@ -275,8 +273,7 @@ class FSDPTest(DistributedParallelTestCase):
     ):
         from thunder.core.prims import PrimIDs
         from thunder.core.transforms import unwrap_one_level_of_subsymbols
-        from thunder.executors.torchex import pad_prim_impl
-        from thunder.executors.torchex import slice_prim_impl
+        from thunder.executors.torchex import pad_prim_impl, slice_prim_impl
 
         class M(nn.Module):
             def __init__(self):
@@ -577,7 +574,7 @@ class FSDPTest(DistributedParallelTestCase):
 
     @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Requires 2 devices")
     def test_fsdpv2_with_1layer_llama_meta_init(self):
-        from thunder.tests.litgpt_model import Config, GPT
+        from thunder.tests.litgpt_model import GPT, Config
 
         device = torch.device("cuda", self.rank)
         config = Config("Llama-2-7b-hf")
@@ -609,7 +606,7 @@ class FSDPTest(DistributedParallelTestCase):
 
     @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Requires 2 devices")
     def test_fsdpv2_no_grad(self):
-        from thunder.tests.litgpt_model import Config, GPT
+        from thunder.tests.litgpt_model import GPT, Config
 
         device = torch.device("cuda", self.rank)
         config = Config("Llama-2-7b-hf")
@@ -654,11 +651,12 @@ class FSDPDDPHybridTest(DistributedParallelTestCase):
     @pytest.mark.skipif(torch.cuda.device_count() < 4, reason="Requires 4 devices")
     def test_fsdp_ddp_hybrid(self):
         import torch
-        import thunder
         import torch.distributed
         from torch.testing import assert_close
-        from thunder.distributed.transforms.fsdp_v2 import FSDPTransform
+
+        import thunder
         from thunder.distributed.transforms.ddp_v2 import DDPTransform
+        from thunder.distributed.transforms.fsdp_v2 import FSDPTransform
 
         torch.manual_seed(1337)
 
@@ -691,10 +689,11 @@ class FSDPDDPHybridTest(DistributedParallelTestCase):
     @pytest.mark.skipif(torch.cuda.device_count() < 4, reason="Requires 4 devices")
     def test_fsdp_ddp_plugin(self):
         import torch
-        import thunder
         import torch.distributed
-        from thunder.plugins import FSDP
         from torch.testing import assert_close
+
+        import thunder
+        from thunder.plugins import FSDP
 
         torch.manual_seed(1337)
 
@@ -954,7 +953,7 @@ def _test_fsdp_transformer_engine(input_data):
 
 def _test_fsdp_transformer_engine_bucketing(input_data):
     # Test Description: Test is to that TE works with bucketing.
-    from thunder.tests.llama2_model import Transformer, ModelArgs
+    from thunder.tests.llama2_model import ModelArgs, Transformer
 
     init_method, world_size, rank, executor, device, _unused_dtype, kwargs = input_data
     thunder_fsdp_strategy, bucketing = kwargs["thunder_fsdp_strategy_and_bucketing"]

--- a/thunder/tests/distributed/test_ops.py
+++ b/thunder/tests/distributed/test_ops.py
@@ -1,21 +1,20 @@
-from itertools import product
 import re
 import unittest
+from itertools import product
 
 import pytest
 import torch
 
 if not torch.distributed.is_available():
     pytest.skip(allow_module_level=True)
-from torch.testing import make_tensor
 from torch.distributed import distributed_c10d as c10d
+from torch.testing import make_tensor
+from torch.testing._internal import common_utils
 
 import thunder
-from thunder.distributed import prims
 import thunder.torch as ltorch
-
+from thunder.distributed import prims
 from thunder.tests.distributed.helper import DistributedParallelTestCase, executors_map
-from torch.testing._internal import common_utils
 
 
 @unittest.skipUnless(

--- a/thunder/tests/distributed/test_tensor_parallel.py
+++ b/thunder/tests/distributed/test_tensor_parallel.py
@@ -7,13 +7,13 @@ import torch.nn as nn
 if not torch.distributed.is_available():
     pytest.skip(allow_module_level=True)
 
-import thunder
-from thunder.distributed import column_parallel, row_parallel
-import thunder.executors
-from thunder.tests.distributed.helper import ToyModel, DistributedParallelTestCase
-from thunder.tests.distributed.modules import ParallelMLP
-
 from torch.testing._internal import common_utils
+
+import thunder
+import thunder.executors
+from thunder.distributed import column_parallel, row_parallel
+from thunder.tests.distributed.helper import DistributedParallelTestCase, ToyModel
+from thunder.tests.distributed.modules import ParallelMLP
 
 _COL = "column"
 _ROW = "row"
@@ -263,10 +263,9 @@ class TensorParallelTest(DistributedParallelTestCase):
 
     @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="")
     def test_litgpt_causal_self_attention(self):
-        from thunder.tests.litgpt_model import Config
-        from thunder.tests.litgpt_model import CausalSelfAttention
-        from thunder.tests.make_tensor import make_tensor
         from thunder.distributed.prims import PrimIDs
+        from thunder.tests.litgpt_model import CausalSelfAttention, Config
+        from thunder.tests.make_tensor import make_tensor
 
         device = torch.device(f"cuda:{self.rank}")
         dtype = torch.bfloat16

--- a/thunder/tests/framework.py
+++ b/thunder/tests/framework.py
@@ -1,32 +1,29 @@
+import contextlib
 import inspect
 import os
-import sys
 import platform
-from functools import wraps, singledispatchmethod, partial
+import sys
+from collections.abc import Callable, Iterable, Sequence
+from functools import partial, singledispatchmethod, wraps
 from itertools import product
-from collections.abc import Callable, Sequence, Iterable
-import packaging.version
-import contextlib
 
+import packaging.version
 import pytest
 import torch
+from lightning_utilities.core.imports import package_available
 from torch._dynamo import is_inductor_supported
 from torch.testing import assert_close
 
-from lightning_utilities.core.imports import package_available
-
-from thunder.core.pytree import tree_flatten, tree_map
-import thunder.core.dtypes as datatypes
+import thunder
 import thunder.core.devices as devices
-import thunder.executors as executors
-import thunder.extend as extend
-import thunder.executors.triton_utils as triton_utils
+import thunder.core.dtypes as datatypes
 import thunder.core.utils as utils
-
+import thunder.executors as executors
+import thunder.executors.triton_utils as triton_utils
+import thunder.extend as extend
+from thunder.core.pytree import tree_flatten, tree_map
 from thunder.core.trace import TraceCtx, detached_trace
 from thunder.dynamo import thunderfx
-
-import thunder
 
 __all__ = [
     "TestExecutor",

--- a/thunder/tests/llama2_model.py
+++ b/thunder/tests/llama2_model.py
@@ -1,5 +1,5 @@
-import math
 import inspect
+import math
 from dataclasses import dataclass
 
 import torch

--- a/thunder/tests/make_tensor.py
+++ b/thunder/tests/make_tensor.py
@@ -1,4 +1,5 @@
 import torch
+
 import thunder
 
 

--- a/thunder/tests/nanogpt_model.py
+++ b/thunder/tests/nanogpt_model.py
@@ -32,8 +32,8 @@ https://github.com/huggingface/transformers/blob/main/src/transformers/models/gp
 
 import inspect
 import math
-from dataclasses import dataclass
 from collections.abc import Sequence
+from dataclasses import dataclass
 
 import torch
 import torch.nn as nn

--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -1,15 +1,15 @@
+import itertools
+import math
+import operator
+import random
 from collections import namedtuple
 from collections.abc import Callable, Generator, Iterable, Sequence
 from functools import partial, wraps
-import itertools
-import math
 from numbers import Number
-import operator
 from typing import Any
 
 import numpy as np
 import pytest
-import random
 
 # TODO: make this import conditional on Torch being available and querying if should test with torch
 import torch
@@ -19,15 +19,15 @@ from torch.testing import assert_close
 import thunder.clang as clang
 import thunder.core.devices as devices
 import thunder.core.dtypes as datatypes
-from thunder.core.dtypes import to_dtype, to_torch_dtype
 import thunder.core.prims as prims
-from thunder.core.pytree import tree_map
-from thunder.core.symbol import Symbol
 import thunder.executors as executors
-from thunder.tests.framework import _all_devicetypes, JAX_AVAILABLE, custom_comparator, IS_WINDOWS
-from thunder.tests.make_tensor import make_tensor, make_tensor_like
 import thunder.tests.bf16
 import thunder.torch as ltorch
+from thunder.core.dtypes import to_dtype, to_torch_dtype
+from thunder.core.pytree import tree_map
+from thunder.core.symbol import Symbol
+from thunder.tests.framework import IS_WINDOWS, JAX_AVAILABLE, _all_devicetypes, custom_comparator
+from thunder.tests.make_tensor import make_tensor, make_tensor_like
 
 #
 # Helpful constants and utility functions

--- a/thunder/tests/test_apex_cross_entropy_executor.py
+++ b/thunder/tests/test_apex_cross_entropy_executor.py
@@ -5,9 +5,9 @@ import torch
 from torch.testing import assert_close
 
 import thunder
-from thunder.tests.framework import requiresCUDA, run_snippet, IN_CI, assert_closer
-from thunder.tests.opinfos import get_opinfo
 from thunder.core.transforms import grad
+from thunder.tests.framework import IN_CI, assert_closer, requiresCUDA, run_snippet
+from thunder.tests.opinfos import get_opinfo
 
 xentropy_cuda = pytest.importorskip("xentropy_cuda")
 from thunder.executors.apexex import apex_ex
@@ -91,9 +91,9 @@ def test_apex_torch_consistency(device: str, dtype: torch.dtype):
 @pytest.mark.parametrize("device,", ["cuda"])
 @requiresCUDA
 def test_apex_cross_entropy_backward(device, dtype):
-    from thunder.core.transforms import value_and_grad
     from thunder.common import CompileData
     from thunder.core.compile_data import compile_data_and_stats
+    from thunder.core.transforms import value_and_grad
 
     logits = torch.randn([2048, 50257], device=device, dtype=thunder.torch.to_torch_dtype(dtype), requires_grad=True)
     labels = torch.randint(0, 50257, [2048], device=device)

--- a/thunder/tests/test_apex_fused_norms.py
+++ b/thunder/tests/test_apex_fused_norms.py
@@ -5,8 +5,9 @@ from torch.testing import assert_close
 fused_layer_norm_cuda = pytest.importorskip("fused_layer_norm_cuda")
 
 from torch.distributed import is_available
-from thunder.executors.apexex import apex_ex
+
 import thunder
+from thunder.executors.apexex import apex_ex
 
 
 # See https://github.com/NVIDIA/apex/issues/1853

--- a/thunder/tests/test_auto_register_torchops.py
+++ b/thunder/tests/test_auto_register_torchops.py
@@ -1,19 +1,19 @@
 from functools import partial
-from unittest.mock import patch
 from itertools import islice
+from unittest.mock import patch
 
 import pytest
+import torch
+from torch.testing._internal.common_device_type import skipCPUIfNoLapack, skipCUDAIfNoMagma
+from torch.testing._internal.common_methods_invocations import op_db
+
 import thunder
 import thunder.torch.default_torch_ops as ops
-from thunder.torch import _get_torch_function_name
-import torch
-
-from thunder.tests.framework import requiresCUDA, TorchExecutor, instantiate, NOTHING
+from thunder.tests.framework import NOTHING, TorchExecutor, instantiate, requiresCUDA
 from thunder.tests.make_tensor import make_tensor
 from thunder.tests.opinfos import get_opinfo
 from thunder.tests.test_einops import skipIfNoCUDA
-from torch.testing._internal.common_device_type import skipCPUIfNoLapack, skipCUDAIfNoMagma
-from torch.testing._internal.common_methods_invocations import op_db
+from thunder.torch import _get_torch_function_name
 
 _name2func = {}
 for m, fns in ops.torch_auto_registered_ops.items():

--- a/thunder/tests/test_autocast.py
+++ b/thunder/tests/test_autocast.py
@@ -8,7 +8,7 @@ import thunder
 import thunder.tests.bf16
 import thunder.torch as ltorch
 from thunder.core import dtypes
-from thunder.tests.framework import instantiate, TorchExecutor, requiresCUDA
+from thunder.tests.framework import TorchExecutor, instantiate, requiresCUDA
 
 
 # TODO This test currently ignores the "should_autocast" argument enumerated in it
@@ -68,8 +68,8 @@ def test_thunder_autocast_transform(executor, device, dtype):
     dtypes=dtypes.float_math_dtypes,
 )
 def test_no_autocast(executor, device, dtype):
-    from thunder.core.symbol import Symbol
     from thunder.core.proxies import NumberProxy
+    from thunder.core.symbol import Symbol
 
     del executor
 

--- a/thunder/tests/test_check_trace.py
+++ b/thunder/tests/test_check_trace.py
@@ -1,7 +1,8 @@
+import pytest
+import torch
+
 import thunder
 from thunder.dev_utils.check_trace import check_trace
-import torch
-import pytest
 
 
 def test_missing_symbol():

--- a/thunder/tests/test_coverage_trace.py
+++ b/thunder/tests/test_coverage_trace.py
@@ -1,24 +1,24 @@
-import torch
-import traceback
-import thunder
 import os
-import pytest
+import traceback
 
+import pytest
+import torch
+
+import thunder
 
 if os.getenv("ALLOW_COVERAGE_TRACE") != "1":
     pytest.skip("Skipping test_coverage_trace.py in regular CI", allow_module_level=True)
 
 
+from test_core import run_prologue
 from transformers import (
     AutoConfig,
-    AutoTokenizer,
     AutoModel,
     AutoModelForCausalLM,
-    AutoModelForSeq2SeqLM,
     AutoModelForImageClassification,
+    AutoModelForSeq2SeqLM,
+    AutoTokenizer,
 )
-from test_core import run_prologue
-
 
 MODEL_LIST = [
     "gpt2",

--- a/thunder/tests/test_cudnn_executor.py
+++ b/thunder/tests/test_cudnn_executor.py
@@ -10,9 +10,9 @@ import thunder.core.devices as devices
 from thunder import dtypes
 from thunder.core.transforms import vjp
 from thunder.core.utils import flatten_func
-from thunder.tests.framework import ops, requiresCUDA, run_snippet, TorchExecutor
+from thunder.tests.framework import TorchExecutor, ops, requiresCUDA, run_snippet
 from thunder.tests.make_tensor import make_tensor, make_tensor_like
-from thunder.tests.opinfos import get_opinfo, OpInfo
+from thunder.tests.opinfos import OpInfo, get_opinfo
 from thunder.tests.test_grad import _make_differentiable_wrapper
 
 cudnn = pytest.importorskip("cudnn")
@@ -272,7 +272,7 @@ def test_vjp_correctness_cudnn_sdpa(dtype, may_cat_grad_qkv):
         with compile_data_and_stats(cd, None):
             initial_trace = thunder.trace()(vjp(filtered_op), filtered_args, (v,))
 
-        from thunder.executors.cudnn_sdpa import cudnn_sdpa_fwd, cudnn_sdpa_bwd
+        from thunder.executors.cudnn_sdpa import cudnn_sdpa_bwd, cudnn_sdpa_fwd
 
         # This is a workaround for the issue with python_ctx replacing symbols
         # with their "call_ctx" values which are not traceable and accept only

--- a/thunder/tests/test_einops.py
+++ b/thunder/tests/test_einops.py
@@ -6,9 +6,8 @@ import torch
 from torch.testing import assert_close
 
 import thunder
-from thunder.tests.opinfos import get_opinfo
 from thunder.tests.make_tensor import make_tensor
-
+from thunder.tests.opinfos import get_opinfo
 
 einops = pytest.importorskip("einops")
 

--- a/thunder/tests/test_elementwise.py
+++ b/thunder/tests/test_elementwise.py
@@ -1,14 +1,14 @@
-from functools import partial
 import builtins
+from functools import partial
 
 import torch
 from torch.testing import assert_close, make_tensor
 
 import thunder
 import thunder.clang as tlang
-import thunder.torch as ttorch
 import thunder.core.devices as devices
-from thunder.tests.framework import instantiate, NOTHING
+import thunder.torch as ttorch
+from thunder.tests.framework import NOTHING, instantiate
 
 
 # TODO Enable the remaining elementwise unary operations (following the pattern of abs)

--- a/thunder/tests/test_examine.py
+++ b/thunder/tests/test_examine.py
@@ -1,5 +1,6 @@
-import thunder.examine
 import torch
+
+import thunder.examine
 
 
 def test_examine_fn():

--- a/thunder/tests/test_examine_memory.py
+++ b/thunder/tests/test_examine_memory.py
@@ -1,11 +1,10 @@
 import torch
 
 import thunder
-from thunder.core.pytree import tree_map
 import thunder.torch as ltorch
+from thunder.core.pytree import tree_map
 from thunder.examine.memory_calculation import get_alloc_memory
-
-from thunder.tests.framework import requiresCUDA, TorchExecutor
+from thunder.tests.framework import TorchExecutor, requiresCUDA
 from thunder.tests.make_tensor import make_tensor
 
 

--- a/thunder/tests/test_extend.py
+++ b/thunder/tests/test_extend.py
@@ -1,23 +1,23 @@
+import re
 from numbers import Number
 
 import numpy as np
-import torch
 import pytest
-import re
+import torch
+from lightning_utilities.core.imports import package_available
 from torch.testing import assert_close
 
 import thunder
 import thunder.core.devices as devices
 from thunder.core.proxies import TensorProxy
-from thunder.core.transforms import grad, get_grad, put_grads
+from thunder.core.transforms import get_grad, grad, put_grads
 from thunder.extend import (
     OperatorExecutor,
-    register_executor,
     deregister_executor,
     get_all_executors,
+    register_executor,
     single_op_executor,
 )
-from lightning_utilities.core.imports import package_available
 
 
 def test_extend_core():
@@ -278,8 +278,9 @@ def test_validate_executors():
 
 
 def test_transient_operator_executor():
-    from thunder.extend import TemporaryExecutor
     from functools import partial
+
+    from thunder.extend import TemporaryExecutor
 
     executor = TemporaryExecutor()
     op = executor.register_operator(

--- a/thunder/tests/test_fa3_executor.py
+++ b/thunder/tests/test_fa3_executor.py
@@ -15,6 +15,7 @@ except:
     HAS_FA3 = False
 
 import math
+
 from einops import rearrange, repeat
 
 

--- a/thunder/tests/test_inplace_copy.py
+++ b/thunder/tests/test_inplace_copy.py
@@ -7,7 +7,7 @@ from torch.testing import assert_close, make_tensor
 import thunder
 import thunder.core.dtypes as datatypes
 import thunder.torch as ttorch
-from thunder.tests.framework import instantiate, nvFuserExecutor, TorchExecutor
+from thunder.tests.framework import TorchExecutor, instantiate, nvFuserExecutor
 
 
 @instantiate(dtypes=datatypes.all_dtypes - datatypes.float_8bit_dtypes)

--- a/thunder/tests/test_inplace_functionalization.py
+++ b/thunder/tests/test_inplace_functionalization.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 from collections.abc import Callable
 from functools import partial
 from typing import TYPE_CHECKING
@@ -11,17 +12,17 @@ import thunder.core.devices as devices
 from thunder.core import dtypes
 from thunder.core.prims import PrimIDs
 from thunder.tests.framework import (
+    NOTHING,
+    TorchCompileExecutor,
+    TorchExecutor,
     instantiate,
+    nvFuserExecutor,
     ops,
     requiresCUDA,
-    NOTHING,
-    TorchExecutor,
-    TorchCompileExecutor,
-    nvFuserExecutor,
 )
-from thunder.tests.opinfos import opinfos, OpInfo, make_number, SampleInput
 from thunder.tests.make_tensor import make_tensor, make_tensor_like
-from thunder.torch import _torch_to_thunder_function_map, _inplace_to_out_of_place
+from thunder.tests.opinfos import OpInfo, SampleInput, make_number, opinfos
+from thunder.torch import _inplace_to_out_of_place, _torch_to_thunder_function_map
 
 if TYPE_CHECKING:
     from thunder.core.symbol import Symbol

--- a/thunder/tests/test_interpreter.py
+++ b/thunder/tests/test_interpreter.py
@@ -1,29 +1,27 @@
-from collections.abc import Iterable, Sequence
-from contextlib import redirect_stdout
-from functools import partial, wraps
-
+import dis
 import io
 import sys
-import dis
 import weakref
-from collections.abc import Callable
+from collections.abc import Callable, Iterable, Sequence
+from contextlib import redirect_stdout
+from functools import partial, wraps
 
 import pytest
 import torch
 from torch.testing import assert_close
-from thunder.tests.framework import IS_WINDOWS
 
 import thunder
 from thunder.core.interpreter import (
-    is_jitting_with_raise,
-    is_jitting,
-    make_opaque,
-    interpret,
     InterpreterError,
-    print_interpreter_log,
-    last_interpreter_log,
+    interpret,
+    is_jitting,
+    is_jitting_with_raise,
     last_interpreted_instructions,
+    last_interpreter_log,
+    make_opaque,
+    print_interpreter_log,
 )
+from thunder.tests.framework import IS_WINDOWS
 
 #
 # Test suite for core Python interpreter functionality
@@ -1517,8 +1515,9 @@ def test_import(jit):
     assert jit(foo)() is foo()
 
     # reload is implemented using exec of the module
-    from . import litgpt_model
     import importlib
+
+    from . import litgpt_model
 
     importlib.reload(litgpt_model)
     assert hasattr(litgpt_model, "GPT")
@@ -2901,9 +2900,9 @@ def test_name_opcodes_and_print_expr(jit):
     reason="Python 3.12 code.InteractiveInterpreter().runsource does not use the displayhook as before",
 )
 def test_displayhook(jit):
-    from contextlib import redirect_stdout
-    import io
     import code
+    import io
+    from contextlib import redirect_stdout
 
     # TODO: Implement the lookaside for exec(). Under the hood, `code.InteractiveInterpreter().runsource('5;6;7')``
     # just compiles the string and calls exec(), plus a little bit of error handling.
@@ -3358,7 +3357,7 @@ def test_exception_in_list_init(jit):
 
 
 def test_nanogpt_mlp(jit):
-    from thunder.benchmarks import NanoGPTMLPBenchmark, NanoGPTConfig, _nanogpt_configs
+    from thunder.benchmarks import NanoGPTConfig, NanoGPTMLPBenchmark, _nanogpt_configs
 
     config: NanoGPTConfig = NanoGPTConfig(dropout=0)
     config.update(**_nanogpt_configs["gpt2"])
@@ -3374,7 +3373,7 @@ def test_nanogpt_mlp(jit):
 
 
 def test_nanogpt_csa(jit):
-    from thunder.benchmarks import NanoGPTCSABenchmark, NanoGPTConfig, _nanogpt_configs
+    from thunder.benchmarks import NanoGPTConfig, NanoGPTCSABenchmark, _nanogpt_configs
 
     config: NanoGPTConfig = NanoGPTConfig(dropout=0)
     config.update(**_nanogpt_configs["gpt2"])

--- a/thunder/tests/test_jit_general.py
+++ b/thunder/tests/test_jit_general.py
@@ -1,24 +1,20 @@
-from functools import partial
-from contextlib import nullcontext
-
 import operator
 import sys
+from contextlib import nullcontext
+from functools import partial
 
 import pytest
 import torch
+from lightning_utilities import compare_version
 from torch.testing import assert_close
 
-from lightning_utilities import compare_version
-
 import thunder
-
-from thunder.tests.framework import requiresCUDA, IS_WINDOWS
-from thunder.core.options import CACHE_OPTIONS
 import thunder.core.prims as prims
-from thunder import pytorch_executor, nvfuser_executor
-from thunder.executors.sdpaex import sdpa_ex
+from thunder import nvfuser_executor, pytorch_executor
+from thunder.core.options import CACHE_OPTIONS
 from thunder.core.transforms import Transform
-
+from thunder.executors.sdpaex import sdpa_ex
+from thunder.tests.framework import IS_WINDOWS, requiresCUDA
 
 thunder_jit = partial(thunder.jit, debug_options=thunder.DebugOptions(check_traces=2))
 
@@ -668,8 +664,9 @@ def test_nanogpt():
     ("cpu", "cuda", "meta"),
 )
 def test_litgpt_variants(name, device):
-    from thunder.tests.litgpt_model import Config
     from litgpt.model import GPT
+
+    from thunder.tests.litgpt_model import Config
 
     if device == "cuda" and not torch.cuda.is_available():
         pytest.skip("CUDA not available")
@@ -724,9 +721,10 @@ def test_litgpt_variants(name, device):
     ("cpu", "cuda"),
 )
 def test_litgpt_variants_kvcache(name, device):
-    from thunder.tests.litgpt_model import Config
-    from litgpt.model import GPT
     import torch._dynamo  # this monkeypatches torch.manual_seed
+    from litgpt.model import GPT
+
+    from thunder.tests.litgpt_model import Config
 
     if device == "cuda" and not torch.cuda.is_available():
         pytest.skip("CUDA not available")
@@ -776,8 +774,9 @@ def test_litgpt_variants_kvcache(name, device):
     ("cpu", "cuda"),
 )
 def test_tom_overrides_proxy(device):
-    from thunder.tests.litgpt_model import Config
     from litgpt.model import GPT
+
+    from thunder.tests.litgpt_model import Config
 
     if device == "cuda" and not torch.cuda.is_available():
         pytest.skip("CUDA not available")

--- a/thunder/tests/test_nvfuser.py
+++ b/thunder/tests/test_nvfuser.py
@@ -1,43 +1,41 @@
 import pytest
-
 import torch
+from looseversion import LooseVersion
 
 import thunder
-import thunder.examine as examine
-from thunder.executors.nvfuserex import nvfuser_version, nvfuserex
-import thunder.torch as ltorch
-import thunder.core.dtypes as dtypes
 import thunder.core.devices as devices
+import thunder.core.dtypes as dtypes
 import thunder.core.prims as prims
+import thunder.examine as examine
+import thunder.torch as ltorch
 from thunder.core.pytree import tree_map
 from thunder.core.transforms import value_and_grad
-
+from thunder.executors.nvfuserex import nvfuser_version, nvfuserex
 from thunder.tests.framework import (
-    instantiate,
-    TestExecutor,
     NOTHING,
+    TestExecutor,
+    instantiate,
     nvFuserExecutor,
 )
 from thunder.tests.make_tensor import make_tensor
 from thunder.tests.opinfos import (
+    embedding_opinfo,
     linear_opinfo,
     matmul_opinfo,
-    embedding_opinfo,
 )
-from looseversion import LooseVersion
 
 
 @instantiate(
     dtypes=NOTHING,
 )
 def test_rematerialization_with_forward_and_backward_from_trace(executor: TestExecutor, device: str, _) -> None:
+    import thunder.torch as ltorch
     from thunder import trace
     from thunder.clang import cos, sin
-    import thunder.torch as ltorch
-    from thunder.core.transforms import forward_and_backward_from_trace
-    from thunder.core.transform_common import wrap_return_value_together_with_arguments
     from thunder.common import transform_for_execution
     from thunder.core.rematerialization import rematerialize_forward_and_backward
+    from thunder.core.transform_common import wrap_return_value_together_with_arguments
+    from thunder.core.transforms import forward_and_backward_from_trace
 
     def func(a, b, *, c):
         d = a + b + c
@@ -303,7 +301,7 @@ def test_cse_subsymbol_redundant_args(executor, device, _):
 @instantiate(dtypes=NOTHING, devicetypes=(devices.DeviceType.CUDA,), executors=(nvFuserExecutor,))
 def test_cse_rematerialization(executor, device, _):
     # Unit test for "llama2.c example failed with bookend disabled."
-    from thunder.tests.llama2_model import Transformer, ModelArgs
+    from thunder.tests.llama2_model import ModelArgs, Transformer
 
     batch_size = 2
     max_seq_len = 32

--- a/thunder/tests/test_nvfuser_remat.py
+++ b/thunder/tests/test_nvfuser_remat.py
@@ -1,13 +1,12 @@
-import pytest
 from functools import partial, wraps
 
+import pytest
 import torch
 
 import thunder
 import thunder.examine
 from thunder import torch as ttorch
-
-from thunder.core import utils, devices
+from thunder.core import devices, prims, utils
 from thunder.core.rematerialization import (
     apply_rematerialization_for_consumer,
     apply_rematerialization_for_producer,
@@ -16,11 +15,10 @@ from thunder.core.rematerialization import (
     find_filtered_producer_consumer_pairs,
     find_nvfuser_producer_consumer_pairs,
 )
-from thunder.core import prims
-from thunder.core.transforms import value_and_grad
 from thunder.core.trace import TraceCtx
+from thunder.core.transforms import value_and_grad
 from thunder.examine import get_fusions
-from thunder.tests.framework import instantiate, NOTHING, nvFuserExecutor, TorchExecutor, requiresCUDA
+from thunder.tests.framework import NOTHING, TorchExecutor, instantiate, nvFuserExecutor, requiresCUDA
 from thunder.tests.make_tensor import make_tensor
 
 
@@ -409,7 +407,7 @@ def test_find_cut(executor, device, _):
 )
 def test_find_cut_dropout(executor, device, _):
     t0 = make_tensor(2, 2, dtype=torch.float32, device=device)
-    from unittest.mock import patch, MagicMock
+    from unittest.mock import MagicMock, patch
 
     # mock the replace_uniform transform to return the input trace
     replace_uniform_mock = MagicMock(side_effect=lambda trc: trc)

--- a/thunder/tests/test_ops.py
+++ b/thunder/tests/test_ops.py
@@ -1,5 +1,5 @@
-from collections.abc import Callable
 import os
+from collections.abc import Callable
 
 import numpy as np
 import pytest
@@ -9,10 +9,10 @@ from torch.testing import assert_close
 import thunder
 import thunder.core.devices as devices
 import thunder.core.dtypes as dtypes
-from thunder.core.pytree import tree_flatten, tree_map
-from thunder.tests.framework import assert_closer, ops, run_snippet, requiresJAX, requiresCUDA
-from thunder.tests.opinfos import OpInfo, SampleInput, opinfos
 import thunder.tests.bf16
+from thunder.core.pytree import tree_flatten, tree_map
+from thunder.tests.framework import assert_closer, ops, requiresCUDA, requiresJAX, run_snippet
+from thunder.tests.opinfos import OpInfo, SampleInput, opinfos
 
 #
 # Generic test templates for all operators

--- a/thunder/tests/test_randomness.py
+++ b/thunder/tests/test_randomness.py
@@ -6,7 +6,7 @@ from torch.testing import assert_close
 import thunder
 import thunder.torch as ltorch
 from thunder.core import devices, dtypes
-from thunder.tests.framework import TorchExecutor, nvFuserExecutor, instantiate, NOTHING
+from thunder.tests.framework import NOTHING, TorchExecutor, instantiate, nvFuserExecutor
 
 
 @instantiate(
@@ -30,8 +30,9 @@ def test_uniform_philox(executor, device: str, dtype: dtypes.dtype):
 
 @instantiate(dtypes=NOTHING, devicetypes=(devices.DeviceType.CUDA,), executors=(nvFuserExecutor,))
 def test_rng_state_prims(executor, device: str, _):
-    import thunder.core.prims as prims
     import torch
+
+    import thunder.core.prims as prims
 
     def func(device):
         s0, o0 = prims.get_and_update_rng_state(None, None, device=device)
@@ -58,8 +59,9 @@ def test_rng_state_prims(executor, device: str, _):
     executors=(nvFuserExecutor,),
 )
 def test_uniform_philox_with_rng_state_prims(executor, device: str, dtype: dtypes.dtype):
-    import thunder.core.prims as prims
     import torch
+
+    import thunder.core.prims as prims
 
     def func1(shape, dtype, device):
         seed0, offset0 = prims.get_and_update_rng_state(None, None, device=device)
@@ -179,7 +181,7 @@ def test_uniform_philox_vs_uniform(executor, device: str, dtype: dtypes.dtype):
         # get the results of uniform
         results = []
         cuda_generator.manual_seed(20)
-        from unittest.mock import patch, MagicMock
+        from unittest.mock import MagicMock, patch
 
         # mock the replace_uniform transform to return the input trace
         replace_uniform_mock = MagicMock(side_effect=lambda trc: trc)
@@ -286,7 +288,7 @@ def test_uniform_philox_vs_uniform_module(executor, device: str, dtype: dtypes.d
             # get the results of uniform
             results = []
             cuda_generator.manual_seed(20)
-            from unittest.mock import patch, MagicMock
+            from unittest.mock import MagicMock, patch
 
             # mock the replace_uniform transform to return the input trace
             replace_uniform_mock = MagicMock(side_effect=lambda trc: trc)

--- a/thunder/tests/test_recipes.py
+++ b/thunder/tests/test_recipes.py
@@ -1,18 +1,18 @@
 from unittest.mock import patch
 
 import pytest
-import thunder
-import transformers
 import torch
-
-from transformers.models.qwen2 import Qwen2Config, Qwen2ForCausalLM
-from transformers.models.llama import LlamaConfig, LlamaForCausalLM
-from thunder.extend import deregister_executor
+import transformers
 from torch.testing import assert_close
-from thunder.recipes import HFTransformers
+from transformers.models.llama import LlamaConfig, LlamaForCausalLM
+from transformers.models.qwen2 import Qwen2Config, Qwen2ForCausalLM
+
+import thunder
 from thunder.executors import nvfuser_available
 from thunder.executors.cudnnex import cudnn_available
-from thunder.tests.framework import version_between, IS_WINDOWS
+from thunder.extend import deregister_executor
+from thunder.recipes import HFTransformers
+from thunder.tests.framework import IS_WINDOWS, version_between
 
 
 @pytest.mark.skipif(not cudnn_available(), reason="cuDNN is not available")
@@ -264,8 +264,9 @@ def test_plugins_hybrid_ddpfsdp(monkeypatch):
     monkeypatch.setenv("LOCAL_RANK", "0")
     if not torch.distributed.is_initialized():
         torch.distributed.init_process_group(backend="gloo", rank=0, world_size=1, init_method="tcp://127.0.0.1:1234")
-    from thunder.plugins import FSDP
     from torch.distributed.device_mesh import init_device_mesh
+
+    from thunder.plugins import FSDP
 
     mesh = init_device_mesh("cpu", (1,), mesh_dim_names=("fsdp",))  # single-dim mesh
 

--- a/thunder/tests/test_reductions.py
+++ b/thunder/tests/test_reductions.py
@@ -5,7 +5,6 @@ import thunder
 import thunder.torch as ttorch
 from thunder.tests.framework import instantiate
 
-
 # TODO: convert these tests to OpInfo generated tests
 
 

--- a/thunder/tests/test_sdpaex_executor.py
+++ b/thunder/tests/test_sdpaex_executor.py
@@ -1,3 +1,5 @@
+from collections import namedtuple
+
 import pytest
 import torch
 
@@ -6,7 +8,6 @@ import thunder.core
 from thunder.executors.sdpaex import sdpa_ex
 from thunder.tests.framework import requiresCUDA, run_snippet
 from thunder.tests.opinfos import get_opinfo
-from collections import namedtuple
 
 CudaVersion = namedtuple("CudaVersion", "major minor")
 

--- a/thunder/tests/test_shape_ops.py
+++ b/thunder/tests/test_shape_ops.py
@@ -1,5 +1,6 @@
-import thunder
 import torch
+
+import thunder
 from thunder.tests.framework import JAX_AVAILABLE
 
 if JAX_AVAILABLE:

--- a/thunder/tests/test_torch_compile_executor.py
+++ b/thunder/tests/test_torch_compile_executor.py
@@ -1,20 +1,21 @@
 import platform
+
 import pytest
 import torch
 from torch._dynamo import is_inductor_supported
+from torch.testing import assert_close
 
 import thunder
+from thunder.executors.nvfuserex import nvfuserex
 from thunder.executors.torch_compile import (
     supported_ops,
-    torch_compile_ex,
     torch_compile_cat_ex,
+    torch_compile_ex,
     torch_compile_xentropy_ex,
 )
 from thunder.executors.torchex import ex as pytorch_ex
-from thunder.executors.nvfuserex import nvfuserex
 from thunder.tests.bf16 import device_supports_bf16
 from thunder.tests.framework import requiresCUDA
-from torch.testing import assert_close
 
 
 def test_supported_ops_are_in_pytorch_executor():
@@ -47,8 +48,9 @@ def test_torch_compile_litgpt():
 @requiresCUDA
 @pytest.mark.skipif(not device_supports_bf16(torch.device("cuda")), reason="bf16 is not supported")
 def test_torch_compile_cat_nvfuser_phi2_tanh():
-    from thunder.tests.litgpt_model import Config
     from litgpt.model import GPT
+
+    from thunder.tests.litgpt_model import Config
 
     device = torch.device("cuda")
     config = Config.from_name("phi-2", n_layer=1, gelu_approximate="tanh")
@@ -101,10 +103,11 @@ def test_transform_for_execution_for_callable():
 @requiresCUDA
 @pytest.mark.skipif(not device_supports_bf16(torch.device("cuda")), reason="bf16 is not supported")
 def test_litgpt_fabric_for_callable():
-    from typing import Any
     from collections.abc import Callable
-    from litgpt.model import Config, GPT
+    from typing import Any
+
     import torch.nn as nn
+    from litgpt.model import GPT, Config
 
     def jit(fn: Callable, executors: list[str]) -> Any:
         assert executors is not None

--- a/thunder/tests/test_transformer_engine_executor.py
+++ b/thunder/tests/test_transformer_engine_executor.py
@@ -6,9 +6,10 @@ import thunder
 from thunder.tests.framework import requiresCUDA
 
 pytest.importorskip("transformer_engine", reason="transformer_engine was not found, skipping the tests.")
-from thunder.executors.transformer_engineex import transformer_engine_ex
-from transformer_engine.common import recipe
 import transformer_engine.pytorch as te
+from transformer_engine.common import recipe
+
+from thunder.executors.transformer_engineex import transformer_engine_ex
 
 # FP8 is supported on compute arch 8.9 onwards.
 # MXFP8 is supported on compute arch 10.0 onwards.

--- a/thunder/tests/test_transformer_engine_v2_executor.py
+++ b/thunder/tests/test_transformer_engine_v2_executor.py
@@ -9,9 +9,10 @@ transformer_engine_module = pytest.importorskip(
     "transformer_engine", reason="transformer_engine was not found, skipping the tests."
 )
 
-from thunder.executors.transformer_engine_v2ex import transformer_engine_v2_ex, TransformerEngineTransformV2
-from transformer_engine.common import recipe
 import transformer_engine.pytorch as te
+from transformer_engine.common import recipe
+
+from thunder.executors.transformer_engine_v2ex import TransformerEngineTransformV2, transformer_engine_v2_ex
 
 # FP8 is supported on compute arch 8.9 onwards.
 # MXFP8 is supported on compute arch 10.0 onwards.

--- a/thunder/tests/test_transforms.py
+++ b/thunder/tests/test_transforms.py
@@ -1,10 +1,10 @@
+import pytest
 import torch
 from torch.testing import assert_close
-import pytest
 
 import thunder
-from thunder.dev_utils.nvtx_profile_transform import NvtxProfileTransform, nvtx_push, nvtx_pop
-from thunder.tests.framework import requiresCUDA, BITSANDBYTES_AVAILABLE
+from thunder.dev_utils.nvtx_profile_transform import NvtxProfileTransform, nvtx_pop, nvtx_push
+from thunder.tests.framework import BITSANDBYTES_AVAILABLE, requiresCUDA
 
 
 class MiniModel(torch.nn.Module):
@@ -73,10 +73,10 @@ def test_nvtx_transform():
 
 @requiresCUDA
 def test_materialization():
-    from thunder.transforms import MaterializationTransform
-    from thunder.tests.litgpt_model import Config
-
     from litgpt.model import GPT
+
+    from thunder.tests.litgpt_model import Config
+    from thunder.transforms import MaterializationTransform
 
     config = Config.from_name("llama2-like")
     with torch.device("cuda"):
@@ -116,10 +116,11 @@ def test_materialization():
 @pytest.mark.skipif(not BITSANDBYTES_AVAILABLE, reason="`bitsandbytes` is not available")
 @requiresCUDA
 def test_quantization_on_meta():
+    from litgpt.model import GPT
+
+    from thunder.tests.litgpt_model import Config
     from thunder.transforms import MaterializationTransform
     from thunder.transforms.quantization import BitsAndBytesLinearQuant4bit, get_bitsandbytes_executor
-    from thunder.tests.litgpt_model import Config
-    from litgpt.model import GPT
 
     bitsandbytes_executor = get_bitsandbytes_executor()
 
@@ -201,8 +202,8 @@ def test_nvfuser_cse():
         )
         inp = torch.randn(1, 512)
 
-    from thunder.transforms.quantization import BitsAndBytesLinearQuant4bit, get_bitsandbytes_executor
     from thunder.executors.nvfuserex import nvfuserex
+    from thunder.transforms.quantization import BitsAndBytesLinearQuant4bit, get_bitsandbytes_executor
 
     bitsandbytes_executor = get_bitsandbytes_executor()
 
@@ -523,11 +524,13 @@ def test_cudagraph_empty_inputs():
 
 @requiresCUDA
 def test_cudagraph_fw_bw():
-    import torch
-    import thunder
-    import litgpt
-    from torch.testing import make_tensor
     from functools import partial
+
+    import litgpt
+    import torch
+    from torch.testing import make_tensor
+
+    import thunder
     from thunder.transforms.cudagraph import CUDAGraphTransform
 
     device = torch.device("cuda")
@@ -566,8 +569,9 @@ def test_cudagraph_fw_bw():
 
 
 def test_disable_params_and_buffer_check():
-    from thunder.tests.litgpt_model import Config
     from litgpt.model import GPT
+
+    from thunder.tests.litgpt_model import Config
     from thunder.transforms.extraction_only_prologue_transform import ExtractionOnlyPrologueTransform
 
     model = GPT(Config.from_name("llama1-like", n_layer=1))
@@ -626,8 +630,9 @@ def test_disable_params_check_thunderfx():
 
 
 def test_buffer_dtype_casting():
-    import torch.nn as nn
     import itertools
+
+    import torch.nn as nn
 
     class CastBuffers(thunder.core.transform_common.Transform):
         def __init__(self):

--- a/thunder/tests/test_triton_ce.py
+++ b/thunder/tests/test_triton_ce.py
@@ -1,20 +1,15 @@
-from typing import Any
 from numbers import Number
+from typing import Any
 
 import pytest
-
 import torch
+from lightning_utilities.core.imports import package_available
 from torch.testing import assert_close
 
 import thunder
-
-
-from thunder.tests.opinfos import get_opinfo
-from thunder.tests.framework import requiresCUDA, requiresTriton, run_snippet, IN_CI
 from thunder.executors import triton_utils
-
-
-from lightning_utilities.core.imports import package_available
+from thunder.tests.framework import IN_CI, requiresCUDA, requiresTriton, run_snippet
+from thunder.tests.opinfos import get_opinfo
 
 TRITON_AVAILABLE = package_available("triton")
 

--- a/thunder/tests/test_update_aliases.py
+++ b/thunder/tests/test_update_aliases.py
@@ -2,10 +2,10 @@ import pytest
 import torch.testing
 
 import thunder
-from thunder.examine import get_fusions
 import thunder.core.dtypes as dtypes
+from thunder.examine import get_fusions
+from thunder.tests.framework import NOTHING, TorchCompileExecutor, TorchExecutor, instantiate, nvFuserExecutor, ops
 from thunder.tests.make_tensor import make_tensor, make_tensor_like
-from thunder.tests.framework import instantiate, ops, NOTHING, TorchExecutor, TorchCompileExecutor, nvFuserExecutor
 from thunder.tests.test_inplace_functionalization import _inplace_opinfos
 
 

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -1,65 +1,65 @@
 from __future__ import annotations
+
 import builtins
+import collections
 import itertools
 import math
 import operator
-import collections
 import re
 import sys
-from collections.abc import Callable
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from enum import Enum
 from functools import partial, reduce, wraps
 from numbers import Number
-from types import NoneType, ModuleType
+from types import ModuleType, NoneType
 from typing import Any, overload
 
 import opt_einsum
 
-# Initializes the language context
-from thunder.torch.langctx import register_method, register_property
-from thunder.core.baseutils import run_once
+import thunder
 import thunder.clang as clang
 import thunder.core.devices as devices
-from thunder.core.devices import to_device
 import thunder.core.dtypes as dtypes
-from thunder.core.dtypes import to_torch_dtype, to_dtype, _torch_to_thunder_dtype_map
 import thunder.core.prims as prims
 import thunder.core.utils as utils
 import thunder.distributed.prims as dist_prims
-from thunder.core.langctxs import langctx, Languages, get_langctx
+from thunder.core.baseutils import run_once
 from thunder.core.compile_data import get_compile_data
-from thunder.core.proxies import (
-    FloatProxy,
-    IntegerProxy,
-    NumberProxy,
-    NumberLike,
-    TensorProxy,
-    FutureTensorProxy,
-    pyval,
-    TupleProxy,
-    ListProxy,
-    DictProxy,
-    numberproxy,
-    ProxyTag,
-)
-from thunder.core.pytree import tree_map, tree_flatten, tree_unflatten
-from thunder.core.symbol import Symbol
-from thunder.core.transforms import register_grad, register_augmented_forward, register_backward
+from thunder.core.devices import to_device
+from thunder.core.dtypes import _torch_to_thunder_dtype_map, to_dtype, to_torch_dtype
+from thunder.core.langctxs import Languages, get_langctx, langctx
 from thunder.core.prims import get_grad, put_grad
-import thunder
+from thunder.core.proxies import (
+    DictProxy,
+    FloatProxy,
+    FutureTensorProxy,
+    IntegerProxy,
+    ListProxy,
+    NumberLike,
+    NumberProxy,
+    ProxyTag,
+    TensorProxy,
+    TupleProxy,
+    numberproxy,
+    pyval,
+)
+from thunder.core.pytree import tree_flatten, tree_map, tree_unflatten
+from thunder.core.symbol import Symbol
+from thunder.core.transforms import register_augmented_forward, register_backward, register_grad
 from thunder.torch.default_torch_ops import _auto_registered_operators_returning_views
 
+# Initializes the language context
+from thunder.torch.langctx import register_method, register_property
 
 __all__ = [
     "is_available",
 ]
 
 # NOTE torch is a requirement
+import warnings
+
 import torch
 import torch._higher_order_ops.wrap
-
-import warnings
 
 # Type annotation helpers
 TensorLike = TensorProxy
@@ -4942,7 +4942,7 @@ def adaptive_avg_pool2d(
     /,
     output_size: int | Sequence[int],
 ) -> TensorProxy:
-    from thunder.core.baseutils import check_valid_shape, check_valid_length
+    from thunder.core.baseutils import check_valid_length, check_valid_shape
 
     utils.check_type(output_size, (int, IntegerProxy, Sequence))
     if isinstance(output_size, Sequence):
@@ -6615,8 +6615,9 @@ def _get_fake_arg(inp: Any):
 
 
 def _fake_type_to_thunder(inp: Any):
-    from thunder.core.proxies import _cls_to_number_proxy_map
     from torch._subclasses.fake_tensor import FakeTensor
+
+    from thunder.core.proxies import _cls_to_number_proxy_map
 
     if inp is None:
         return inp

--- a/thunder/torch/experimental/dtensor_codeutils.py
+++ b/thunder/torch/experimental/dtensor_codeutils.py
@@ -1,10 +1,12 @@
 from typing import Any
+
 import torch
+
 from thunder.torch.experimental.dtensor_utils import run_only_if_distributed_is_available
 
 if torch.distributed.is_available():
-    from torch.distributed.tensor._dtensor_spec import DTensorSpec, TensorMeta
     from torch.distributed.tensor import DeviceMesh, Partial, Placement, Replicate, Shard
+    from torch.distributed.tensor._dtensor_spec import DTensorSpec, TensorMeta
 
 
 @run_only_if_distributed_is_available

--- a/thunder/torch/experimental/dtensor_proxy.py
+++ b/thunder/torch/experimental/dtensor_proxy.py
@@ -1,9 +1,9 @@
-from thunder.core.proxies import TensorProxy, AnyProxy, _infer_tensor_properties
-from thunder.core.proxies import proxy
+import torch
+
 import thunder.core.devices as devices
 import thunder.core.dtypes as dtypes
 import thunder.core.utils as utils
-import torch
+from thunder.core.proxies import AnyProxy, TensorProxy, _infer_tensor_properties, proxy
 from thunder.torch.experimental.dtensor_utils import run_only_if_distributed_is_available
 
 if torch.distributed.is_available():

--- a/thunder/torch/experimental/dtensor_torch_and_prims.py
+++ b/thunder/torch/experimental/dtensor_torch_and_prims.py
@@ -1,28 +1,25 @@
-from functools import partial
 from collections.abc import Callable
-
-from thunder.torch import torchsymbol, TensorLike, register_function
-import thunder.torch as ltorch
-from thunder.core.pytree import tree_flatten
-from thunder import clang
-from thunder.torch.experimental.dtensor_utils import run_with_fake_tensor
-from thunder.torch.experimental.dtensor_proxy import DTensorProxy, create_dtensor_proxy_from_proxies
-from thunder.torch.langctx import register_method
-
-from thunder.core.proxies import TensorProxy, AnyProxy
-from thunder.core.transforms import (
-    register_grad,
-    put_grads,
-    get_grad,
-)
-from thunder.executors.torchex import ex as pytorchex
-from thunder.executors.pythonex import ex as pythonex
-from thunder.core.prims import make_prim, OpTags
-from thunder.core import prims
-from thunder.core import baseutils
-from thunder.core import utils
+from functools import partial
 
 import torch
+
+import thunder.torch as ltorch
+from thunder import clang
+from thunder.core import baseutils, prims, utils
+from thunder.core.prims import OpTags, make_prim
+from thunder.core.proxies import AnyProxy, TensorProxy
+from thunder.core.pytree import tree_flatten
+from thunder.core.transforms import (
+    get_grad,
+    put_grads,
+    register_grad,
+)
+from thunder.executors.pythonex import ex as pythonex
+from thunder.executors.torchex import ex as pytorchex
+from thunder.torch import TensorLike, register_function, torchsymbol
+from thunder.torch.experimental.dtensor_proxy import DTensorProxy, create_dtensor_proxy_from_proxies
+from thunder.torch.experimental.dtensor_utils import run_with_fake_tensor
+from thunder.torch.langctx import register_method
 
 dtensor_torchsymbol = partial(torchsymbol, allow_tensor_subclass_proxy=True)
 

--- a/thunder/torch/experimental/dtensor_utils.py
+++ b/thunder/torch/experimental/dtensor_utils.py
@@ -1,15 +1,13 @@
 import torch
+from torch._subclasses.fake_tensor import FakeTensorMode
 
-from thunder.core.proxies import TensorProxy, NumberProxy
 from thunder.core.devices import to_torch_device
 from thunder.core.dtypes import to_torch_dtype
-from thunder.core.pytree import tree_map
-from thunder.core.trace import TraceCtx
 from thunder.core.prims import PrimIDs
+from thunder.core.proxies import NumberProxy, TensorProxy
+from thunder.core.pytree import tree_map
 from thunder.core.symbol import Symbol
-from thunder.core.trace import from_trace
-
-from torch._subclasses.fake_tensor import FakeTensorMode
+from thunder.core.trace import TraceCtx, from_trace
 
 if torch.distributed.is_available():
     from torch.distributed.tensor import DTensor

--- a/thunder/torch/langctx.py
+++ b/thunder/torch/langctx.py
@@ -1,8 +1,8 @@
 from collections.abc import Callable
 
-from thunder.core.langctxs import LanguageContext, register_langctx, Languages, resolve_language
-from thunder.core.pytree import tree_flatten
+from thunder.core.langctxs import LanguageContext, Languages, register_langctx, resolve_language
 from thunder.core.proxies import TensorProxy
+from thunder.core.pytree import tree_flatten
 
 #
 # Creates and registers the torch language context

--- a/thunder/transforms/__init__.py
+++ b/thunder/transforms/__init__.py
@@ -1,9 +1,8 @@
 from .constant_folding import ConstantFolding
-from .materialization import MaterializationTransform
-from .qlora import LORATransform
-from .prune_prologue_checks import PrunePrologueChecks
 from .extraction_only_prologue_transform import ExtractionOnlyPrologueTransform
-
+from .materialization import MaterializationTransform
+from .prune_prologue_checks import PrunePrologueChecks
+from .qlora import LORATransform
 
 __all__ = [
     "ConstantFolding",

--- a/thunder/transforms/autocast.py
+++ b/thunder/transforms/autocast.py
@@ -1,18 +1,16 @@
+from collections.abc import Callable, Sequence
 from contextlib import contextmanager
 from functools import partial, wraps
-from collections.abc import Callable
-from collections.abc import Sequence
 
-from thunder.core import dtypes, prims, devices
-from thunder.core.pytree import tree_map, tree_flatten
-from thunder.core.proxies import TensorProxy
-from thunder.core.symbol import BoundSymbolInterface, Symbol
-from thunder.core.transforms import construct_trace, eval_trace
+import thunder.torch as ltorch
 from thunder.clang import (
     maybe_convert_to_dtype,
 )
-import thunder.torch as ltorch
-
+from thunder.core import devices, dtypes, prims
+from thunder.core.proxies import TensorProxy
+from thunder.core.pytree import tree_flatten, tree_map
+from thunder.core.symbol import BoundSymbolInterface, Symbol
+from thunder.core.transforms import construct_trace, eval_trace
 
 autocast_impls: dict[prims.PrimIDs, Callable] = {}
 

--- a/thunder/transforms/autodiff.py
+++ b/thunder/transforms/autodiff.py
@@ -1,21 +1,20 @@
 import time
 
+import thunder.torch as ltorch
 from thunder.core import prims, utils
-
-from thunder.core.pytree import tree_map, tree_iter, tree_flatten_with_dataclass
-from thunder.core.proxies import TensorProxy, ProxyTag, Proxy, CollectionProxy, variableify
+from thunder.core.proxies import CollectionProxy, Proxy, ProxyTag, TensorProxy, variableify
+from thunder.core.pytree import tree_flatten_with_dataclass, tree_iter, tree_map
 from thunder.core.symbol import BoundSymbol, BoundSymbolTag
-from thunder.core.trace import TraceProvenance, tracectx, TraceCtx, from_trace, TraceTag
+from thunder.core.trace import TraceCtx, TraceProvenance, TraceTag, from_trace, tracectx
 from thunder.core.trace_interpreter import TraceSubstitutionProcessor
 from thunder.core.transforms import (
-    dce,
-    is_constant_for_vjp,
+    ForwardBackwardTraces,
     _get_gradfn_and_executor,
     augmented_forward_impls,
     backward_impls,
-    ForwardBackwardTraces,
+    dce,
+    is_constant_for_vjp,
 )
-import thunder.torch as ltorch
 
 
 def _should_recompute_bsym_in_backward(bsym):

--- a/thunder/transforms/constant_folding.py
+++ b/thunder/transforms/constant_folding.py
@@ -1,18 +1,17 @@
+from collections.abc import Callable
 from numbers import Number
 from typing import Any
-from collections.abc import Callable
 
 import torch
 
 import thunder
-from thunder.core.trace import from_trace
-from thunder.core.proxies import variableify, Variable, TensorProxy, NumberProxy
-from thunder.core.symbol import BoundSymbol
-from thunder.core.dtypes import to_dtype
 from thunder.core.devices import to_device
-from thunder.torch import _torch_to_thunder_function_map
+from thunder.core.dtypes import to_dtype
+from thunder.core.proxies import NumberProxy, TensorProxy, Variable, variableify
+from thunder.core.symbol import BoundSymbol
+from thunder.core.trace import from_trace
 from thunder.core.utils import get_symbols_to_last_used_variables
-
+from thunder.torch import _torch_to_thunder_function_map
 
 __all__ = [
     "ConstantFolding",

--- a/thunder/transforms/cudagraph.py
+++ b/thunder/transforms/cudagraph.py
@@ -5,21 +5,21 @@ from typing import Any
 
 import torch
 
-from thunder.core.transform_common import Transform
-from thunder.core import utils, prims, vjp_utils
+from thunder.core import prims, utils, vjp_utils
 from thunder.core.proxies import Proxy, ProxyTag, unvariableify
 from thunder.core.symbol import BoundSymbol, Symbol
 from thunder.core.trace import (
     TraceCtx,
-    from_trace,
     TraceProvenance,
-    get_tracectx,
-    set_tracectx,
-    reset_tracectx,
     TraceTag,
+    from_trace,
+    get_tracectx,
+    reset_tracectx,
+    set_tracectx,
 )
+from thunder.core.transform_common import Transform
+from thunder.executors.data_dependent_partition import Node, fuse_bound_symbols
 from thunder.executors.utils import Region
-from thunder.executors.data_dependent_partition import fuse_bound_symbols, Node
 
 
 @dataclass(**utils.default_dataclass_params)

--- a/thunder/transforms/extraction_only_prologue_transform.py
+++ b/thunder/transforms/extraction_only_prologue_transform.py
@@ -1,6 +1,6 @@
 import thunder
-from thunder.core.trace import from_trace
 from thunder.core.proxies import ProxyTag
+from thunder.core.trace import from_trace
 
 
 class ExtractionOnlyPrologueTransform(thunder.Transform):

--- a/thunder/transforms/materialization.py
+++ b/thunder/transforms/materialization.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
-from collections.abc import Callable
+
 import copy
+from collections.abc import Callable
 from itertools import chain
 from typing import TYPE_CHECKING
 

--- a/thunder/transforms/qlora.py
+++ b/thunder/transforms/qlora.py
@@ -1,13 +1,15 @@
-import thunder
-from thunder.core.proxies import TensorProxy
-from thunder.core.transform_common import Transform
-from thunder.core import prims
-import torch
 import math
 
+import torch
+
+import thunder
+from thunder.core import prims
+from thunder.core.proxies import TensorProxy
+from thunder.core.transform_common import Transform
+
 from .utils import (
-    get_checks,
     add_trace_output,
+    get_checks,
     trace_with_replaced_proxy_metadata,
 )
 

--- a/thunder/transforms/quantization.py
+++ b/thunder/transforms/quantization.py
@@ -1,16 +1,16 @@
 from collections.abc import Sequence
 
-import thunder
-from thunder.core.transform_common import Transform
-from thunder.core import prims
 import torch
 
+import thunder
+from thunder.core import prims
+from thunder.core.transform_common import Transform
+
 from .utils import (
-    get_checks,
     add_trace_output,
+    get_checks,
     trace_with_replaced_proxy_metadata,
 )
-
 
 bitsandbytes_executor = None
 

--- a/thunder/transforms/utils.py
+++ b/thunder/transforms/utils.py
@@ -1,8 +1,7 @@
 import thunder
-from thunder.core import utils
-from thunder.core import prims
-from thunder.core.trace import TraceCtx
+from thunder.core import prims, utils
 from thunder.core.pytree import tree_map
+from thunder.core.trace import TraceCtx
 
 
 def get_checks(prologue_trace):


### PR DESCRIPTION
## What does this PR do?

As per title, this enables `isort` via ruff.