### PR TITLE
Use underlying class's __new__ in MutableMappingWrapper.__new__

### DIFF
--- a/thunder/core/interpreter.py
+++ b/thunder/core/interpreter.py
@@ -2513,7 +2513,8 @@ class MappingItemsWrapper(ThunderInterpreterObject):
 
 class MutMappingWrapperMethods(WrappedValue):
     def __new__(cls, /, *args, **kwds):
-        uvalue = unwrap(cls)()
+        ucls = unwrap(cls)
+        uvalue = ucls.__new__(ucls)
         # todo: for subclasses, better record the call to the constructor
         return wrap(uvalue, provenance=ProvenanceRecord(PseudoInst.NEW, inputs=[cls.provenance]))
 

--- a/thunder/tests/test_jit_general.py
+++ b/thunder/tests/test_jit_general.py
@@ -1730,3 +1730,17 @@ def test_jit_nn_module_cycle_leak():
     ref = _allocate_and_call_model_in_function()
     assert ref() is None
     assert torch.cuda.memory_allocated() == memory_start
+
+
+def test_dataclass_dict():
+    # diffusers model outputs are like this
+    from dataclasses import dataclass
+
+    @dataclass
+    class Foo(dict):
+        musthave: int
+
+    def fn():
+        return Foo(musthave=1)
+
+    assert fn() == thunder.jit(fn)()


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

## What does this PR do?

We use `__new__` in `MutableMappingWrapper.__new__` to instantiate a new class.
This is needed for classes that are dataclasses and dicts simultaneously, happens eg in HF diffusers.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
