### PR TITLE
Fix memory leak due to CompileData being in a cycle

### DIFF
--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -779,10 +779,10 @@ def jit(
         return wrapped
 
     get_computation_and_inputs = decorate_computation_function(get_computation_and_inputs, host_execution_timer)
-    cd.get_computation_and_inputs = get_computation_and_inputs
-    cd.populate_cache_info = populate_cache_info
-    cd.acquire_initial_trace = acquire_initial_trace
-    cd.apply_transforms_and_build_cache_entry = apply_transforms_and_build_cache_entry
+    # cd.get_computation_and_inputs = get_computation_and_inputs
+    # cd.populate_cache_info = populate_cache_info
+    # cd.acquire_initial_trace = acquire_initial_trace
+    # cd.apply_transforms_and_build_cache_entry = apply_transforms_and_build_cache_entry
 
     def update_call_statistics(fn):
         def wrapped(*args, **kwargs):
@@ -846,7 +846,7 @@ def jit(
         cd._thunder_module_map[id(fn)] = fn_
 
     # Sets compile options and statistics attributes
-    cd._get_computation_and_inputs = get_computation_and_inputs
+    # cd._get_computation_and_inputs = get_computation_and_inputs
     fn_._lc_cd = cd
     fn_._lc_cs = cs
 


### PR DESCRIPTION
In `thunder.jit`, there is a pattern that function where inner function like `populate_cache_info` captures `cd` (CompileData) and later there is `cd.populate_cache_info = populate_cache_info` which leads to a reference cycle leading to memory leak. (This also happens with other inner functions like `get_computation_and_inputs`, `acquire_initial_trace`, etc.

https://github.com/Lightning-AI/lightning-thunder/blob/9918ec734cfc838df41483b63b3bb90b3c7dd31d/thunder/__init__.py#L607
https://github.com/Lightning-AI/lightning-thunder/blob/9918ec734cfc838df41483b63b3bb90b3c7dd31d/thunder/__init__.py#L783

Example Cycle: 
<img width="617" height="459" alt="image" src="https://github.com/user-attachments/assets/92fd0fba-96eb-4222-9474-ac7c9a0c5006" />

Repro:
```python
import torch
import thunder
import weakref


memory_at_start = torch.cuda.memory_allocated()

def _allocate_model_in_function():
    model = torch.nn.Linear(256, 256, device="cuda")

    tfn = thunder.jit(model)
    cd = tfn._lc_cd
    return weakref.ref(cd), weakref.ref(model)

refs = _allocate_model_in_function()

assert torch.cuda.memory_allocated() == memory_at_start
for ref in refs:
    assert ref() is None
```