### PR TITLE
Make inplace flags defaults consistent

### DIFF
--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -684,8 +684,8 @@ def jit(
         # aliases wouldn't matter, thus it'd be better to nullify this entry in such cases.
         # It however would require the functionalized computation trace to interact with `cache_info`,
         # which seems to break the consistency of cache_info, leading to a failure in cache_info check.
-        if not compile_options.get("skip_inplace_alias_updates", True) or not compile_options.get(
-            "skip_inplace_functionalization", False
+        if not compile_options.get("skip_inplace_alias_updates", False) or not compile_options.get(
+            "skip_inplace_functionalization", True
         ):
             cache_info["alias_tensor_indices"] = _alias_tensor_of_args_kwargs(*args, **kwargs)
 


### PR DESCRIPTION
The default values for inplace flags are mixed: `False` for skip_inplace_alias_updates [here](https://github.com/Lightning-AI/lightning-thunder/blob/95b76454ffb4365fc8b320d4c502ad29361f8a3b/thunder/__init__.py#L491) but `True` [here](https://github.com/Lightning-AI/lightning-thunder/blob/95b76454ffb4365fc8b320d4c502ad29361f8a3b/thunder/__init__.py#L687).  This PR fixes that inconsistency.
