### PR TITLE
pin transformers for quickstart

### DIFF
--- a/examples/quickstart/requirements.txt
+++ b/examples/quickstart/requirements.txt
@@ -1,4 +1,4 @@
-transformers
+transformers==4.55.4
 accelerate
 nvfuser-cu128-torch27
 nvidia-cudnn-frontend

--- a/thunder/dynamo/compiler.py
+++ b/thunder/dynamo/compiler.py
@@ -29,7 +29,6 @@ from thunder.transforms.extraction_only_prologue_transform import ExtractionOnly
 if TYPE_CHECKING:
     from typing import Any
     from thunder.dynamo.utils import SubgraphInfo
-    from thunder.core.transform_common import Transform
     from thunder.core.trace import TraceCtx as Trace
     from os import PathLike
     from collections.abc import Callable

--- a/thunder/recipes/hf_transformers.py
+++ b/thunder/recipes/hf_transformers.py
@@ -38,7 +38,7 @@ class InplaceIndexCopyTransform(thunder.Transform):
         return pro, comp_new, epi
 
 
-@Recipe.register("transformers")
+@Recipe.register("hf-transformers")
 class HFTransformers(BaseRecipe):
     """
     Recipe tuned for Hugging Face ``transformers`` models.
@@ -77,7 +77,7 @@ class HFTransformers(BaseRecipe):
 
         version = LooseVersion(transformers.__version__)
         min_version = LooseVersion("4.46.0")
-        max_version = LooseVersion("5.0.0")
+        max_version = LooseVersion("4.55.4")
 
         if version < min_version or version > max_version:
             warnings.warn(
@@ -178,5 +178,8 @@ class HFTransformers(BaseRecipe):
 
         if getattr(thunder_model, "_sample", None):
             thunder_model._sample = partial(thunder_model._sample.__func__, thunder_model)
+
+        if getattr(thunder_model, "_valid_auto_compile_criteria", None):
+            thunder_model._valid_auto_compile_criteria = lambda *args, **kwargs: False
 
         return thunder_model

--- a/thunder/tests/test_transforms.py
+++ b/thunder/tests/test_transforms.py
@@ -588,7 +588,6 @@ def test_disable_params_and_buffer_check():
 
 @pytest.mark.parametrize("dynamic", (False, True))
 def test_disable_params_check_thunderfx(dynamic: bool):
-    from thunder.transforms.extraction_only_prologue_transform import ExtractionOnlyPrologueTransform
     from thunder.dynamo import thunderfx
 
     class Model(torch.nn.Module):


### PR DESCRIPTION
This pins transformers for the quickstart.

Transformers 4.56 seems to use torch.compile more aggressively and also change something in the generation in an incompatible way. 