### PR TITLE
Remove the bookend optimization

### DIFF
--- a/thunder/core/transforms.py
+++ b/thunder/core/transforms.py
@@ -1301,11 +1301,7 @@ def _var_mean_prim_grad(a: TensorProxy, /, dims: Sequence[int], *, correction: N
     # Computes var bwd
     normalization_scalar = n_elem_reduced - correction
     restored_gv = restore_reduced_dims(gv, dims, a.shape)
-    # Inserting a conversion to the same dtype to disable nvFuser executors's
-    # bookend optimization (nv_enable_bookend), which can cause the backward
-    # pass to generate two kernels
-    mean_mdtype = prims.convert_element_type(m, m.dtype)
-    restored_mean = restore_reduced_dims(mean_mdtype, dims, a.shape)
+    restored_mean = restore_reduced_dims(m, dims, a.shape)
     var_grad = (2 * restored_gv * (a - restored_mean)) / normalization_scalar
 
     put_grad(a, mean_grad + var_grad)

--- a/thunder/tests/distributed/test_fsdp.py
+++ b/thunder/tests/distributed/test_fsdp.py
@@ -296,7 +296,7 @@ class FSDPTest(DistributedParallelTestCase):
         y.mean().backward()
 
         fw_extrace = thunder.last_traces(jitted)[-1]
-        # When bookend is turned off, `slice` and `pad` may appear in nvFusion subsymbols.
+        # `slice` and `pad` may appear in nvFusion subsymbols.
         fw_extrace = unwrap_one_level_of_subsymbols(fw_extrace)
         fw_symids = [bsym.sym.id for bsym in fw_extrace.bound_symbols]
         self.assertTrue(any(sym_id in {PrimIDs.SLICE, slice_prim_impl.id} for sym_id in fw_symids))

--- a/thunder/tests/test_core.py
+++ b/thunder/tests/test_core.py
@@ -1104,7 +1104,6 @@ def test_bsym_toposort(executor: TestExecutor, device: str, dtype: dtypes.dtype)
     assert sub_preferring_sub_bsym.sym.id == "torch.sub"
 
     # Tests collection and reshape with -1 input
-    # NOTE Additions before and after the reshape are to prevent nvFuser from "bookending" the operation
     def bar(a, shape):
         b = a + 3
         c = a + 2.0

--- a/thunder/tests/test_einops.py
+++ b/thunder/tests/test_einops.py
@@ -111,8 +111,7 @@ def test_reduce(device: str, dtype: torch.dtype):
     def f(input, expr, **kwargs):
         return einops.reduce(input, expr, **kwargs)
 
-    # TODO(#1993): don't enforce `nv_enable_bookend` when #1993 is resolved.
-    fc = thunder.jit(f, nv_enable_bookend=True)
+    fc = thunder.jit(f)
 
     for shape, expr, kwargs in cases:
         input = make_tensor(shape, dtype=dtype, device=device)

--- a/thunder/tests/test_jit_general.py
+++ b/thunder/tests/test_jit_general.py
@@ -1111,7 +1111,7 @@ def test_cache_symbolic_values_reshape():
     def foo(t, batch_size):
         return t.reshape(batch_size, -1).sum(-1)
 
-    jfoo = thunder_jit(foo, cache="symbolic values", nv_enable_bookend=False)
+    jfoo = thunder_jit(foo, cache="symbolic values")
     expected = foo(a, 32)
     actual = jfoo(a, 32)
 

--- a/thunder/tests/test_nvfuser.py
+++ b/thunder/tests/test_nvfuser.py
@@ -302,7 +302,6 @@ def test_cse_subsymbol_redundant_args(executor, device, _):
 
 @instantiate(dtypes=NOTHING, devicetypes=(devices.DeviceType.CUDA,), executors=(nvFuserExecutor,))
 def test_cse_rematerialization(executor, device, _):
-    # Unit test for "llama2.c example failed with bookend disabled."
     from thunder.tests.llama2_model import Transformer, ModelArgs
 
     batch_size = 2
@@ -328,7 +327,6 @@ def test_cse_rematerialization(executor, device, _):
         model.eval(),
         disable_torch_autograd=True,
         executors=executor.executors_list(),
-        nv_enable_bookend=False,
     )
     compiled_func(x, y)
 
@@ -612,220 +610,6 @@ def test_cse_issue1789(executor, device, _):
 
 @instantiate(
     dtypes=NOTHING,
-    executors=(
-        nvFuserExecutor,
-        # NOTE We might want to do transpose bookend optimization for other executors than nvFuser.
-    ),
-)
-def test_bookend_meta_optimization(executor, device, _):
-    a = torch.ones(2, 3, 5, device=device, dtype=torch.float32)
-
-    def subtest(fn, n):
-        # Enable bookending so it gets tested.
-        cfn = thunder.jit(fn, nv_enable_bookend=True)
-
-        _ = cfn(a)
-        traces = thunder.last_traces(cfn)
-        execution_trace = traces[-1]
-
-        transposes_in_fusions = 0
-        for bsym in execution_trace.bound_symbols:
-            sym = bsym.sym
-            if sym.is_fusion:
-                for sbsym in bsym.subsymbols:
-                    ssym = sbsym.sym
-                    if ssym.id is prims.PrimIDs.TRANSPOSE:
-                        transposes_in_fusions += 1
-
-        assert transposes_in_fusions == n, (
-            f"Expected {n} prims.transpose operations in fusions, but found {transposes_in_fusions} transpose in fusions in the trace {traces[-1]}"
-        )
-
-    # one transpose at the beginning
-    # should be moved out of fusion
-    def func_0(t):
-        t0 = t.transpose(0, 1)
-        t1 = t0.tanh()
-        t2 = t1.sin()
-        return t2
-
-    subtest(func_0, 0)
-
-    # one transpose at the end
-    # should be moved out of fusion
-    def func_1(t):
-        t0 = t.tanh()
-        t1 = t0.sin()
-        t2 = t1.transpose(0, 1)
-        return t2
-
-    subtest(func_1, 0)
-
-    # one transpose at the beginning and another at the end
-    # both should be moved out of fusion
-    def func_2(t):
-        t0 = t.transpose(0, 1)
-        t1 = t0.tanh()
-        t2 = t1.sin()
-        t3 = t2.transpose(0, 2)
-        return t3
-
-    subtest(func_2, 0)
-
-    # a couple independent transposes at the beginning
-    # both should be moved out of fusion
-    def func_3(t):
-        t0 = t.transpose(0, 1)
-        t1 = t0.tanh()
-        t2 = t1.sin()
-
-        t3 = t.transpose(0, 2)
-        t4 = t3.sin()
-        t5 = t4.tanh()
-        return t2, t5
-
-    subtest(func_3, 0)
-
-    # a couple independent transposes at the end
-    # both should be moved out of fusion
-    def func_4(t):
-        t0 = t.tanh()
-        t1 = t0.sin()
-        t2 = t1.transpose(0, 1)
-
-        t3 = t.sin()
-        t4 = t3.tanh()
-        t5 = t4.transpose(0, 2)
-        return t2, t5
-
-    subtest(func_4, 0)
-
-    # a couple chained transposes at the beginning
-    # both should be moved out of fusion
-    def func_5(t):
-        t0 = t.transpose(0, 1)
-        t1 = t0.transpose(0, 2)
-        t2 = t1.tanh()
-        t3 = t2.sin()
-        return t3
-
-    subtest(func_5, 0)
-
-    # a couple chained transposes at the end
-    # both should be moved out of fusion
-    def func_6(t):
-        t0 = t.tanh()
-        t1 = t0.sin()
-        t2 = t1.transpose(0, 1)
-        t3 = t2.transpose(0, 2)
-        return t3
-
-    subtest(func_6, 0)
-
-    # a couple chained transposes at the beginning and end
-    # both should be moved out of fusion
-    def func_7(t):
-        t0 = t.transpose(0, 1)
-        t1 = t0.transpose(0, 2)
-        t2 = t1.tanh()
-        t3 = t2.sin()
-        t4 = t3.transpose(0, 1)
-        t5 = t4.transpose(0, 2)
-        return t5
-
-    subtest(func_7, 0)
-
-    # complicated case, where two non-meta ops are each sandwiched by transpose
-    # the two transposes on the edge should be moved out of fusion
-    def func_8(t):
-        t0 = t.transpose(0, 1)
-        t1 = t0.tanh()
-        # transpose in the middle should stay
-        t2 = t1.transpose(0, 1)
-        t3 = t2.sin()
-        t4 = t3.transpose(0, 2)
-        return t4
-
-    subtest(func_8, 1)
-
-    # NOTE func_9 and func_10 are symmetrical, this is designed to double check our toposort based approach can break
-    # ties
-
-    # complicated case, where two branches have transpose ops towards the end
-    # the two transposes on the edge should be moved out of fusion
-    def func_9(t):
-        t0 = t.tanh()
-        t1 = t0.sin()
-        t2 = t1.transpose(0, 1)
-        t3 = t2.transpose(2, 1)
-
-        t4 = t.sin()
-        t5 = t4.tanh()
-        t6 = t5.transpose(0, 2)
-        t7 = t6.sin()
-        return t3, t7
-
-    subtest(func_9, 1)
-
-    # complicated case, where two branches have transpose ops towards the end
-    # the two transposes on the edge should be moved out of fusion
-    def func_10(t):
-        t0 = t.tanh()
-        t1 = t0.sin()
-        t2 = t1.transpose(0, 1)
-        t3 = t2.sin()
-
-        t4 = t.sin()
-        t5 = t4.tanh()
-        t6 = t5.transpose(0, 2)
-        t7 = t6.transpose(2, 1)
-        return t3, t7
-
-    subtest(func_10, 1)
-
-    # complicated case, where a chain of transposed operations is both an output and consumed as an intermediate
-    # no transposes should be removed
-    def func_11(t):
-        t0 = t.tanh()
-        t1 = t0.sin()
-        t2 = t1.transpose(0, 1)
-        t3 = t2.transpose(0, 2)
-
-        t4 = t3.sin()
-        return t3, t4
-
-    subtest(func_11, 2)
-
-    # complicated case
-    def func_12(t):
-        t0 = t.transpose(0, 1)
-        t1 = t0.transpose(0, 2)
-        t2 = t1.tanh()
-        t3 = t2 + 1.0
-        t4 = t3.transpose(2, 1)
-        t4 = t4.transpose(0, 1)
-
-        t5 = t * 0.5
-        # this is the only transpose that should stay in fusion, because it is surrounded by non-meta ops
-        t6 = t5.transpose(0, 2)
-        t7 = t6.tanh()
-
-        t8 = t1.transpose(1, 2)
-
-        t9 = t.transpose(2, 1)
-        t10 = t9.tanh()
-
-        t11 = t.transpose(1, 2)
-        t12 = t11.transpose(0, 2)
-        t13 = t12.transpose(0, 1)
-
-        return t4, t6, t7, t8, t10, t13
-
-    subtest(func_12, 1)
-
-
-@instantiate(
-    dtypes=NOTHING,
     executors=(nvFuserExecutor,),
 )
 def test_optimization_fuel(executor, device, _):
@@ -925,12 +709,10 @@ def test_rm_unused_inputs_of_nvfusion(executor, device, _):
 
     t = make_tensor(5, 3, device=device, dtype=torch.float32)
     ab = (slice(3, 1), slice(1, 2))
-    # enable bookend would remove the error and let you look at the trace without fusion.
     jfoo = thunder.jit(
         foo,
         cache="no caching",
         disable_torch_autograd=True,
-        nv_enable_bookend=False,
     )
     out = jfoo(t, ab)
     out_ref = foo(t, ab)

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -4385,15 +4385,9 @@ def _native_batch_norm(
 
     # Handles weight and bias
     if weight is not None:
-        # Inserting a conversion to the computation_dtype for weight and bias to
-        # disable nvFuser executors's bookend optimization (nv_enable_bookend),
-        # preventing the executor to push out the shape operations out of the
-        # fusion region.
-        weight = to(weight, computation_dtype)
         weight = reshape(weight, params_shape)
         out = out * weight
     if bias is not None:
-        bias = to(bias, computation_dtype)
         bias = reshape(bias, params_shape)
         out = out + bias
 


### PR DESCRIPTION
It has been disabled by default since nvFuser 0.2.10 and been used only by unit tests. 