### PR TITLE
Propagate backward tags more consistently

### DIFF
--- a/thunder/core/functionalization.py
+++ b/thunder/core/functionalization.py
@@ -6,7 +6,7 @@ from thunder.core.compile_data import get_compile_data
 import thunder.core.prims as prims
 from thunder.core.proxies import variableify, TensorProxy, unvariableify, ProxyInterface
 from thunder.core.pytree import tree_flatten, tree_unflatten
-from thunder.core.symbol import BoundSymbol
+from thunder.core.symbol import BoundSymbol, BoundSymbolTag, has_tags
 from thunder.core.trace import from_trace, TraceProvenance, TraceCtx as Trace, tracectx
 from thunder.core.utils import ProxyDict, producers, check, consumers
 
@@ -351,6 +351,8 @@ def create_functional_bsym_from(inplace_bsym: BoundSymbol) -> BoundSymbol:
         functional_bsym.subsymbols = functional_bsym.subsymbols[:-1]
     if len(functional_bsym.subsymbols) == 1 and functional_bsym.rhs == functional_bsym.subsymbols[0].rhs:
         functional_bsym.subsymbols = functional_bsym.subsymbols[0].subsymbols
+    if has_tags(inplace_bsym, {BoundSymbolTag.BACKWARD}):
+        functional_bsym.tags.add(BoundSymbolTag.BACKWARD)
     return functional_bsym
 
 

--- a/thunder/core/update_aliases.py
+++ b/thunder/core/update_aliases.py
@@ -3,6 +3,7 @@ from functools import reduce, partial
 from thunder.core.functionalization import replace_args_with_alias_map
 import thunder.core.prims as prims
 from thunder.core.proxies import TensorProxy, variableify, unvariableify
+from thunder.core.symbol import BoundSymbolTag, has_tags
 from thunder.core.trace import from_trace, tracectx, TraceCtx as Trace, TraceProvenance
 
 
@@ -104,9 +105,11 @@ def insert_alias_updates(computation_trace: Trace, alias_tensor_indices: list[li
             new_aliases = _get_new_aliases(views_encountered, computation_trace)
 
             update_bsym, swap_map = _get_update_bsym(views_encountered, swap_map, new_aliases)
+            new_bsym = bsym.from_bsym_swap_proxies(swap_map)
+            if has_tags(bsym, {BoundSymbolTag.BACKWARD}):
+                update_bsym.tags.add(BoundSymbolTag.BACKWARD)
             bsyms.append(update_bsym)
             encountered.update(out_tensors)
-            new_bsym = bsym.from_bsym_swap_proxies(swap_map)
             bsyms.append(new_bsym)
             if _is_inplace_op(bsym) and len(out_tensors) == 1 and len(in_tensors) == 1:
                 #  This relies on these being one element sets (ltorch.setitem_ yields no outs).

--- a/thunder/executors/passes.py
+++ b/thunder/executors/passes.py
@@ -14,6 +14,7 @@ from thunder.core.utils import ProxyDict
 from thunder.executors.pythonex import clear_mutable_collection
 from thunder.extend import Executor, get_always_executors, OperatorExecutor, FusionExecutor
 import thunder.core.prims as prims
+from thunder.core.symbol import BoundSymbolTag, has_tags
 import thunder.core.utils as cutils
 
 if TYPE_CHECKING:
@@ -84,7 +85,11 @@ def _transform_for_operator_executor_execution(trace: TraceCtx, executors_list: 
             # No executor found, need to descend
             cutils.check(not bsym.sym.is_prim, lambda: f"Failed to find an executor for bound symbol {bsym=}")
             # OUTPUTS to map
-            self.add_unprocessed_bsyms(bsym.subsymbols[:])
+            sub_bsyms = bsym.subsymbols[:]
+            if has_tags(bsym, {BoundSymbolTag.BACKWARD}):
+                for subbsym in sub_bsyms:
+                    subbsym.tags.add(BoundSymbolTag.BACKWARD)
+            self.add_unprocessed_bsyms(sub_bsyms)
 
     start_time_ns = time.perf_counter_ns()
 

--- a/thunder/tests/test_jit_general.py
+++ b/thunder/tests/test_jit_general.py
@@ -1194,6 +1194,37 @@ def test_custom_autograd_function():
     assert jitted.l1.weight.grad is not None
 
 
+def test_complex_backward_custom_autograd():
+    # This tests that backward tags are correctly propagated to the subsymbols of the custom autograd function.
+    # Without this propagation, operations for the backward pass could be fused with forward pass operations.
+    class CustomBackward(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx, x):
+            return x
+
+        @staticmethod
+        def backward(ctx, grad_at_output):
+            x = torch.randn_like(grad_at_output)
+            index = torch.randint(0, 1, (0, x.shape[-1]), device="cuda", dtype=torch.int64)
+            # the descent to scatter_add_'s subsymbols doesn't happen until _transform_for_operator_executor_execution
+            x.scatter_add_(index=index, src=grad_at_output, dim=-1)
+            return grad_at_output * x
+
+    def f(x):
+        y = CustomBackward.apply(x)
+        # the in-place op introduces a fusion break
+        x.add_(1)
+        z = x + x
+        return y, z
+
+    jf = thunder_jit(f, skip_inplace_alias_updates=False, skip_inplace_functionalization=True, fusion_type="dataflow")
+
+    x = torch.ones(2, 3, device="cuda", requires_grad=True)
+
+    # This should not raise an error about variables referenced before assignment.
+    jf(x)
+
+
 @pytest.mark.filterwarnings("ignore:Please use torch.vmap")
 def test_autograd_function_apply():
     # see https://github.com/Lightning-AI/lightning-thunder/issues/1248#issuecomment-2388655917

--- a/thunder/tests/test_jit_general.py
+++ b/thunder/tests/test_jit_general.py
@@ -1218,7 +1218,7 @@ def test_complex_backward_custom_autograd():
         z = x + x
         return y, z
 
-    jf = thunder_jit(f, skip_inplace_alias_updates=False, skip_inplace_functionalization=True, fusion_type="dataflow")
+    jf = thunder_jit(f, fusion_type="dataflow")
 
     x = torch.ones(2, 3, device="cuda", requires_grad=True)
 

--- a/thunder/tests/test_jit_general.py
+++ b/thunder/tests/test_jit_general.py
@@ -1194,6 +1194,7 @@ def test_custom_autograd_function():
     assert jitted.l1.weight.grad is not None
 
 
+@requiresCUDA
 def test_complex_backward_custom_autograd():
     # This tests that backward tags are correctly propagated to the subsymbols of the custom autograd function.
     # Without this propagation, operations for the backward pass could be fused with forward pass operations.


### PR DESCRIPTION
The backward tags are not being propagated consistently, leading to certain bound symbols which should be in the backward trace appearing in the forward trace.  After the backward trace is split, there are error about undefined tensors.  
This is made evident in the following non-trivial example:

```py
import torch


class mp(torch.autograd.Function):
    @staticmethod
    def forward(
        ctx,
        scores: torch.Tensor,
        multiplier: torch.Tensor,
        selected_experts: torch.Tensor,
        masked_gates: torch.Tensor,
        mask_for_one: torch.Tensor,
    ):
        ctx.save_for_backward(selected_experts, masked_gates)
        return multiplier * mask_for_one

    @staticmethod
    def backward(ctx, grad_at_output: torch.Tensor):
        selected_experts, masked_gates = ctx.saved_tensors
        masked_gates.scatter_add_(dim=-1, index=selected_experts, src=grad_at_output)
        return masked_gates, None, None, None, None


def sparsemixer(scores, top_k=2, jitter_eps=0.01, training=True):
    mask_logits_threshold, max_ind = scores.max(dim=-1, keepdim=True)

    masked_gates = scores.masked_fill(torch.zeros_like(mask_logits_threshold).to(torch.bool), float("-inf"))
    selected_experts = masked_gates.max(dim=-1)[1].unsqueeze(-1)

    # compute scores for gradients
    multiplier_o = masked_gates.gather(dim=-1, index=selected_experts)

    # compute midpoint mask
    max_scores, max_ind = masked_gates.max(dim=-1, keepdim=True)
    mask_for_one = torch.logical_or(
        selected_experts == max_ind,
        torch.rand_like(max_scores) > 0.75,
    )

    multiplier = mp.apply(
        scores,
        multiplier_o,
        selected_experts,
        masked_gates,
        mask_for_one,
    )

    # masked out first expert
    masked_scores = torch.scatter(
        scores,
        -1,
        selected_experts,
        float("-inf"),
    )

    # # apply mask
    masked_gates_top2 = masked_scores.masked_fill(torch.zeros_like(mask_logits_threshold).to(torch.bool), float("-inf"))

    # compute midpoint mask
    max_scores, max_ind = masked_gates_top2.max(dim=-1, keepdim=True)
    mask_for_one_top2 = torch.logical_or(
        max_ind == max_ind,
        torch.rand_like(max_scores).uniform_() > 0.75,
    )

    return (
        multiplier,
        selected_experts,
    )


class GRINMoESparseMoeBlock(torch.nn.Module):
    def __init__(self):
        super().__init__()
        self.hidden_dim = 4096
        self.num_experts = 16
        # gating
        self.gate = torch.nn.Linear(self.hidden_dim, self.num_experts, bias=False)

    def forward(self, hidden_states: torch.Tensor):
        """ """
        sequence_length, hidden_dim = hidden_states.shape
        hidden_states *= torch.empty_like(hidden_states).uniform_(0.1, 1.0)
        hidden_states = hidden_states.view(-1, hidden_dim)

        router_logits = self.gate(hidden_states)

        routing_weights, selected_experts = sparsemixer(
            router_logits,
            training=True,
        )

        return routing_weights, selected_experts


from thunder.dynamo import ThunderCompiler

a = torch.rand((128, 4096), device="cuda")
model = GRINMoESparseMoeBlock().to("cuda")
back = ThunderCompiler(skip_inplace_alias_updates=False, skip_inplace_functionalization=True, disable_inplace_copy_check=True)
jfoo = torch.compile(model, backend=back)
jfoo(a)
```
The `copy_` subsymbol of `mp.backward`'s `scatter_add_` is what is missing the backward tag.  The associated update_aliases bsyms were also missing the tag.
