### PR TITLE
restore type condition on training resnet test

### DIFF
--- a/thunder/tests/test_update_aliases.py
+++ b/thunder/tests/test_update_aliases.py
@@ -87,7 +87,6 @@ def turn_off_tf32_and_set_seed(monkeypatch):
     monkeypatch.setenv("NVIDIA_TF32_OVERRIDE", "0")
     torch.manual_seed(42)
     yield
-    monkeypatch.delenv("NVIDIA_TF32_OVERRIDE")
     torch.seed()
 
 
@@ -120,14 +119,8 @@ def test_parse_resnet18(executor, device, dtype, turn_off_tf32_and_set_seed, tra
         out1 = ref_model(x)
         out2 = jitted(x)
         torch.testing.assert_close(out1, out2, atol=1e-4, rtol=1e-1)
-        # Numerical accuracy error when TorchExecutor, `train=True` and dtype is fp32.
-        # with RTX6000 Ada and CUDA 12.3, I see somewhat huge error:
-        # E   AssertionError: Tensor-likes are not close!
-        # E
-        # E   Mismatched elements: 9401 / 9408 (99.9%)
-        # E   Greatest absolute difference: 0.07035164535045624 at index (4, 1, 0, 3) (up to 1e-05 allowed)
-        # E   Greatest relative difference: 343.7076110839844 at index (5, 0, 5, 4) (up to 1.3e-06 allowed)
-        # E   The failure occurred for item [0]
+        # TODO: https://github.com/Lightning-AI/lightning-thunder/issues/2497
+        # Numerical accuracy error when dtype is fp32.
         if train and dtype == thunder.float64:
             torch_grads = torch.autograd.grad(out1, ref_model.parameters(), torch.ones_like(out1))
             thunder_grads = torch.autograd.grad(out2, jitted.parameters(), torch.ones_like(out2))

--- a/thunder/tests/test_update_aliases.py
+++ b/thunder/tests/test_update_aliases.py
@@ -120,7 +120,15 @@ def test_parse_resnet18(executor, device, dtype, turn_off_tf32_and_set_seed, tra
         out1 = ref_model(x)
         out2 = jitted(x)
         torch.testing.assert_close(out1, out2, atol=1e-4, rtol=1e-1)
-        if train:
+        # Numerical accuracy error when TorchExecutor, `train=True` and dtype is fp32.
+        # with RTX6000 Ada and CUDA 12.3, I see somewhat huge error:
+        # E   AssertionError: Tensor-likes are not close!
+        # E
+        # E   Mismatched elements: 9401 / 9408 (99.9%)
+        # E   Greatest absolute difference: 0.07035164535045624 at index (4, 1, 0, 3) (up to 1e-05 allowed)
+        # E   Greatest relative difference: 343.7076110839844 at index (5, 0, 5, 4) (up to 1.3e-06 allowed)
+        # E   The failure occurred for item [0]
+        if train and dtype == thunder.float64:
             torch_grads = torch.autograd.grad(out1, ref_model.parameters(), torch.ones_like(out1))
             thunder_grads = torch.autograd.grad(out2, jitted.parameters(), torch.ones_like(out2))
             torch.testing.assert_close(torch_grads, thunder_grads, atol=1e-3, rtol=1e-1)


### PR DESCRIPTION
In copying (#2473) over the resnet test from test_inplace_functionalization.py (now deleted, #2368) to test_update_aliases.py, I did not encounter numerical issues either locally or in CI for training in float32.  This case, however, was removed from testing in the original version of the test.  Nevertheless, numerical issues are being reported by the nvfuser team.  This PR removes testing resnet training for float32 in test_update_aliases.py, in line with the original.