### PR TITLE
Make pre-commit hooks work on all python3s

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.10
+  python: python3
 
 ci:
   autofix_prs: true


### PR DESCRIPTION
For example, many docker images have switched to python 3.12. 