### PR TITLE
Update TE v2 executor tests

### DIFF
--- a/thunder/executors/transformer_engine_v2ex_impl.py
+++ b/thunder/executors/transformer_engine_v2ex_impl.py
@@ -140,6 +140,7 @@ def _linear_fwd_impl(a, w, bias, input_quantizer: Quantizer, weight_quantizer: Q
         input=a,
         weight=w,
         bias=bias,
+        dtype=w.dtype,
         with_quantized_compute=True,
         input_quantizer=input_quantizer,
         weight_quantizer=weight_quantizer,

--- a/thunder/tests/test_transformer_engine_v2_executor.py
+++ b/thunder/tests/test_transformer_engine_v2_executor.py
@@ -113,7 +113,7 @@ def test_te_linear_forward_backward_multiple_iteration(fp8_recipe: recipe.Recipe
     # Running more iterations leads to `nan` for both eager and thunder
     # with BlockScaling.
     # Potentially because we are training on dummy data and task
-    iterations = 3
+    iterations = 6
 
     # TE inputs
     input_shape = (768, 4096)
@@ -126,7 +126,7 @@ def test_te_linear_forward_backward_multiple_iteration(fp8_recipe: recipe.Recipe
     # Parameters for thunder to optimize
     w1, w2, b1, b2 = clone_params(te_linear1.weight, te_linear2.weight, te_linear1.bias, te_linear2.bias)
 
-    target_value = torch.tensor(42, dtype=dtype, device=device)
+    target_value = torch.randint(42, (768,), dtype=torch.int64, device=device)
 
     inputs = tuple(torch.rand(*input_shape, device=device, dtype=dtype) for _ in range(iterations))
 
@@ -134,8 +134,7 @@ def test_te_linear_forward_backward_multiple_iteration(fp8_recipe: recipe.Recipe
         # Run for `iterations`.
         for iter_n in range(iterations):
             x = inputs[iter_n]
-            result = model(x)
-            loss = torch.nn.functional.mse_loss(result.sum(), target_value)
+            loss = torch.nn.functional.cross_entropy(result, target_value)
             loss.backward()
             optimizer.step()
             optimizer.zero_grad()
@@ -190,7 +189,7 @@ def test_te_linear_forward_backward_multiple_iteration_multiple_recipes():
     # Running more iterations leads to `nan` for both eager and thunder
     # with BlockScaling.
     # Potentially because we are training on dummy data and task
-    iterations = 3
+    iterations = 6
 
     # TE inputs
     input_shape = (768, 4096)
@@ -203,7 +202,7 @@ def test_te_linear_forward_backward_multiple_iteration_multiple_recipes():
     # Parameters for thunder to optimize
     w1, w2, b1, b2 = clone_params(te_linear1.weight, te_linear2.weight, te_linear1.bias, te_linear2.bias)
 
-    target_value = torch.tensor(42, dtype=dtype, device=device)
+    target_value = torch.randint(42, (768,), dtype=torch.int64, device=device)
 
     inputs = tuple(torch.rand(*input_shape, device=device, dtype=dtype) for _ in range(iterations))
 
@@ -213,7 +212,7 @@ def test_te_linear_forward_backward_multiple_iteration_multiple_recipes():
             te_recipe = recipes[iter_n % 2]
             x = inputs[iter_n]
             result = model(x, te_recipe)
-            loss = torch.nn.functional.mse_loss(result.sum(), target_value)
+            loss = torch.nn.functional.cross_entropy(result, target_value)
             loss.backward()
             optimizer.step()
             optimizer.zero_grad()


### PR DESCRIPTION
While working on #2344 I've noticed that when using mse we cannot do more than 3 iterations otherwise the loss goes outside well fp8 range. Using cross entropy helps testing a more realistic scenario and leaves more iterations for numerical errors to accumulate in case there is a mismatch with TE behavior