### PR TITLE
Break ref cycle related to CompileStatistics object

### DIFF
--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -382,6 +382,7 @@ def jit(
     weakref_cd = weakref.ref(cd)
 
     cs = CompileStats()
+    weakref_cs = weakref.ref(cs)
 
     def _alias_tensor_of_args_kwargs_dict(*args, **kwargs) -> dict[int, list[int]]:
         flat_args, _ = tree_flatten((args, kwargs))
@@ -670,9 +671,11 @@ def jit(
     @langctxs.langctx(cd.langctx)
     @_with_cache_info_ctx
     def get_computation_and_inputs(*args, **kwargs):
-        # NOTE: Don't capture cd in the closure, otherwise it will create a cycle
+        # NOTE: Don't capture cd or cs in the closure, otherwise it will create a cycle
         cd = weakref_cd()
         assert cd is not None, "cd has been cleared."
+        cs = weakref_cs()
+        assert cs is not None, "cs has been cleared."
 
         # set up a record of things in the current environment that impact caching / prologues
         # this could be replaced by the respective querying in the prologues
@@ -763,6 +766,9 @@ def jit(
 
     def host_execution_timer(fn):
         def wrapped(*args, **kwargs):
+            # NOTE: Don't capture cd or cs in the closure, otherwise it will create a cycle
+            cs = weakref_cs()
+            assert cs is not None, "cs has been cleared."
             cs.last_trace_host_execution_start = time.perf_counter_ns()
             try:
                 return fn(*args, **kwargs)
@@ -773,6 +779,9 @@ def jit(
 
     def prologue_execution_timer(fn):
         def wrapped(*args, **kwargs):
+            # NOTE: Don't capture cd or cs in the closure, otherwise it will create a cycle
+            cs = weakref_cs()
+            assert cs is not None, "cs has been cleared."
             cs.last_prologue_execution_start = time.perf_counter_ns()
             try:
                 return fn(*args, **kwargs)
@@ -801,6 +810,9 @@ def jit(
 
     def update_call_statistics(fn):
         def wrapped(*args, **kwargs):
+            # NOTE: Don't capture cd or cs in the closure, otherwise it will create a cycle
+            cs = weakref_cs()
+            assert cs is not None, "cs has been cleared."
             cs.calls += 1
             cs.last_trace_host_start = time.perf_counter_ns()
             try:
@@ -843,6 +855,9 @@ def jit(
     @wraps(fn)
     @update_call_statistics
     def fn_(*args, **kwargs) -> Any:
+        # NOTE: Don't capture cd or cs in the closure, otherwise it will create a cycle
+        cs = weakref_cs()
+        assert cs is not None, "cs has been cleared."
         if is_tracing():
             _recursive_jit_call_warning()
             return fn(*args, **kwargs)

--- a/thunder/tests/test_jit_general.py
+++ b/thunder/tests/test_jit_general.py
@@ -1708,3 +1708,25 @@ def test_jit_compile_data_cycle_leak():
     assert torch.cuda.memory_allocated() == memory_at_start
     for ref in refs:
         assert ref() is None
+
+
+@requiresCUDA
+def test_jit_nn_module_cycle_leak():
+    def _allocate_model_in_function():
+        model = torch.nn.Linear(256, 256, device="cuda")
+
+        tfn = thunder.jit(model)
+        tfn(torch.randn(256, device="cuda"))
+        return weakref.ref(model)
+
+    # Warm-up run.
+    # If this test is run independently, then on the first run,
+    # PyTorch will allocate some memory for cuBlas, etc. So, we can't expect
+    # the memory to be the same before and after the first run.
+    ref = _allocate_model_in_function()
+    assert ref() is None
+
+    memory_start = torch.cuda.memory_allocated()
+    ref = _allocate_model_in_function()
+    assert ref() is None
+    assert torch.cuda.memory_allocated() == memory_start


### PR DESCRIPTION
Fixes #2458 

Ref Cycle:
<img width="565" height="691" alt="image" src="https://github.com/user-attachments/assets/3caa0d4b-7f8a-4aef-93ef-9a8c956a0ce2" />

Path from object in the cycle to user passed `nn.Module` which leads to leak

<img width="456" height="807" alt="image" src="https://github.com/user-attachments/assets/4756fb2c-2855-4dd6-b832-68216ea4cb9a" />
