### PR TITLE
[WIP] DTensor: Add _grouped_mm torch and prim

### DIFF
--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -3219,6 +3219,7 @@ def _grouped_mm_transform(
 
 
 register_supported(prims._grouped_mm, _grouped_mm_transform, _grouped_mm_check)
+register_supported(DTensorPrimIDs._GROUPED_MM, _grouped_mm_transform, _grouped_mm_check)
 
 
 def _cumsum_check(a: TensorProxy, dim: int, /, dtype: dtypes.dtype | None = None) -> bool:

--- a/thunder/torch/experimental/dtensor_utils.py
+++ b/thunder/torch/experimental/dtensor_utils.py
@@ -58,14 +58,14 @@ def run_with_fake_tensor(torch_op, *args, **kwargs):
                 return t
 
             if isinstance(t, DTensorProxy):
-                i_t = torch.randn(
+                i_t = torch.ones(
                     t.local_tensor.shape,
                     device=to_torch_device(t.local_tensor.device),
                     dtype=to_torch_dtype(t.local_tensor.dtype),
                 )
                 return DTensor.from_local(i_t, t.spec._o.device_mesh, t.spec._o.placements)
 
-            return torch.randn(t.shape, device=to_torch_device(t.device), dtype=to_torch_dtype(t.dtype))
+            return torch.ones(t.shape, device=to_torch_device(t.device), dtype=to_torch_dtype(t.dtype))
 
         args, kwargs = tree_map(materialize_fake_tensors, (args, kwargs))
 


### PR DESCRIPTION
Related #2338 

TODO:
* [ ] Figure out why we see `Error from segmentation group 1: The singleton Communicator isn't available. This is most likely because the instance wasn't successfully initialized due to lack of a multi-process running (e.g. mpirun or torchrun).` only when running this primitive.