### PR TITLE
thunderfx: Avoid failure when `example_value` does not have attr of `grad_fn`

### DIFF
--- a/thunder/dynamo/splitter.py
+++ b/thunder/dynamo/splitter.py
@@ -172,7 +172,8 @@ def _splitter(
             for n in graph_module.graph.nodes:
                 if n.op == "output":
                     for n in n.all_input_nodes:
-                        if n.meta["example_value"].grad_fn is None:
+                        # `n.meta["example_value"]` could be `torch.SymInt`.
+                        if getattr(n.meta["example_value"], "grad_fn", None) is None:
                             is_differentiable_outputs.append(False)
                         else:
                             is_differentiable_outputs.append(True)

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -1686,3 +1686,27 @@ def test_thunderfx_with_intermediate_output_marked_as_non_differentiable():
         actual_output.backward()
         expected_output.backward()
         torch.testing.assert_close(org_m.fc.weight.grad, thunder_m.fc.weight.grad)
+
+
+# Ref: https://github.com/Lightning-AI/lightning-thunder/issues/2420
+def test_splitter_with_symint_node():
+
+    class GraphModule(torch.nn.Module):
+        def forward(self, L_self_cumulative_length_1_: "Sym(s27)"):
+            l_self_cumulative_length_1_ = L_self_cumulative_length_1_
+
+            add: "Sym(s27 + 1)" = l_self_cumulative_length_1_ + 1
+            l_self_cumulative_length_1_ = None
+            return (add,)
+
+    module = GraphModule()
+    ref_inputs = (100,)
+    reference = module(*ref_inputs)
+
+    jitted = thunderfx(GraphModule(), dynamic=True)
+    inputs = (100,)
+    actual = jitted(*inputs)
+    assert reference == actual
+
+    for subgraph in jitted._backend.subgraph_infos:
+        assert not subgraph.split_reasons

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -1690,7 +1690,6 @@ def test_thunderfx_with_intermediate_output_marked_as_non_differentiable():
 
 # Ref: https://github.com/Lightning-AI/lightning-thunder/issues/2420
 def test_splitter_with_symint_node():
-
     class GraphModule(torch.nn.Module):
         def forward(self, L_self_cumulative_length_1_: "Sym(s27)"):
             l_self_cumulative_length_1_ = L_self_cumulative_length_1_


### PR DESCRIPTION
Running the script of #2416 of 91289af7fcdc6ee9fafc497ec28bbd620900c819 with #2418, the following failure would happen:
```
[rank0]:   File "/opt/pytorch/lightning-thunder/thunder/dynamo/compiler.py", line 117, in __call__
[rank0]:     split_module, subgraph_info = _splitter(gm, self._thunder_jit, self._torch_compile, sample_args)
[rank0]:                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]:   File "/opt/pytorch/lightning-thunder/thunder/dynamo/splitter.py", line 176, in _splitter
[rank0]:     if n.meta["example_value"].grad_fn is None:
[rank0]:        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank0]: torch._dynamo.exc.BackendCompilerFailed: backend='<thunder.dynamo.compiler.ThunderCompiler object at 0x7f1f2bc3bce0>' raised:
[rank0]: AttributeError: 'SymInt' object has no attribute 'grad_fn'
```
Apparently, a straightforward fix/workaround would be this PR.
