### PR TITLE
thunderfx: Avoid failure when example_value does not have attr of grad_fn

### DIFF
--- a/thunder/dynamo/splitter.py
+++ b/thunder/dynamo/splitter.py
@@ -175,7 +175,7 @@ def _splitter(
             for n in graph_module.graph.nodes:
                 if n.op == "output":
                     for n in n.all_input_nodes:
-                        if "example_value" not in n.meta or n.meta["example_value"].grad_fn is None:
+                        if "example_value" not in n.meta or getattr(n.meta["example_value"], "grad_fn") is None:
                             is_differentiable_outputs.append(False)
                         else:
                             is_differentiable_outputs.append(True)

--- a/thunder/dynamo/splitter.py
+++ b/thunder/dynamo/splitter.py
@@ -175,7 +175,7 @@ def _splitter(
             for n in graph_module.graph.nodes:
                 if n.op == "output":
                     for n in n.all_input_nodes:
-                        if "example_value" not in n.meta or getattr(n.meta["example_value"], "grad_fn") is None:
+                        if "example_value" not in n.meta or getattr(n.meta["example_value"], "grad_fn", None) is None:
                             is_differentiable_outputs.append(False)
                         else:
                             is_differentiable_outputs.append(True)

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -1697,3 +1697,26 @@ def test_thunderfx_node_with_no_example_value():
     actual = thunderfx(test_fn)(x)
     expected = test_fn(x)
     torch.testing.assert_close(actual, expected)
+
+
+# Ref: https://github.com/Lightning-AI/lightning-thunder/issues/2420
+def test_splitter_with_symint_node():
+    class GraphModule(torch.nn.Module):
+        def forward(self, L_self_cumulative_length_1_: "Sym(s27)"):
+            l_self_cumulative_length_1_ = L_self_cumulative_length_1_
+
+            add: "Sym(s27 + 1)" = l_self_cumulative_length_1_ + 1
+            l_self_cumulative_length_1_ = None
+            return (add,)
+
+    module = GraphModule()
+    ref_inputs = (100,)
+    reference = module(*ref_inputs)
+
+    jitted = thunderfx(GraphModule(), dynamic=True)
+    inputs = (100,)
+    actual = jitted(*inputs)
+    assert reference == actual
+
+    for subgraph in jitted._backend.subgraph_infos:
+        assert not subgraph.split_reasons


### PR DESCRIPTION
## What does this PR do?

This is reopened 2419.
Some values, such as `torch.SymInt` would not have `grad_fn` attr.

Signed-off-by: Masaki Kozuki <mkozuki@nvidia.com>
