### PR TITLE
Skip sections with vmap for thunderfx

### DIFF
--- a/thunder/dynamo/utils.py
+++ b/thunder/dynamo/utils.py
@@ -338,7 +338,7 @@ def get_nodes_in_unsupported_ctx_regions(gm: torch.fx.GraphModule) -> set[torch.
     nodes_in_unsupported_ctx_regions: set[torch.fx.Node] = set()
     ctx_cnt = 0  # Count of  we have seen till now
 
-    UNSUPPORTED_THUNDER_CTX = ()
+    UNSUPPORTED_THUNDER_CTX = (torch._C._functorch._vmap_increment_nesting, torch._C._functorch._vmap_decrement_nesting)
     for node in gm.graph.nodes:
         if node.op == "call_function" and node.target in UNSUPPORTED_THUNDER_CTX:
             ctx_cnt += 1


### PR DESCRIPTION
This is to work with latest transformers and PyTorch.

This resolves a failure seen in #2391 , so will be tested once we bump transformers.