### PR TITLE
Enable direct bindings in Thunder

### DIFF
--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -70,7 +70,7 @@ from thunder.executors.nvfuserex import nvfuser_version
 # NOTE This impl file is here because nvFuser may not be available, so it's imported conditionally
 #   by nvfuserex.py when nvFuser is available.
 
-DIRECT_BINDINGS_SUPPORTED_VERSION = LooseVersion("0.2.32")
+DIRECT_BINDINGS_SUPPORTED_VERSION = LooseVersion("0.2.34")
 DTENSOR_SUPPORTED_VERSION = LooseVersion("0.2.28")
 if nvfuser_version() >= DIRECT_BINDINGS_SUPPORTED_VERSION:
     import nvfuser_direct as nvfuser


### PR DESCRIPTION
This PR enables the direct bindings for nvfuser executor if `DIRECT_BINDINGS_SUPPORTED_VERSION >= 0.2.34`.

* Legacy bindings will remain in the nvfuser pip wheel under `import nvfuser`, but it will be deprecated and no longer receive new operations.
* `dockers/ubuntu-cuda/Dockerfile`, `scripts/validate_build.py`, `thunder/tests/conftest.py`, `thunder/executors/nvfuserex.py` contain `import nvfuser` for version checks and `FusionCache.reset()`. These files will need to be updated when legacy bindings are removed.

## What is direct bindings?
* TL;DR: It is direct pybind11 mapping from nvfuser CPP API to python.
* The python API is the same as legacy bindings, so Thunder is minimally affected.
* Direct bindings does not have a static Fusion Definition cache like legacy bindings.

## Why direct bindings?
* The legacy bindings utilized an intermediate representation from nvFuser's underlying FusionIR where only the definition ops were exposed in this intermediate representation to allow for graph caching.  By moving to direct bindings, we are allowing for the possibility of adding more bindings to expose the scheduling of operations from python to allow users to more directly interact with nvFuser internals from python.  One example where exposing scheduling operations is useful is multi-gpu support where the mesh dimensions of a tensor are annotated via a scheduling operation.
* It is difficult to expose multi-gpu scheduling primitives with legacy bindings.
* The static Fusion Definition cache can be a memory hog and cumbersome to update.
