### PR TITLE
re-enable cuda-python nb

### DIFF
--- a/notebooks/extend_thunder_with_cuda_python.ipynb
+++ b/notebooks/extend_thunder_with_cuda_python.ipynb
@@ -334,7 +334,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "4628c9c2",
    "metadata": {
     "hideCode": false,
@@ -371,7 +371,7 @@
     "    block = block + (3 - len(block)) * (1,)\n",
     "    \n",
     "    # Launch!\n",
-    "    err, = cuda.cuLaunchKernel(\n",
+    "    err, = driver.cuLaunchKernel(\n",
     "       kernel,\n",
     "       *grid, *block, # xyz each\n",
     "       shmem,  # dynamic shared memory\n",
@@ -379,7 +379,7 @@
     "       args.ctypes.data,  # kernel arguments\n",
     "       0,  # extra (ignore)\n",
     "    )\n",
-    "    if err != cuda.CUresult.CUDA_SUCCESS:\n",
+    "    if err != driver.CUresult.CUDA_SUCCESS:\n",
     "        raise RuntimeError(f\"CUDA error: {err}\")"
    ]
   },

--- a/notebooks/extend_thunder_with_cuda_python.ipynb
+++ b/notebooks/extend_thunder_with_cuda_python.ipynb
@@ -229,7 +229,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "471a1133",
    "metadata": {
     "hideCode": false,
@@ -238,7 +238,7 @@
    },
    "outputs": [],
    "source": [
-    "from cuda import cuda, nvrtc"
+    "from cuda.bindings import driver, nvrtc"
    ]
   },
   {
@@ -257,7 +257,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "017cd520",
    "metadata": {
     "hideCode": false,
@@ -277,9 +277,9 @@
     "\n",
     "    def check_error(results):\n",
     "        err, *results = results\n",
-    "        if isinstance(err, cuda.CUresult):\n",
-    "            if err != cuda.CUresult.CUDA_SUCCESS:\n",
-    "                _, err_str = cuda.cuGetErrorString(err)\n",
+    "        if isinstance(err, driver.CUresult):\n",
+    "            if err != driver.CUresult.CUDA_SUCCESS:\n",
+    "                _, err_str = driver.cuGetErrorString(err)\n",
     "                raise RuntimeError(f\"CUDA error: {err_str.decode()}\")\n",
     "        elif isinstance(err, nvrtc.nvrtcResult):\n",
     "            if err != nvrtc.nvrtcResult.NVRTC_SUCCESS:\n",
@@ -313,8 +313,8 @@
     "    check_error(nvrtc.nvrtcGetPTX(prog, ptx))\n",
     "\n",
     "    # Load PTX as module data and retrieve function\n",
-    "    module = check_error(cuda.cuModuleLoadData(ptx))\n",
-    "    kernel = check_error(cuda.cuModuleGetFunction(module, function_name.encode()))\n",
+    "    module = check_error(driver.cuModuleLoadData(ptx))\n",
+    "    kernel = check_error(driver.cuModuleGetFunction(module, function_name.encode()))\n",
     "    return kernel"
    ]
   },

--- a/requirements/notebooks.txt
+++ b/requirements/notebooks.txt
@@ -4,5 +4,5 @@
 ipython[all] ~=8.37.0
 numpy
 liger-kernel == 0.4.0
-cuda-python
+cuda-python >=12.6.1, <14.0.0
 litgpt == 0.5.1

--- a/requirements/notebooks.txt
+++ b/requirements/notebooks.txt
@@ -4,5 +4,5 @@
 ipython[all] ~=8.37.0
 numpy
 liger-kernel == 0.4.0
-cuda-python >=12.0, <13.0.0  # todo
+cuda-python
 litgpt == 0.5.1


### PR DESCRIPTION
Was disabled in https://github.com/Lightning-AI/lightning-thunder/pull/2410

Few modules from cuda-python were updated - https://nvidia.github.io/cuda-python/cuda-bindings/13.0.0/release/13.0.0-notes.html#breaking-changes

cc @borda