### PR TITLE
[dtensor] don't rely on __repr__ of DTenorSpec

### DIFF
--- a/thunder/core/codeutils.py
+++ b/thunder/core/codeutils.py
@@ -152,12 +152,10 @@ def to_printable(
     if isinstance(x, ProxyInterface):
         return x
 
-    from thunder.torch.experimental.dtensor_codeutils import populate_object_ctx_for_dtensor_spec
+    from thunder.torch.experimental.dtensor_codeutils import is_dtensor_spec
 
-    if populate_object_ctx_for_dtensor_spec(x, object_ctx):
-        return x
-
-    if dataclasses.is_dataclass(x):
+    # NOTE: DTensorSpec is a dataclass but we want it to be handled differently from other dataclasses.
+    if dataclasses.is_dataclass(x) and not is_dtensor_spec(x):
         # Add `class` to the object_ctx so that we can reuse it during the trace execution.
         if isinstance(x, type):  # dataclass type
             cls = x
@@ -240,11 +238,6 @@ def prettyprint(
 
     if isinstance(x, ContextObject):
         return m(x.name)
-
-    from thunder.torch.experimental.dtensor_codeutils import prettyprint_dtensor_spec
-
-    if dtensor_repr := prettyprint_dtensor_spec(x):
-        return m(dtensor_repr)
 
     if dataclasses.is_dataclass(x):
         # For a dataclass instance of class

--- a/thunder/torch/experimental/dtensor_codeutils.py
+++ b/thunder/torch/experimental/dtensor_codeutils.py
@@ -3,39 +3,9 @@ import torch
 from thunder.torch.experimental.dtensor_utils import run_only_if_distributed_is_available
 
 if torch.distributed.is_available():
-    from torch.distributed.tensor._dtensor_spec import DTensorSpec, TensorMeta
-    from torch.distributed.tensor import DeviceMesh, Partial, Placement, Replicate, Shard
+    from torch.distributed.tensor._dtensor_spec import DTensorSpec
 
 
 @run_only_if_distributed_is_available
-def populate_object_ctx_for_dtensor_spec(x: Any, object_ctx: dict[str, Any]) -> bool:
-    """
-    Populate object context for DTensorSpec.
-
-    ..note::
-        This function will mutate the `object_ctx`
-
-    Returns:
-        bool: True if `x` is DTensorSpec (and also updates `object_ctx`) otherwise False.
-    """
-    if isinstance(x, DTensorSpec):
-        object_ctx.update(
-            {
-                "DTensorSpec": DTensorSpec,
-                "DeviceMesh": DeviceMesh,
-                "Placement": Placement,
-                "Replicate": Replicate,
-                "Shard": Shard,
-                "Partial": Partial,
-                "TensorMeta": TensorMeta,
-            }
-        )
-        return True
-    return False
-
-
-@run_only_if_distributed_is_available
-def prettyprint_dtensor_spec(x):
-    if isinstance(x, DTensorSpec):
-        return x.__repr__()
-    return ""
+def is_dtensor_spec(x: Any) -> bool:
+    return isinstance(x, DTensorSpec)


### PR DESCRIPTION
DTensorSpec.__repr__ was changed in https://github.com/pytorch/pytorch/pull/158822/files which makes it so that `__repr__` can't be used to recreate the DTensorSpec.

Instead, we add the actual object to the TraceCtx and give it a name.

Eg.
Backward Exec Trace Before - 
```python
def backward_fn(saved_for_backward, cotangents):
  C0, _, = saved_for_backward
  clear_mutable_collection(saved_for_backward)
  del saved_for_backward
  dtensor_10, = cotangents
  # dtensor_10: "DTensor cuda:0 f32[16, 16] mesh=DeviceMesh('cuda', [0, 1]), placements=(Shard(dim=0),)"
  clear_mutable_collection(cotangents)
  del cotangents
  thunder.torch.experimental.dtensor_utils.check_dtensor_cotangent_metadata(dtensor_10, DTensorSpec(mesh=DeviceMesh('cuda', [0, 1]), placements=(Shard(dim=0),), tensor_meta=TensorMeta(shape=torch.Size([16, 16]), stride=(16, 1), dtype=torch.float32)))
  w, x, = C0
  # w: "DTensor cuda:0 f32[16, 16] mesh=DeviceMesh('cuda', [0, 1]), placements=(Shard(dim=0),)"
  # x: "DTensor cuda:0 f32[16, 16] mesh=DeviceMesh('cuda', [0, 1]), placements=(Shard(dim=0),)"
  clear_mutable_collection(C0)
  del C0
  [dtensor_13, dtensor_16] = nvFusion1(w, dtensor_10, x)
    # dtensor_13 = thunder.torch.experimental.dtensor_torch_and_prims.dtensor_mul_prim(w, dtensor_10)  # dtensor_13: "DTensor cuda:0 f32[16, 16] mesh=DeviceMesh('cuda', [0, 1]), placements=(Shard(dim=0),)"
    # dtensor_16 = thunder.torch.experimental.dtensor_torch_and_prims.dtensor_mul_prim(x, dtensor_10)  # dtensor_16: "DTensor cuda:0 f32[16, 16] mesh=DeviceMesh('cuda', [0, 1]), placements=(Shard(dim=0),)"
  del w, dtensor_10, x
  return (dtensor_13, dtensor_16)
```

Backward Exec Trace After - 
```py
def backward_fn(saved_for_backward, cotangents):
  C0, _, = saved_for_backward
  clear_mutable_collection(saved_for_backward)
  del saved_for_backward
  dtensor_10, = cotangents
  # dtensor_10: "DTensor cuda:0 f32[16, 16] mesh=DeviceMesh('cuda', [0, 1]), placements=(Shard(dim=0),)"
  clear_mutable_collection(cotangents)
  del cotangents
  thunder.torch.experimental.dtensor_utils.check_dtensor_cotangent_metadata(dtensor_10, _torch_distributed_tensor__dtensor_spec_DTensorSpec_0)
  w, x, = C0
  # w: "DTensor cuda:0 f32[16, 16] mesh=DeviceMesh('cuda', [0, 1]), placements=(Shard(dim=0),)"
  # x: "DTensor cuda:0 f32[16, 16] mesh=DeviceMesh('cuda', [0, 1]), placements=(Shard(dim=0),)"
  clear_mutable_collection(C0)
  del C0
  [dtensor_13, dtensor_16] = nvFusion1(w, dtensor_10, x)
    # dtensor_13 = thunder.torch.experimental.dtensor_torch_and_prims.dtensor_mul_prim(w, dtensor_10)  # dtensor_13: "DTensor cuda:0 f32[16, 16] mesh=DeviceMesh('cuda', [0, 1]), placements=(Shard(dim=0),)"
    # dtensor_16 = thunder.torch.experimental.dtensor_torch_and_prims.dtensor_mul_prim(x, dtensor_10)  # dtensor_16: "DTensor cuda:0 f32[16, 16] mesh=DeviceMesh('cuda', [0, 1]), placements=(Shard(dim=0),)"
  del w, dtensor_10, x
  return (dtensor_13, dtensor_16)
```

NOTE: The only difference is for the arguments to `check_dtensor_cotangent_metadata` .