### PR TITLE
Implement `thunder.executors.custom_op_ex._override_custom_op_forward`

### DIFF
--- a/thunder/executors/custom_op_ex.py
+++ b/thunder/executors/custom_op_ex.py
@@ -1,11 +1,49 @@
 """Executor for `torch.library.custom_op` operators"""
 
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+from thunder.core import baseutils
 from thunder.extend import OperatorExecutor
+from thunder.extend import register_executor
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from typing import Any
+    from thunder.core.symbol import Symbol
 
 
 __all__ = [
     "custom_op_ex",
+    "_override_custom_op_forward",
 ]
 
 
+# TODO: Implement a function which allows customizing backward.
+def _override_custom_op_forward(
+    symbol: Symbol,
+    executable_definition: Callable[[Any], Any],
+) -> None:
+    """Override the forward implementation of ``symbol`` using ``executable_definition``.
+
+    Args:
+        symbol: This should be the symbol from :func:`thunder.torch.custom_op._register_custom_op`.
+        executable_definition:
+            Custom forward definition that has the same signature as the custom op of ``symbol``.
+    """
+    baseutils.check(
+        symbol.id in custom_op_ex._implmap,
+        lambda: f"{symbol=} is not found in {custom_op_ex._implmap}",
+    )
+
+    custom_def = custom_op_ex.register_operator(
+        f"custom_{symbol.name}_forward",
+        meta=symbol.meta,
+        fn=executable_definition,
+    )
+    implinfo = custom_op_ex._implmap[symbol.id]
+    implinfo.execution_transform = custom_def
+
+
 custom_op_ex = OperatorExecutor("custom_op")
+register_executor(custom_op_ex)

--- a/thunder/torch/custom_op.py
+++ b/thunder/torch/custom_op.py
@@ -303,7 +303,7 @@ def define_backward_for(
 
 
 def _register_custom_op(custom_op: CustomOpDef) -> Symbol:
-    """Register :func:`~torch.library.custom_op`'ed function to Thunder.
+    """Register :func:`~torch.library.custom_op`'ed or :func:`~torch.library.triton_op`'ed function to Thunder.
 
     :func:`torch.library.custom_op` operators always have schema as per https://docs.google.com/document/d/1_W62p8WJOQQUzPsJYa7s701JXt0qf2OfLub2sbkHOaU/edit?tab=t.0#heading=h.aotf6sastysc saying
     "Use torch.library.custom_op to decorate a function to turn it into a custom operator.
@@ -311,6 +311,7 @@ def _register_custom_op(custom_op: CustomOpDef) -> Symbol:
     An example schema is ``my_lib::foo(Tensor a, Tensor b, float? c=None, str d="") -> Tensor``.
 
     This function does three things:
+
     1. Register ``custom_op`` as a new :class:`~thunder.core.symbol.Symbol` whose ``fn`` is ``custom_op._opoverload`` and ``meta`` is based on ``custom_op._abstract_fn``
     2. When ``_setup_context_fn`` and ``_backward_fn`` are defined, register augmented forward and backward through :func:`thunder.core.transforms.register_augmented_forward` and :func:`thunder.core.transforms.register_backward`.
 
@@ -319,7 +320,13 @@ def _register_custom_op(custom_op: CustomOpDef) -> Symbol:
 
     Returns:
         :class:`~thunder.core.symbol.Symbol`: A symbol representing the input ``custom_op``.
+
+    .. note::
+        This feature is experimental and subject to change.
     """
+    from thunder.extend import add_executor_lists
+    from thunder.extend import get_default_executors
+    from thunder.extend import set_default_executors
     from thunder.executors.torchex import _always_executable
     from thunder.executors.custom_op_ex import custom_op_ex
     from thunder.torch import register_function
@@ -376,5 +383,11 @@ def _register_custom_op(custom_op: CustomOpDef) -> Symbol:
         backward_meta, backward_impl = define_backward_for(custom_op, num_saved_tensors, tensor_indices)
         backward_op = custom_op_ex.register_operator(bwd_fn_name, meta=backward_meta, fn=backward_impl)
         register_backward(symbol.id)(backward_op)
+
+    # NOTE: `thunder.extend.add_default_executor` basically does `lst.insert(ex, 0)`.
+    if custom_op_ex not in get_default_executors():
+        default_executors = get_default_executors()
+        new_default_executors = add_executor_lists(default_executors, [custom_op_ex])
+        set_default_executors(new_default_executors)
 
     return symbol


### PR DESCRIPTION
which allows overriding forward of `torch.library.custom_op`'s forward

<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Fixes # (issue).

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
