### PR TITLE
nvfuserex: return cumsum result in `int64` when input is int/bool and result dtypes is not specified

### DIFF
--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -3139,7 +3139,7 @@ def cumsum_transform(
         compute_dtype = lcdtype_to_nvdtype(a.dtype)
 
     if dtype is None:
-        out_dtype = lcdtype_to_nvdtype(a.dtype)
+        out_dtype = lcdtype_to_nvdtype(a.dtype if a.dtype not in dtypes.integer_dtypes else dtypes.int64)
     else:
         out_dtype = lcdtype_to_nvdtype(dtypes.to_dtype(dtype))
 

--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -6265,8 +6265,8 @@ def cumsum_sample_generator(op, device, dtype, requires_grad, **kwargs):
 
     for shape, dim in cases:
         # torch.cumsum not implemented for dtype='Bool'
-        output_dtype = torch.float if dtype is torch.bool else dtype
-        yield (SampleInput(make(shape), dim, dtype=output_dtype))
+        for output_dtype in (None, torch.float if dtype is torch.bool else dtype):
+            yield (SampleInput(make(shape), dim, dtype=output_dtype))
 
 
 cumsum_opinfo = OpInfo(


### PR DESCRIPTION
## What does this PR do?

Fix dtype mismatch between pytorch and nvfuser when `a` is int/bool and `dtype` is `None`.
Following #1953.

An alternative could be register `cumsum_transform` for `clang` and/or `prim` cumsum, rather than `ltorch`.