### PR TITLE
Add full support for `set_grad_enabled`

### DIFF
--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -865,13 +865,14 @@ def jit(
         cache_entry, inps, pro_to_epi = get_computation_and_inputs(*args, **kwargs)
 
         result = cache_entry.computation_fn(*inps)
-        # We must do this before connecting to autograd so that
-        # grad_fn attribute will be set on the outputs accordingly
-        pytorch.set_grad_enabled(cd.is_grad_enabled)
         result = maybe_connect_to_autograd(cache_entry, result)
         result = call_epilogue(cache_entry, result, pro_to_epi)
 
         cs.last_computation = cache_entry.computation_fn
+
+        # Reflect the state of is_grad_enabled, as its changes have been recorded only inside Thunder
+        pytorch.set_grad_enabled(cd.is_grad_enabled)
+
         return result
 
     if isinstance(fn, pytorch.nn.Module):

--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -865,6 +865,9 @@ def jit(
         cache_entry, inps, pro_to_epi = get_computation_and_inputs(*args, **kwargs)
 
         result = cache_entry.computation_fn(*inps)
+        # We must do this before connecting to autograd so that
+        # grad_fn attribute will be set on the outputs accordingly
+        pytorch.set_grad_enabled(cd.is_grad_enabled)
         result = maybe_connect_to_autograd(cache_entry, result)
         result = call_epilogue(cache_entry, result, pro_to_epi)
 

--- a/thunder/core/symbol.py
+++ b/thunder/core/symbol.py
@@ -327,11 +327,13 @@ class Symbol:
 
         cd = get_compile_data()
         if cd is not None and not cd.is_grad_enabled:
+            flat_args, _ = tree_flatten((args, kwargs))
+            flat_arg_ids = {id(arg) for arg in flat_args}
             # If grad is disabled using `torch.no_grad` or `torch._C._set_grad_enabled(False)`,
             # tag the results with `DETACHED_AUTOGRAD_GRAPH` which makes this Symbol a constant for
             # vjp transform (applied later).
             def tag_tensorproxy_output_as_detached(proxy):
-                if isinstance(proxy, TensorProxy):
+                if isinstance(proxy, TensorProxy) and id(proxy) not in flat_arg_ids:
                     proxy.tags.add(ProxyTag.DETACHED_AUTOGRAD_GRAPH)
 
                 return proxy

--- a/thunder/core/symbol.py
+++ b/thunder/core/symbol.py
@@ -329,6 +329,7 @@ class Symbol:
         if cd is not None and not cd.is_grad_enabled:
             flat_args, _ = tree_flatten((args, kwargs))
             flat_arg_ids = {id(arg) for arg in flat_args}
+
             # If grad is disabled using `torch.no_grad` or `torch._C._set_grad_enabled(False)`,
             # tag the results with `DETACHED_AUTOGRAD_GRAPH` which makes this Symbol a constant for
             # vjp transform (applied later).

--- a/thunder/executors/torch_autograd.py
+++ b/thunder/executors/torch_autograd.py
@@ -168,17 +168,18 @@ def connect_to_autograd(
             disable_split_autograd, lambda: "is_differentiable_outputs is not supported when split_autograd is enabled"
         )
 
-    dummy_res = ThunderFunction.apply(
-        return_none_instead_of_grads,
-        backward_fn,
-        side_channel,
-        saved_tensors,
-        saved_other,
-        is_differentiable_outputs,
-        flat_output,
-        *flat_args,
-    )
-    if side_channel is not None:
-        # we need to pass the inputs to avoid "leave has moved inside the graph"
-        # if the function returns an argument as is
-        ThunderOutputFunction.apply(dummy_res, side_channel, *flat_args)
+    with torch.enable_grad():
+        dummy_res = ThunderFunction.apply(
+            return_none_instead_of_grads,
+            backward_fn,
+            side_channel,
+            saved_tensors,
+            saved_other,
+            is_differentiable_outputs,
+            flat_output,
+            *flat_args,
+        )
+        if side_channel is not None:
+            # we need to pass the inputs to avoid "leave has moved inside the graph"
+            # if the function returns an argument as is
+            ThunderOutputFunction.apply(dummy_res, side_channel, *flat_args)

--- a/thunder/tests/test_core.py
+++ b/thunder/tests/test_core.py
@@ -5,6 +5,7 @@ from functools import partial, reduce
 import dataclasses
 import re
 import weakref
+import itertools
 
 import pytest
 import torch
@@ -2557,6 +2558,44 @@ def test_grad_ctx():
     jfoo(x).sum().backward()
     torch.testing.assert_close(x.grad, x_ref.grad)
     assert thunder.cache_misses(jfoo) == 2
+
+
+@instantiate(dtypes=NOTHING)
+def test_set_grad_enabled(executor, device, dtype):
+    def fn(x, n_flips, next_enable, starts_with_op, ends_with_op):
+        for i in range(n_flips):
+            if starts_with_op or i > 0:
+                x = x.sin()
+            torch.set_grad_enabled(next_enable)
+            next_enable = not next_enable
+        if ends_with_op:
+            x = x.sin()
+        return x
+
+    for global_grad_enabled in [False, True]:
+        for n_flips, next_enable, starts_with_op, ends_with_op in itertools.product(
+            range(4), [False, True], [False, True], [False, True]
+        ):
+            x = torch.randn(10, requires_grad=True, device=device)
+            x_ref = x.detach().clone().requires_grad_(True)
+
+            torch.set_grad_enabled(global_grad_enabled)
+            jfn = executor.make_callable(fn)
+            y = jfn(x, n_flips, next_enable, starts_with_op, ends_with_op)
+            is_grad_enabled = torch.is_grad_enabled()
+
+            torch.set_grad_enabled(global_grad_enabled)
+            y_ref = fn(x_ref, n_flips, next_enable, starts_with_op, ends_with_op)
+            is_grad_enabled_ref = torch.is_grad_enabled()
+
+            torch.testing.assert_close(y, y_ref)
+            assert is_grad_enabled == is_grad_enabled_ref
+            assert (y.grad_fn is None) == (y_ref.grad_fn is None)
+            if y.grad_fn is not None:
+                with torch.enable_grad():
+                    y.sum().backward()
+                    y_ref.sum().backward()
+                    torch.testing.assert_close(x.grad, x_ref.grad)
 
 
 def test_serialize_trace():


### PR DESCRIPTION
Fixes #2398. Thunder has support for `torch.set_grad_enabled` calls that come from `torch.no_grad()` context by managing `cd.is_grad_enabled` without actually calling `torch.set_grad_enabled`. As in #2398, when Thunder's graph splitter splits the region, `torch.set_grad_enabled(True/False)` appears in each segment independently without its counterpart. We should actually call it, and it should be done before connecting the computation to Autograd so that it will populate the `grad_fn` attribute appropriately.