### PR TITLE
Break ref cycle in interpreter.py:fn_

### DIFF
--- a/thunder/core/interpreter.py
+++ b/thunder/core/interpreter.py
@@ -7514,7 +7514,7 @@ def interpret(
     if hasattr(fn, "__thunder_interpreter_orig_fn"):
         fn = fn.__thunder_interpreter_orig_fn
 
-    interpreter_log = []
+    interpreter_log: list[InterpreterLogItem] = []
 
     @functools.wraps(fn)
     def fn_(*args, **kwargs) -> Any:
@@ -7572,9 +7572,7 @@ def interpret(
                     del e
                     raise
 
-            # NOTE: Wrapped functions are valid to assign new attributes to.
-            # interpreter_log = runtimectx.interp_log  # type: ignore
-            fn_._last_interpreter_log = runtimectx.interp_log  # type: ignore
+            interpreter_log = runtimectx.interp_log
 
             if interpretation_result is INTERPRETER_SIGNALS.EXCEPTION_RAISED:
                 e = runtimectx.curexc
@@ -7590,7 +7588,7 @@ def interpret(
             return interpretation_result
 
     fn_.__thunder_interpreter_orig_fn = fn  # type: ignore
-    fn_._last_interpreter_log = interpreter_log  # type: ignore
+    fn_._last_interpreter_log = interpreter_log  # type:ignore
     return fn_
 
 

--- a/thunder/core/interpreter.py
+++ b/thunder/core/interpreter.py
@@ -7514,6 +7514,8 @@ def interpret(
     if hasattr(fn, "__thunder_interpreter_orig_fn"):
         fn = fn.__thunder_interpreter_orig_fn
 
+    interpreter_log = []
+
     @functools.wraps(fn)
     def fn_(*args, **kwargs) -> Any:
         runtimectx: InterpreterRuntimeCtx = InterpreterRuntimeCtx(debug_log=debug_log, record_history=record_history)
@@ -7571,6 +7573,7 @@ def interpret(
                     raise
 
             # NOTE: Wrapped functions are valid to assign new attributes to.
+            # interpreter_log = runtimectx.interp_log  # type: ignore
             fn_._last_interpreter_log = runtimectx.interp_log  # type: ignore
 
             if interpretation_result is INTERPRETER_SIGNALS.EXCEPTION_RAISED:
@@ -7587,6 +7590,7 @@ def interpret(
             return interpretation_result
 
     fn_.__thunder_interpreter_orig_fn = fn  # type: ignore
+    fn_._last_interpreter_log = interpreter_log  # type: ignore
     return fn_
 
 


### PR DESCRIPTION
Related https://github.com/Lightning-AI/lightning-thunder/issues/2458

Unfortunately, this doesn't completely fix #2458 as there seems to be another cycle after this patch - 
<img width="283" height="198" alt="image" src="https://github.com/user-attachments/assets/429422b8-b298-4bb1-961c-f60d4a5b43f3" />
