### PR TITLE
[WIP][dtensor] use nvfuser_direct for nvfuser dtensor execution

### DIFF
--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -536,7 +536,7 @@ class FusionDefinitionWrapper:
         if self.store_inputs:
             self.last_inputs = args
 
-        if any(isinstance(t, torch.distributed.tensor.DTensor) for t in args):
+        if IS_TORCH_DISTRIBUTED_AVAILABLE and any(isinstance(t, torch.distributed.tensor.DTensor) for t in args):
             with annotate_for_profile(self.name):
                 output = nvfd.execute_with_dtensors(fd, args)
                 return output


### PR DESCRIPTION
Ref #2338

Tested with existing `thunder/tests/distributed/test_dtensor.py`

Current nvFuser Python interface  leads to an error when creating multiple FusionDefinitions with the same math but different device schedules - [issue](https://github.com/NVIDIA/Fuser/issues/4507).


For this, nvFuser has a new Python front-end (nvfuser_direct) which doesn't face this issue. In this PR, we update the multi-device path to use this interface. Also, in future, this will be the default interface and we will update to using this for single-device path as well.


EDIT: ~~Fix for https://github.com/NVIDIA/Fuser/issues/4806 needs to land first~~ This has been fixed