### PR TITLE
Fix memory leak related to prologue holding onto user passed nn.Module

### DIFF
--- a/thunder/core/trace.py
+++ b/thunder/core/trace.py
@@ -7,7 +7,6 @@ from typing import Any
 from enum import Enum
 from collections.abc import Callable
 from types import ModuleType
-import weakref
 
 import thunder
 import thunder.core.codeutils as codeutils


### PR DESCRIPTION
Ref: #2458 

Cycle:

<img width="283" height="198" alt="image" src="https://github.com/user-attachments/assets/fbb01947-3353-41de-8102-8501bdcced8e" />


Path from object in cycle to the nn.Module

<img width="456" height="570" alt="image" src="https://github.com/user-attachments/assets/695538e7-cfe5-4efc-9f51-5c8c582cb914" />

Failed Patch: Trying to do `ctx["__function_obj"] = weakref.ref(self.fn)` but it fails with `TypeError: cannot create weak reference to 'Symbol' object`

<details>

```patch
From a5649aa7272f2da53377eba025179500fd392822 Mon Sep 17 00:00:00 2001
From: kshitij12345 <kshitijkalambarkar@gmail.com>
Date: Mon, 25 Aug 2025 12:20:10 -0700
Subject: [PATCH 1/3] Fix memory leak related to prologue holding onto user
 passed nn.Module

---
 thunder/core/module.py | 2 ++
 thunder/core/prims.py  | 2 +-
 thunder/core/trace.py  | 7 +++++--
 3 files changed, 8 insertions(+), 3 deletions(-)

diff --git a/thunder/core/module.py b/thunder/core/module.py
index 5454a1c121..cefcd1ddfe 100644
--- a/thunder/core/module.py
+++ b/thunder/core/module.py
@@ -388,6 +388,8 @@ def __getattr__(self, name: str) -> Any:
 
 
 def get_thunder_module(model):
+    assert model() is not None
+    model = model()
     cd = get_compile_data()
 
     # to not hold a reference to model in the _thunder_module_map dict, we index by id.
diff --git a/thunder/core/prims.py b/thunder/core/prims.py
index 32852215f8..fe04be4eb6 100644
--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -732,7 +732,7 @@ def unpack_function_obj_printer(
     )
 
     result_str = "_" if bsym.output is None else f"{codeutils.prettyprint(out_printables, with_type=True)}"
-    s = f"{result_str} = globals()['__function_obj']"
+    s = f"{result_str} = globals()['__function_obj_weakref']"
     return s
 
 
diff --git a/thunder/core/trace.py b/thunder/core/trace.py
index 50a8c2e4aa..dfd1f5f2ed 100644
--- a/thunder/core/trace.py
+++ b/thunder/core/trace.py
@@ -7,6 +7,7 @@
 from enum import Enum
 from collections.abc import Callable
 from types import ModuleType
+import weakref
 
 import thunder
 import thunder.core.codeutils as codeutils
@@ -490,13 +491,15 @@ def python_callable(self, *, global_dicts: None | dict = None, **kwargs: Any) ->
         ctx = self.python_ctx()
         if global_dicts is not None:
             ctx["__global_dicts"] = global_dicts
-        ctx["__function_obj"] = self.fn
+        ctx["__function_obj_weakref"] = weakref.ref(self.fn) if self.fn is not None else None
         ctx["thunder"] = thunder
 
-        return baseutils.build_callable(
+        callable = baseutils.build_callable(
             self.siginfo().name, python_str=python_str, file_name=f"thunder.{self.siginfo().name}", ctx=ctx
         )
 
+        return callable
+
     def __repr__(self) -> str:
         return self.python(print_depth=-1)
 

From 183016a0afde8a0568673f50bc7d03450d76b389 Mon Sep 17 00:00:00 2001
From: kshitij12345 <kshitijkalambarkar@gmail.com>
Date: Mon, 25 Aug 2025 12:23:14 -0700
Subject: [PATCH 2/3] undo unncessary change

---
 thunder/core/trace.py | 4 +---
 1 file changed, 1 insertion(+), 3 deletions(-)

diff --git a/thunder/core/trace.py b/thunder/core/trace.py
index dfd1f5f2ed..f64ce1399d 100644
--- a/thunder/core/trace.py
+++ b/thunder/core/trace.py
@@ -494,12 +494,10 @@ def python_callable(self, *, global_dicts: None | dict = None, **kwargs: Any) ->
         ctx["__function_obj_weakref"] = weakref.ref(self.fn) if self.fn is not None else None
         ctx["thunder"] = thunder
 
-        callable = baseutils.build_callable(
+        return baseutils.build_callable(
             self.siginfo().name, python_str=python_str, file_name=f"thunder.{self.siginfo().name}", ctx=ctx
         )
 
-        return callable
-
     def __repr__(self) -> str:
         return self.python(print_depth=-1)
 

From 512fc2b85a272f3d411115d731a333a531366e83 Mon Sep 17 00:00:00 2001
From: kshitij12345 <kshitijkalambarkar@gmail.com>
Date: Mon, 25 Aug 2025 12:35:24 -0700
Subject: [PATCH 3/3] consider get_thunder_module may get an actual module

---
 thunder/core/module.py | 8 ++++++--
 1 file changed, 6 insertions(+), 2 deletions(-)

diff --git a/thunder/core/module.py b/thunder/core/module.py
index cefcd1ddfe..4f733d9306 100644
--- a/thunder/core/module.py
+++ b/thunder/core/module.py
@@ -3,6 +3,7 @@
 import itertools
 from typing import TYPE_CHECKING
 import collections
+import weakref
 
 import torch as pytorch
 from torch.utils.weak import WeakTensorKeyDictionary
@@ -388,8 +389,11 @@ def __getattr__(self, name: str) -> Any:
 
 
 def get_thunder_module(model):
-    assert model() is not None
-    model = model()
+    if isinstance(model, weakref.ReferenceType):
+        # NOTE: `prologue` holds a reference to the original `nn.Module` via `__function_obj_weakref`.
+        assert model() is not None
+        model = model()
+
     cd = get_compile_data()
 
     # to not hold a reference to model in the _thunder_module_map dict, we index by id.
```

</details>

NOTE: After this, there is another cycle which leads to leak (will post more about this in the main issue).