### PR TITLE
TEv2 Add multi-gpu support and tests

### DIFF
--- a/thunder/executors/transformer_engine_v2ex_impl.py
+++ b/thunder/executors/transformer_engine_v2ex_impl.py
@@ -1,6 +1,8 @@
 import time
 from typing import TYPE_CHECKING
 
+import torch.distributed as torch_dist
+
 from thunder.core.prims import linear as linear_prim
 from thunder.core.prims import get_grad, put_grad
 from thunder.core.proxies import AnyProxy, TensorProxy
@@ -263,8 +265,21 @@ def _te_fp8_amax_and_scale_update_meta(recipe: AnyProxy, *, states: tuple[AnyPro
 
 # TODO can gather and scatter be made explicit here for ddp
 def _te_fp8_amax_and_scale_update_impl(recipe: Recipe, states: tuple[RecipeState], tokens: tuple[TensorProxy]):
-    if recipe.delayed():
-        for state in states:
+    for state in states:
+        
+        if recipe.reduce_amax and torch_dist.is_initialized():
+            from torch.distributed import distributed_c10d
+
+            pg = distributed_c10d._get_default_group()
+            if torch_dist.get_world_size(group=pg) > 1:
+                torch_dist.all_reduce(
+                    state.amax_history,
+                    op=torch_dist.ReduceOp.MAX,
+                    group=pg,
+                    async_op=False,
+                )
+
+        if recipe.delayed():
             _amax_and_scale_update(
                 state.amax_history, state.scale, get_fp8_max(recipe, state.mode == "forward"), recipe
             )

--- a/thunder/tests/distributed/test_ddp.py
+++ b/thunder/tests/distributed/test_ddp.py
@@ -25,6 +25,8 @@ from thunder.executors.transformer_engineex import (
     te_sync_fp8_meta_bwd,
 )
 
+from thunder.executors.transformer_engine_v2ex import transformer_engine_v2_ex, TransformerEngineTransformV2
+
 
 is_fp8_supported: bool = False
 # This will be correctly updated below when TE Engine is installed
@@ -572,6 +574,206 @@ def _test_ddp_transformer_engine_llama_sanity(input_data):
     return None
 
 
+def _test_ddp_transformer_engine_v2(input_data):
+    # Test Description: We run a dummy training loop for a simple `Linear(Relu(Linear(x)))`
+    # model with thunder (using TE executor) and with PyTorch eager + TE
+    # and verify that the weights have converged to same value after `n_iter`.
+
+    init_method, world_size, rank, executor, device, dtype, _unused_kwargs = input_data
+    devicetype = devices.device_from_string(device).devicetype
+    _unused_dtype = ltorch.to_torch_dtype(dtype)
+    init_per_process_distributed(init_method, devicetype, world_size, rank)
+
+    fp8_recipe = get_default_fp8_recipe()
+
+    torch.cuda.set_device(rank)
+
+    dim = 256
+    # Running more iterations leads to `nan` for both eager and thunder
+    # with BlockScaling.
+    # Potentially because we are training on dummy data and task
+    n_iter = 4
+
+    class ThunderModel(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.fc1 = torch.nn.Linear(dim, dim, bias=False)
+            self.fc2 = torch.nn.Linear(dim, dim, bias=False)
+
+        def forward(self, x):
+            return self.fc2(torch.nn.functional.relu(self.fc1(x)))
+
+    # Weights
+    fc1_weight = torch.randn(dim, dim, requires_grad=True).cuda()
+    fc2_weight = torch.randn(dim, dim, requires_grad=True).cuda()
+
+    # Inputs (different input on different rank).
+    if rank == 0:
+        x = torch.arange(dim * dim, dtype=torch.float).view(dim, dim).cuda()
+    if rank == 1:
+        x = torch.randn(dim, dim).cuda() * 100
+
+    thunder_model = ThunderModel().cuda()
+    thunder_model.fc1.weight.data = fc1_weight.clone()
+    thunder_model.fc2.weight.data = fc2_weight.clone()
+
+    jit_model = thunder.distributed.ddp(
+        thunder.jit(
+            thunder_model,
+            executors=[
+                transformer_engine_v2_ex,
+            ]
+            + executor.executors_list(),
+            transforms=[TransformerEngineTransformV2()],
+        )
+    )
+
+    optim = torch.optim.SGD(jit_model.parameters())
+
+    for _ in range(n_iter):
+        with fp8_autocast(fp8_recipe=fp8_recipe):
+            o = jit_model(x).sum()
+        o.backward()
+        optim.step()
+        optim.zero_grad()
+
+    FP8GlobalStateManager.reset()
+
+    class TEModel(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.fc1 = TELinear(dim, dim, bias=False)
+            self.fc2 = TELinear(dim, dim, bias=False)
+
+        def forward(self, x):
+            return self.fc2(torch.nn.functional.relu(self.fc1(x)))
+
+    te_model = TEModel().cuda()
+    te_model.fc1.weight.data = fc1_weight.clone()
+    te_model.fc2.weight.data = fc2_weight.clone()
+
+    ddp_model = DDP(te_model)
+
+    optim = torch.optim.SGD(te_model.parameters())
+
+    for _ in range(n_iter):
+        with fp8_autocast(fp8_recipe=fp8_recipe):
+            o = ddp_model(x).sum()
+
+        o.backward()
+        optim.step()
+        optim.zero_grad()
+
+    # Compare weights after `n_iters`
+    comparison_exceptions = []
+    try:
+        assert_close(thunder_model.fc1.weight, te_model.fc1.weight)
+        assert_close(thunder_model.fc2.weight, te_model.fc2.weight)
+    except Exception as e:
+        # Return exceptions only for rank==0
+        if rank == 0:
+            comparison_exceptions.append(e)
+
+    return comparison_exceptions
+
+
+def _test_ddp_transformer_engine_v2_llama_sanity(input_data):
+    # Test Description: We run a dummy training loop for a Transformer Model
+    # We run a few iterations to see that TransformerEngine doesn't throw internal assertion
+    # due to reordering of forward and backward operators.
+    # (This test will fail without `_rearrange_transformer_engine_linear` in `torch_autograd.py`)
+    # For more details, see docstring for `_rearrange_transformer_engine_linear` in transformer_engine_ex.py.
+    from thunder.tests.llama2_model import Transformer, ModelArgs
+    from thunder.core.proxies import variableify
+
+    init_method, world_size, rank, executor, device, dtype, _unused_kwargs = input_data
+    devicetype = devices.device_from_string(device).devicetype
+    _unused_dtype = ltorch.to_torch_dtype(dtype)
+    init_per_process_distributed(init_method, devicetype, world_size, rank)
+
+    fp8_recipe = get_default_fp8_recipe()
+
+    torch.cuda.set_device(rank)
+    # data
+    batch_size = 64
+    max_seq_len = 64
+    vocab_size = 64
+
+    model_args = dict(
+        dim=64,
+        n_layers=1,
+        n_heads=2,
+        n_kv_heads=2,
+        vocab_size=vocab_size,
+        multiple_of=32,
+        max_seq_len=max_seq_len,
+        dropout=0.0,
+        hidden_dim=64,
+    )
+    gptconf = ModelArgs(**model_args)
+    model = Transformer(gptconf)
+    model.to(device)
+    x = torch.randint(0, vocab_size, (batch_size, max_seq_len), dtype=torch.int64, device=device)
+    y = torch.randint(0, vocab_size, (batch_size, max_seq_len), dtype=torch.int64, device=device)
+    jit_model = thunder.distributed.ddp(
+        thunder.jit(
+            model,
+            executors=(transformer_engine_v2_ex,) + thunder.get_default_executors(),
+            transforms=[TransformerEngineTransformV2()],
+        )
+    )
+
+    sanity_exceptions = []
+    try:
+        for _ in range(5):
+            with fp8_autocast(fp8_recipe=fp8_recipe):
+                out = jit_model(x, y).sum()
+                out.backward()
+
+        fwd_exec_trace = thunder.last_traces(jit_model)[-1]
+        bwd_exec_trace = thunder.last_backward_traces(jit_model)[-1]
+
+        recipe_names = set()
+        num_fwd = 0
+        num_bwd = 0
+        num_amax_updates = 0
+        for bsym in bwd_exec_trace.bound_symbols:
+            if "get_te_fp8_recipe" in bsym.sym.name:
+                recipe_names.add(variableify(bsym.output))
+
+            if "te_functional_linear_fwd" in bsym.sym.name:
+                num_fwd += 1
+
+            if "te_functional_linear_bwd" in bsym.sym.name:
+                num_bwd += 1
+
+            if "te_fp8_amax_and_scale_update" in bsym.sym.name:
+                num_amax_updates += 1
+
+        for bsym in fwd_exec_trace.bound_symbols:
+            if "get_te_fp8_recipe" in bsym.sym.name:
+                recipe_names.add(variableify(bsym.output))
+
+            if "te_functional_linear_fwd" in bsym.sym.name:
+                num_fwd += 1
+
+            if "te_fp8_amax_and_scale_update" in bsym.sym.name:
+                num_amax_updates += 1
+
+        assert len(recipe_names) == 1, f"There should be only one recipe, found {len(recipe_names)}"
+
+        # For delayed scaling check that there are as many updates as there are fwd and bwd calls
+        if fp8_recipe.delayed():
+            assert num_fwd + num_bwd == num_amax_updates
+
+    except Exception as e:
+        sanity_exceptions.append(e)
+
+    if rank == 0:
+        return sanity_exceptions
+    return None
+
+
 # NOTE This is just a stub, see the NOTE for ddp_wrapper
 @instantiate(
     dtypes=(thunder.float32,),
@@ -627,6 +829,51 @@ def test_ddp_transformer_engine(executor, devices, dtype):
 )
 @distributed_wrapper("test_ddp_transformer_engine_llama_sanity", _test_ddp_transformer_engine_llama_sanity)
 def test_ddp_transformer_engine_llama_sanity(executor, devices, dtype):
+    pass
+
+
+@instantiate(
+    dtypes=(thunder.float32,),
+    num_devices=2,
+    devicetypes=(devices.DeviceType.CUDA,),
+    executors=(TorchExecutor,),
+    decorators=(
+        pytest.mark.skipif(not TE_AVAILABLE, reason="TransformerEngine is not installed."),
+        pytest.mark.skipif(not is_fp8_supported, reason=fp8_support_reason),
+        # NOTE: Setting `NVTE_TORCH_COMPILE`
+        # It is important to set this flag so that TE doesn't use
+        # `torch.compile` to fuse a few operations. This is because
+        # `torch.compile` creates a new process and that leads to
+        # the error : daemonic processes are not allowed to have children
+        # when running the tests.
+        # With the setting below, we use `torch.jit` for this test suite
+        # See: https://github.com/NVIDIA/TransformerEngine/blob/a38b291b0d1b04847e8ab1df8550df642a03a27d/transformer_engine/pytorch/jit.py#L11-L19
+        # NOTE: We don't pass `clear=True` to `unittest.mock.patch.dict` as that may clear paths
+        # from environment leading to picking up of incorrect dependencies in the spawned process.
+        unittest.mock.patch.dict(os.environ, {"NVTE_TORCH_COMPILE": "0"}),
+    ),
+)
+@distributed_wrapper("test_ddp_transformer_engine_v2", _test_ddp_transformer_engine_v2)
+def test_ddp_transformer_engine_v2(executor, devices, dtype):
+    pass
+
+
+@instantiate(
+    dtypes=(thunder.float32,),
+    num_devices=2,
+    devicetypes=(devices.DeviceType.CUDA,),
+    executors=(TorchExecutor,),
+    decorators=(
+        pytest.mark.skipif(not TE_AVAILABLE, reason="TransformerEngine is not installed."),
+        pytest.mark.skipif(not is_fp8_supported, reason=fp8_support_reason),
+        # See NOTE: Setting `NVTE_TORCH_COMPILE`
+        # NOTE: We don't pass `clear=True` to `unittest.mock.patch.dict` as that may clear paths
+        # from environment leading to picking up of incorrect dependencies in the spawned process.
+        unittest.mock.patch.dict(os.environ, {"NVTE_TORCH_COMPILE": "0"}),
+    ),
+)
+@distributed_wrapper("test_ddp_transformer_engine_v2_llama_sanity", _test_ddp_transformer_engine_v2_llama_sanity)
+def test_ddp_transformer_engine_v2_llama_sanity(executor, devices, dtype):
     pass
 
 

--- a/thunder/tests/distributed/test_fsdp.py
+++ b/thunder/tests/distributed/test_fsdp.py
@@ -28,6 +28,8 @@ from thunder.executors.transformer_engineex import (
     TE_AVAILABLE,
 )
 
+from thunder.executors.transformer_engine_v2ex import transformer_engine_v2_ex, TransformerEngineTransformV2
+
 
 is_fp8_supported: bool = False
 # This will be correctly updated below when TE Engine is installed
@@ -1053,6 +1055,266 @@ def test_fsdp_transformer_engine(executor, devices, dtype, thunder_fsdp_strategy
 )
 @distributed_wrapper("test_fsdp_transformer_engine_bucketing", _test_fsdp_transformer_engine_bucketing)
 def test_fsdp_transformer_engine_bucketing(executor, devices, dtype, thunder_fsdp_strategy_and_bucketing):
+    pass
+
+
+def _test_fsdp_transformer_engine_v2(input_data):
+    # Test Description: We run a dummy training loop for a simple `Linear(Relu(Linear(x)))`
+    # model with thunder (using TE executor) and with PyTorch eager + TE
+    # and verify that the weights have converged to same value after `n_iter`.
+
+    init_method, world_size, rank, executor, device, _unused_dtype, kwargs = input_data
+    thunder_fsdp_strategy, intermediate_activation_sharding = kwargs["thunder_fsdp_strategy_and_intermediate_sharding"]
+    devicetype = devices.device_from_string(device).devicetype
+
+    fp8_recipe = get_default_fp8_recipe()
+
+    # Setting LOCAL_RANK is necessary for thunder.distributed.fsdp
+    with unittest.mock.patch.dict(os.environ, {"LOCAL_RANK": str(rank)}):
+        init_per_process_distributed(init_method, devicetype, world_size, rank)
+        torch.cuda.set_device(rank)
+
+        dim = 256
+        # Running more iterations leads to `nan` for both eager and thunder
+        # with BlockScaling.
+        n_iter = 5
+
+        class ThunderModel(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.fc1 = torch.nn.Linear(dim, dim, bias=False)
+                self.fc2 = torch.nn.Linear(dim, dim, bias=False)
+
+            def forward(self, x):
+                return self.fc2(torch.nn.functional.relu(self.fc1(x)))
+
+        # Weights
+        fc1_weight = torch.randn(dim, dim, requires_grad=True, device="cuda")
+        fc2_weight = torch.randn(dim, dim, requires_grad=True, device="cuda")
+
+        # Inputs (different input on different rank).
+        if rank == 0:
+            x = torch.arange(dim * dim, dtype=torch.float, device="cuda").view(dim, dim)
+        if rank == 1:
+            x = torch.randn(dim, dim, device="cuda") * 100
+
+        with torch.device("cuda"):
+            thunder_model = ThunderModel()
+        thunder_model.fc1.weight.data = fc1_weight.clone()
+        thunder_model.fc2.weight.data = fc2_weight.clone()
+
+        jit_model = thunder.distributed.fsdp(
+            thunder.jit(
+                thunder_model,
+                executors=[
+                    transformer_engine_v2_ex,
+                ]
+                + executor.executors_list(),
+                fp8_shard_intermediate_activation=intermediate_activation_sharding,
+                transforms=[TransformerEngineTransformV2()],
+            ),
+            sharding_strategy=thunder_fsdp_strategy,
+        )
+
+        optim = torch.optim.SGD(jit_model.parameters())
+
+        for _ in range(n_iter):
+            with fp8_autocast(fp8_recipe=fp8_recipe):
+                o = jit_model(x).sum()
+            o.backward()
+            optim.step()
+            optim.zero_grad()
+
+        FP8GlobalStateManager.reset()
+
+        class TEModel(torch.nn.Module):
+            def __init__(self) -> None:
+                super().__init__()
+                self.fc1 = TELinear(dim, dim, bias=False)
+                self.fc2 = TELinear(dim, dim, bias=False)
+
+            def forward(self, x):
+                return self.fc2(torch.nn.functional.relu(self.fc1(x)))
+
+        with torch.device("cuda"):
+            te_model = TEModel()
+        te_model.fc1.weight.data = fc1_weight.clone()
+        te_model.fc2.weight.data = fc2_weight.clone()
+
+        fsdp_model = FullyShardedDataParallel(te_model, auto_wrap_policy=always_wrap_policy)
+        if intermediate_activation_sharding:
+            transformer_engine.pytorch.distributed.prepare_te_modules_for_fsdp(fsdp_model)
+        optim = torch.optim.SGD(te_model.parameters())
+
+        for _ in range(n_iter):
+            with fp8_autocast(fp8_recipe=fp8_recipe):
+                o = fsdp_model(x).sum()
+
+            o.backward()
+            optim.step()
+            optim.zero_grad()
+
+        # Compare weights after `n_iters`
+        comparison_exceptions = []
+        shard_size = int(dim / world_size)
+        fsdp_te_params = tuple(te_model.parameters())
+        try:
+            assert_close(jit_model.get_parameter("fc1.weight"), fsdp_te_params[0].view(shard_size, dim))
+            assert_close(jit_model.get_parameter("fc2.weight"), fsdp_te_params[1].view(shard_size, dim))
+        except Exception as e:
+            # Return exceptions only for rank==0
+            if rank == 0:
+                comparison_exceptions.append(e)
+
+        return comparison_exceptions
+
+
+def _test_fsdp_transformer_engine_v2_bucketing(input_data):
+    # Test Description: Test is to that TEv2 works with bucketing.
+    from thunder.tests.llama2_model import Transformer, ModelArgs
+
+    init_method, world_size, rank, executor, device, _unused_dtype, kwargs = input_data
+    thunder_fsdp_strategy, bucketing = kwargs["thunder_fsdp_strategy_and_bucketing"]
+    devicetype = devices.device_from_string(device).devicetype
+
+    fp8_recipe = get_default_fp8_recipe()
+
+    # Setting LOCAL_RANK is necessary for thunder.distributed.fsdp
+    with unittest.mock.patch.dict(os.environ, {"LOCAL_RANK": str(rank)}):
+        init_per_process_distributed(init_method, devicetype, world_size, rank)
+        torch.cuda.set_device(rank)
+
+        # data
+        batch_size = 64
+        max_seq_len = 64
+        vocab_size = 64
+
+        model_args = dict(
+            dim=64,
+            n_layers=2,
+            n_heads=2,
+            n_kv_heads=2,
+            vocab_size=vocab_size,
+            multiple_of=32,
+            max_seq_len=max_seq_len,
+            dropout=0.0,
+            hidden_dim=64,
+        )
+        gptconf = ModelArgs(**model_args)
+        model = Transformer(gptconf)
+        model.to(device)
+        x = torch.randint(0, vocab_size, (batch_size, max_seq_len), dtype=torch.int64, device=device)
+        y = torch.randint(0, vocab_size, (batch_size, max_seq_len), dtype=torch.int64, device=device)
+        jit_model = thunder.distributed.fsdp(
+            thunder.jit(
+                model,
+                executors=(transformer_engine_v2_ex,) + thunder.get_default_executors(),
+                transforms=[TransformerEngineTransformV2()],
+            ),
+            sharding_strategy=thunder_fsdp_strategy,
+            bucketing_strategy=bucketing,
+        )
+
+        sanity_exceptions = []
+        try:
+            for _ in range(5):
+                with fp8_autocast(fp8_recipe=fp8_recipe):
+                    out = jit_model(x, y).sum()
+                out.backward()
+
+            # Verifies te_linear was called
+            forward_trace = thunder.last_traces(jit_model)
+            backward_trace = thunder.last_backward_traces(jit_model)
+            assert any(bsym.sym.name.startswith("te_functional_linear_fwd") for bsym in forward_trace[-1].bound_symbols)
+            assert any(
+                bsym.sym.name.startswith("te_functional_linear_bwd") for bsym in backward_trace[-1].bound_symbols
+            )
+        except Exception as e:
+            sanity_exceptions.append(e)
+
+        if rank == 0:
+            return sanity_exceptions
+        return None
+
+
+# NOTE CPU is skipped because of
+# RuntimeError: no support for _allgather_base in Gloo process group
+@instantiate(
+    dtypes=(thunder.float32,),
+    num_devices=2,
+    devicetypes=(devices.DeviceType.CUDA,),
+    decorators=(
+        pytest.mark.parametrize(
+            "fsdp_bucketing_strategy",
+            (
+                FSDPBucketingStrategy.NONE,
+                FSDPBucketingStrategy.LAYER,
+                FSDPBucketingStrategy.BLOCK,
+            ),
+        ),
+    ),
+)
+@distributed_wrapper("test_native_fsdp", _test_native_fsdp_helper)
+def test_native_fsdp(executor, devices, dtype, fsdp_bucketing_strategy):
+    pass
+
+
+@instantiate(
+    dtypes=(thunder.float32,),
+    num_devices=2,
+    devicetypes=(devices.DeviceType.CUDA,),
+    executors=(TorchExecutor,),
+    decorators=(
+        # NOTE: ddp_wrapper
+        pytest.mark.parametrize(
+            "thunder_fsdp_strategy_and_intermediate_sharding",
+            (
+                (FSDPType.ZERO2, False),
+                (FSDPType.ZERO3, False),
+                # Intermediate sharding is only availabe TE v1.8 onwards
+                pytest.param(
+                    (FSDPType.ZERO3, True),
+                    marks=pytest.mark.skip("Intermediate sharding is errors in TE 2.0 (also with eager)."),
+                ),
+            ),
+        ),
+        pytest.mark.skipif(not TE_AVAILABLE, reason="TransformerEngine is not installed."),
+        pytest.mark.skipif(not is_fp8_supported, reason=fp8_support_reason),
+        # See NOTE: Setting `NVTE_TORCH_COMPILE`
+        # NOTE: We don't pass `clear=True` to `unittest.mock.patch.dict` as that may clear paths
+        # from environment leading to picking up of incorrect dependencies in the spawned process.
+        unittest.mock.patch.dict(os.environ, {"NVTE_TORCH_COMPILE": "0"}),
+    ),
+)
+@distributed_wrapper("test_fsdp_transformer_engine_v2", _test_fsdp_transformer_engine_v2)
+def test_fsdp_transformer_engine_v2(executor, devices, dtype, thunder_fsdp_strategy_and_intermediate_sharding):
+    pass
+
+
+@instantiate(
+    dtypes=(thunder.float32,),
+    num_devices=2,
+    devicetypes=(devices.DeviceType.CUDA,),
+    executors=(TorchExecutor,),
+    decorators=(
+        # NOTE: ddp_wrapper
+        pytest.mark.parametrize(
+            "thunder_fsdp_strategy_and_bucketing",
+            (
+                (FSDPType.ZERO3, FSDPBucketingStrategy.LAYER),
+                (FSDPType.ZERO3, FSDPBucketingStrategy.BLOCK),
+            ),
+        ),
+        pytest.mark.skipif(not TE_AVAILABLE, reason="TransformerEngine is not installed."),
+        pytest.mark.skipif(not is_fp8_supported, reason=fp8_support_reason),
+        # See NOTE: Setting `NVTE_TORCH_COMPILE`
+        # NOTE: We don't pass `clear=True` to `unittest.mock.patch.dict` as that may clear paths
+        # from environment leading to picking up of incorrect dependencies in the spawned process.
+        unittest.mock.patch.dict(os.environ, {"NVTE_TORCH_COMPILE": "0"}),
+    ),
+)
+@distributed_wrapper("test_fsdp_transformer_engine_v2_bucketing", _test_fsdp_transformer_engine_v2_bucketing)
+def test_fsdp_transformer_engine_v2_bucketing(executor, devices, dtype, thunder_fsdp_strategy_and_bucketing):
     pass
 
 

--- a/thunder/tests/test_transformer_engine_v2_executor.py
+++ b/thunder/tests/test_transformer_engine_v2_executor.py
@@ -518,6 +518,11 @@ def test_te_activation_checkpointing_correctness(fp8_recipe: recipe.Recipe, comp
     device = "cuda"
     iterations = 6
 
+    from transformer_engine.pytorch.fp8 import FP8GlobalStateManager
+
+    # Before starting, reset the state manager.
+    FP8GlobalStateManager.reset()
+
     checkpoint_fn = partial(torch.utils.checkpoint.checkpoint, use_reentrant=False)
 
     input_shape = (768, 4096)
@@ -555,8 +560,6 @@ def test_te_activation_checkpointing_correctness(fp8_recipe: recipe.Recipe, comp
 
     # TE does not expose the scales for MXFP8
     if fp8_recipe.delayed():
-        from transformer_engine.pytorch.fp8 import FP8GlobalStateManager
-
         te_scales = []
         te_amax_hist = []
         with te.fp8_autocast(enabled=True, fp8_recipe=fp8_recipe):
@@ -642,6 +645,3 @@ def test_te_activation_checkpointing_correctness(fp8_recipe: recipe.Recipe, comp
         # check that amax history is the same as TE
         for te_amax, th_amax in zip(te_amax_hist, th_amax_hist):
             assert_close(te_amax[:, :-1], th_amax)
-
-        # Reset state manager before next run.
-        FP8GlobalStateManager.reset()


### PR DESCRIPTION
This PR will close #2081 by adding multi-gpu tests for TEv2. 

Moreover this adds an amax reduction which is needed for delayed scaling in a distributed context, ref:

https://github.com/NVIDIA/TransformerEngine/blob/dd083bdfca296294322f2b5f8143ce54ee15db22/transformer_engine/pytorch/fp8.py#L391-L397

https://github.com/NVIDIA/TransformerEngine/blob/dd083bdfca296294322f2b5f8143ce54ee15db22/transformer_engine/pytorch/fp8.py#L361-L370
 
