### PR TITLE
Restore resnet18 test

### DIFF
--- a/thunder/tests/test_update_aliases.py
+++ b/thunder/tests/test_update_aliases.py
@@ -86,6 +86,9 @@ for op in opinfos:
 def turn_off_tf32_and_set_seed(monkeypatch):
     monkeypatch.setenv("NVIDIA_TF32_OVERRIDE", "0")
     torch.manual_seed(42)
+    yield
+    monkeypatch.delenv("NVIDIA_TF32_OVERRIDE")
+    torch.seed()
 
 
 @instantiate(

--- a/thunder/tests/test_update_aliases.py
+++ b/thunder/tests/test_update_aliases.py
@@ -96,7 +96,6 @@ def turn_off_tf32_and_set_seed(monkeypatch):
 def test_parse_resnet18(executor, device, dtype, turn_off_tf32_and_set_seed, train: bool):
     from contextlib import nullcontext
 
-    print(executor.name)
     import thunder
 
     torchvision = pytest.importorskip("torchvision")
@@ -114,25 +113,17 @@ def test_parse_resnet18(executor, device, dtype, turn_off_tf32_and_set_seed, tra
         ctx = nullcontext
     ref_model.load_state_dict(model.state_dict())
 
-    jitted = executor.make_callable(model, skip_inplace_alias_updates=True, skip_inplace_functionalization=False)
+    jitted = executor.make_callable(model)
     x = make_tensor((1, 3, 224, 224), dtype=tdtype, device=device)
 
     with ctx():
         out1 = ref_model(x)
         out2 = jitted(x)
         torch.testing.assert_close(out1, out2, atol=1e-4, rtol=1e-1)
-        # Numerical accuracy error when TorchExecutor, `train=True` and dtype is fp32.
-        # with RTX6000 Ada and CUDA 12.3, I see somewhat huge error:
-        # E   AssertionError: Tensor-likes are not close!
-        # E
-        # E   Mismatched elements: 9401 / 9408 (99.9%)
-        # E   Greatest absolute difference: 0.07035164535045624 at index (4, 1, 0, 3) (up to 1e-05 allowed)
-        # E   Greatest relative difference: 343.7076110839844 at index (5, 0, 5, 4) (up to 1.3e-06 allowed)
-        # E   The failure occurred for item [0]
-        if train and dtype == thunder.float64:
+        if train:
             torch_grads = torch.autograd.grad(out1, ref_model.parameters(), torch.ones_like(out1))
             thunder_grads = torch.autograd.grad(out2, jitted.parameters(), torch.ones_like(out2))
-            torch.testing.assert_close(torch_grads, thunder_grads)
+            torch.testing.assert_close(torch_grads, thunder_grads, atol=1e-3, rtol=1e-1)
 
 
 @ops(_inplace_opinfos, supported_dtypes=(dtypes.float32,))

--- a/thunder/tests/test_update_aliases.py
+++ b/thunder/tests/test_update_aliases.py
@@ -1,8 +1,11 @@
 from collections.abc import Callable
+from contextlib import nullcontext
 from functools import partial
 import pytest
 import torch.testing
 
+
+import torch
 import thunder
 from thunder.examine import get_fusions
 import thunder.core.dtypes as dtypes
@@ -81,8 +84,6 @@ for op in opinfos:
 
 @pytest.fixture
 def turn_off_tf32_and_set_seed(monkeypatch):
-    import torch
-
     monkeypatch.setenv("NVIDIA_TF32_OVERRIDE", "0")
     torch.manual_seed(42)
 
@@ -94,10 +95,6 @@ def turn_off_tf32_and_set_seed(monkeypatch):
 )
 @requiresCUDA
 def test_parse_resnet18(executor, device, dtype, turn_off_tf32_and_set_seed, train: bool):
-    from contextlib import nullcontext
-
-    import thunder
-
     torchvision = pytest.importorskip("torchvision")
 
     tdtype = thunder.torch.to_torch_dtype(dtype)


### PR DESCRIPTION
With #2368, this test was removed and never properly copied over to test_update_aliases.py.  This PR restores the test with relaxed tolerances.
