### PR TITLE
Fix example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ x = torch.randn(64, 2048)
 
 y = thunder_model(x)
 
-assert torch.testing.assert_close(y, model(x))
+torch.testing.assert_close(y, model(x))
 ```
 
 ## Examples


### PR DESCRIPTION
[`assert_close`](https://docs.pytorch.org/docs/stable/testing.html#torch.testing.assert_close) returns None. Mismatches are reported by raising errors. So it makes no sense to assert on the return value of `assert_close`.
