### PR TITLE
Create `Symbol` with `is_prim=True` in `_register_custom_op`

### DIFF
--- a/thunder/torch/custom_op.py
+++ b/thunder/torch/custom_op.py
@@ -357,7 +357,7 @@ def _register_custom_op(custom_op: CustomOpDef) -> Symbol:
         name=fn_name,
         meta=meta_fn,
         id=op_id,
-        is_prim=False,
+        is_prim=True,
         tags=tags,
     )
     # Register both `torch.ops.my_lib.foo` and `torch.ops.my_lib.foo.default`.


### PR DESCRIPTION
## What does this PR do?

This changes how we create `Symbol` for `custon_op`s: changing `is_primt=False` to `is_prim=True`.

Related:
- https://github.com/Lightning-AI/lightning-thunder/issues/2361