### PR TITLE
thunderfx: handle output node with no example_value

### DIFF
--- a/thunder/dynamo/splitter.py
+++ b/thunder/dynamo/splitter.py
@@ -172,7 +172,7 @@ def _splitter(
             for n in graph_module.graph.nodes:
                 if n.op == "output":
                     for n in n.all_input_nodes:
-                        if n.meta["example_value"].grad_fn is None:
+                        if "example_value" not in n.meta or n.meta["example_value"].grad_fn is None:
                             is_differentiable_outputs.append(False)
                         else:
                             is_differentiable_outputs.append(True)

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -1686,3 +1686,15 @@ def test_thunderfx_with_intermediate_output_marked_as_non_differentiable():
         actual_output.backward()
         expected_output.backward()
         torch.testing.assert_close(org_m.fc.weight.grad, thunder_m.fc.weight.grad)
+
+
+def test_thunderfx_node_with_no_example_value():
+    def test_fn(x):
+        y = x + 10
+        z = y.tolist()[0]
+        return z + 2
+
+    x = torch.tensor([1, 2, 3, 4, 5])
+    actual = thunderfx(test_fn)(x)
+    expected = test_fn(x)
+    torch.testing.assert_close(actual, expected)


### PR DESCRIPTION
It is possible to have nodes with no `example_value` which could end up being an output node after splitter. This is happens for "ibm-granite/granite-3.1-3b-a800m-instruct"

NOTE: There is a graph-break at `tolist` if the tensor is floating type.

Example of graph where node may have no example value
```python
import torch

def test_fn(x):
    y = (x + 10)
    z = y.tolist()[0]
    return z + 2

x = torch.tensor([1, 2, 3, 4, 5])

def backend(gm, inps):
    gm.print_readable()
    # def forward(self, L_x_: "i64[5]"):
    #     l_x_ = L_x_
        
    #      # File: /opt/pytorch/lightning-thunder/test.py:4 in test_fn, code: y = (x + 10)
    #     y: "i64[5]" = l_x_ + 10;  l_x_ = None
        
    #      # File: /opt/pytorch/lightning-thunder/test.py:5 in test_fn, code: z = y.tolist()[0]
    #     getitem = y[0];  y = None
    #     item: "Sym(u0)" = getitem.item();  getitem = None
        
    #      # File: /opt/pytorch/lightning-thunder/test.py:6 in test_fn, code: return z + 2
    #     add_1: "Sym(u0 + 2)" = item + 2;  item = None
    #     return (add_1,)

    for node in gm.graph.nodes:
        if "example_value" not in node.meta:
            print(node)  # prints `getitem` and `output`
    return gm

torch.compile(test_fn, backend=backend)(x)

from thunder.dynamo import thunderfx

model = thunderfx(test_fn)

#   File "/opt/pytorch/lightning-thunder/thunder/dynamo/splitter.py", line 175, in _splitter
#     if n.meta["example_value"].grad_fn is None:
#        ~~~~~~^^^^^^^^^^^^^^^^^
# torch._dynamo.exc.BackendCompilerFailed: backend='<thunder.dynamo.compiler.ThunderCompiler object at 0x70b657217800>' raised:
# KeyError: 'example_value'
model(x)
```