### PR TITLE
Add scatter support in nvfuserex

### DIFF
--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -2756,57 +2756,6 @@ register_supported(PrimIDs.EMBEDDING, embedding, _embedding_check)
 register_supported(ltorch.embedding, embedding, _embedding_check)
 
 
-<<<<<<< Updated upstream
-=======
-def _index_put_check(a: TensorProxy, /, indices: Sequence[TensorProxy], values: TensorProxy, accumulate: bool) -> bool:
-    # temporary flag to allow scatter-like operations to be consumed by nvfuserex
-    enable_scatter: None | bool = get_compile_option("nv_enable_scatter", "Enable nvFuser scatter-like operations.")
-    if not enable_scatter:
-        return False
-
-    # TODO: limited support inside nvfuser. remove this when codegen support is generalized.
-    if len(indices) != 1 or indices[0].ndim != 1:
-        return False
-
-    if accumulate == True:
-        return False
-
-    return True
-
-
-def index_put(
-    a: TensorProxy,
-    /,
-    indices: Sequence[TensorProxy],
-    values: TensorProxy,
-    accumulate: bool,
-    *,
-    fd: FusionDefinition,
-    lc_to_nv_map: dict,
-) -> any:
-    utils.check(
-        not accumulate, lambda: "Unsupported accumulate in index_put by nvfuserex", exception_type=AssertionError
-    )
-    nva = getnv(a, fd, lc_to_nv_map)
-    nvi = getnv(indices[0], fd, lc_to_nv_map)
-    # construct the shape of broadcast indices tensor as
-    # [-1, *a.shape[1:]]
-    shapes = nva.shape()
-    flag = [-1]
-    for i in range(1, nva.ndim):
-        flag += [shapes[i]]
-    # broadcast index tensor nvi to abide to scatter semantics
-    nvi_b = fd.ops.broadcast_in_dim(nvi, flag, [0])
-
-    nvs = getnv(values, fd, lc_to_nv_map)
-
-    # index_put is translated to scatter in nvfuser
-    return fd.ops.scatter(nva, nvi_b, nvs, 0)
-
-
-register_supported(PrimIDs.INDEX_PUT, index_put, _index_put_check)
-
-
 def _scatter_check(a: TensorProxy, /, index: TensorProxy, src: TensorProxy | Number, dim: int) -> bool:
     # temporary flag to allow scatter-like operations to be consumed by nvfuserex
     enable_scatter: None | bool = get_compile_option("nv_enable_scatter", "Enable nvFuser scatter-like operations.")
@@ -2828,7 +2777,6 @@ def scatter(a: TensorProxy, /, index: TensorProxy, src: TensorProxy | Number, di
 register_supported(PrimIDs.SCATTER, scatter, _scatter_check)
 
 
->>>>>>> Stashed changes
 def _cross_entropy_check(
     a: TensorLike,
     /,

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -2765,7 +2765,11 @@ def _scatter_check(a: TensorProxy, /, index: TensorProxy, src: TensorProxy | Num
     return True
 
 
-def scatter(a: TensorProxy, /, index: TensorProxy, src: TensorProxy | Number, dim: int) -> TensorProxy:
+def scatter(a: TensorProxy, /, index: TensorProxy, src: TensorProxy | Number, dim: int,
+    *,
+    fd: FusionDefinition,
+    lc_to_nv_map: dict,
+) -> Any:
     nva = getnv(a, fd, lc_to_nv_map)
     nvi = getnv(index, fd, lc_to_nv_map)
     nvs = getnv(src, fd, lc_to_nv_map)

--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -2756,6 +2756,79 @@ register_supported(PrimIDs.EMBEDDING, embedding, _embedding_check)
 register_supported(ltorch.embedding, embedding, _embedding_check)
 
 
+<<<<<<< Updated upstream
+=======
+def _index_put_check(a: TensorProxy, /, indices: Sequence[TensorProxy], values: TensorProxy, accumulate: bool) -> bool:
+    # temporary flag to allow scatter-like operations to be consumed by nvfuserex
+    enable_scatter: None | bool = get_compile_option("nv_enable_scatter", "Enable nvFuser scatter-like operations.")
+    if not enable_scatter:
+        return False
+
+    # TODO: limited support inside nvfuser. remove this when codegen support is generalized.
+    if len(indices) != 1 or indices[0].ndim != 1:
+        return False
+
+    if accumulate == True:
+        return False
+
+    return True
+
+
+def index_put(
+    a: TensorProxy,
+    /,
+    indices: Sequence[TensorProxy],
+    values: TensorProxy,
+    accumulate: bool,
+    *,
+    fd: FusionDefinition,
+    lc_to_nv_map: dict,
+) -> any:
+    utils.check(
+        not accumulate, lambda: "Unsupported accumulate in index_put by nvfuserex", exception_type=AssertionError
+    )
+    nva = getnv(a, fd, lc_to_nv_map)
+    nvi = getnv(indices[0], fd, lc_to_nv_map)
+    # construct the shape of broadcast indices tensor as
+    # [-1, *a.shape[1:]]
+    shapes = nva.shape()
+    flag = [-1]
+    for i in range(1, nva.ndim):
+        flag += [shapes[i]]
+    # broadcast index tensor nvi to abide to scatter semantics
+    nvi_b = fd.ops.broadcast_in_dim(nvi, flag, [0])
+
+    nvs = getnv(values, fd, lc_to_nv_map)
+
+    # index_put is translated to scatter in nvfuser
+    return fd.ops.scatter(nva, nvi_b, nvs, 0)
+
+
+register_supported(PrimIDs.INDEX_PUT, index_put, _index_put_check)
+
+
+def _scatter_check(a: TensorProxy, /, index: TensorProxy, src: TensorProxy | Number, dim: int) -> bool:
+    # temporary flag to allow scatter-like operations to be consumed by nvfuserex
+    enable_scatter: None | bool = get_compile_option("nv_enable_scatter", "Enable nvFuser scatter-like operations.")
+    if not enable_scatter:
+        return False
+
+    return True
+
+
+def scatter(a: TensorProxy, /, index: TensorProxy, src: TensorProxy | Number, dim: int) -> TensorProxy:
+    nva = getnv(a, fd, lc_to_nv_map)
+    nvi = getnv(index, fd, lc_to_nv_map)
+    nvs = getnv(src, fd, lc_to_nv_map)
+
+    # index_put is translated to scatter in nvfuser
+    return fd.ops.scatter(nva, nvi, nvs, 0)
+    
+
+register_supported(PrimIDs.SCATTER, scatter, _scatter_check)
+
+
+>>>>>>> Stashed changes
 def _cross_entropy_check(
     a: TensorLike,
     /,

--- a/thunder/tests/test_nvfuser.py
+++ b/thunder/tests/test_nvfuser.py
@@ -979,12 +979,12 @@ def test_scatter(executor, device: str, dtype: dtypes.dtype):
         idxs: torch.Tensor
         src: torch.Tensor
         inp, idxs, src = inputs
-        out = torch.scatter(inp, idx, src, 0)
+        out = torch.scatter(inp, 0, idxs, src)
         return out
 
     bsz = 4
     hidden = 8
-    scatter_size = 64
+    scatter_size = 3
     x = torch.randn([bsz, hidden], device=device, dtype=dtype)
     _, ind = torch.topk(x, k=scatter_size, dim=0)
     src = torch.randn(scatter_size, hidden, device=device, dtype=dtype)

--- a/thunder/tests/test_nvfuser.py
+++ b/thunder/tests/test_nvfuser.py
@@ -967,3 +967,41 @@ def test_slice_dynamic_extent(executor, device: str, dtype: dtypes.dtype):
 
     outside_fusion_syms = ["unpack_trivial", "python_return"]
     assert {el.sym.name for el in fw_trace.bound_symbols if not el.sym.is_fusion} == set(outside_fusion_syms)
+
+
+@instantiate(
+    executors=(nvFuserExecutor,),
+    dtypes=NOTHING,
+)
+def test_scatter(executor, device: str, dtype: dtypes.dtype):
+    def foo(inputs: list):
+        inp: torch.Tensor
+        idxs: torch.Tensor
+        src: torch.Tensor
+        inp, idxs, src = inputs
+        out = torch.scatter(inp, idx, src, 0)
+        return out
+
+    bsz = 4
+    hidden = 8
+    scatter_size = 64
+    x = torch.randn([bsz, hidden], device=device, dtype=dtype)
+    _, ind = torch.topk(x, k=scatter_size, dim=0)
+    src = torch.randn(scatter_size, hidden, device=device, dtype=dtype)
+
+    # NOTE nv_enable_scatter to allow scatter operation to go through nvfuser
+    jfoo = thunder.jit(foo, nv_enable_scatter=True)
+
+    inputs = [x, ind, src]
+
+    actual = jfoo(inputs)
+    expected = foo(inputs)
+    torch.testing.assert_close(actual, expected)
+
+    fw_trace = thunder.last_traces(jfoo)[-1]
+    fusion_bsyms = tuple(filter(lambda a: a.sym.is_fusion, fw_trace.bound_symbols))
+
+    # assert that everything is merged as a single nvfuser operation
+    assert len(fusion_bsyms) == 1
+    outside_fusion_syms = ["unpack_trivial", "python_return"]
+    assert {el.sym.name for el in fw_trace.bound_symbols if not el.sym.is_fusion} == set(outside_fusion_syms)


### PR DESCRIPTION
only optionally enabled via `nv_enable_scatter` flag since the codegen support is still under development.