### PR TITLE
Initial TE NVFP4 recipe support

### DIFF
--- a/thunder/executors/transformer_engineex_impl.py
+++ b/thunder/executors/transformer_engineex_impl.py
@@ -282,7 +282,10 @@ def _linear_checker(
             return shape[0] % MXFP8_BLOCK_SCALING_SIZE == 0 and shape[1] % MXFP8_BLOCK_SCALING_SIZE == 0
 
         if hasattr(fp8_recipe, "nvfp4") and fp8_recipe.nvfp4():
-            return shape[0] % MXFP8_BLOCK_SCALING_SIZE == 0 and shape[1] % MXFP8_BLOCK_SCALING_SIZE / 2 == 0
+            import math
+            from transformer_engine.pytorch.constants import NVFP4_BLOCK_SCALING_SIZE
+            # https://github.com/ksivaman/TransformerEngine-1/blob/1af7dd88aae5afb45e82148089038e1d1de9675d/transformer_engine/pytorch/tensor/nvfp4_tensor.py#L176-L184 
+            return len(shape) > 2 and shape[-1] % NVFP4_BLOCK_SCALING_SIZE == 0 and math.prod(shape[:-1]) % NVFP4_BLOCK_SCALING_SIZE == 0
 
         return False
 

--- a/thunder/executors/transformer_engineex_impl.py
+++ b/thunder/executors/transformer_engineex_impl.py
@@ -271,6 +271,18 @@ def _linear_checker(
 
     fp8_recipe = FP8GlobalStateManager.get_fp8_recipe()
 
+    import transformer_engine.common.recipe as recipe
+
+    suported_recipes = [recipe.DelayedScaling, recipe.MXFP8BlockScaling]
+    if hasattr(recipe, "NVFP4BlockScaling"):
+        suported_recipes.append(recipe.NVFP4BlockScaling)
+
+    if not isinstance(fp8_recipe, suported_recipes):
+        import warnings
+
+        warnings.warn(f"{type(fp8_recipe)} is not supported by TE executor, TE wont be used.")
+        return False
+
     def check_valid_fp8_shapes(a):
         # DelayedScaling and MXFP8BlockScaling have different shape requirements.
         if fp8_recipe.delayed():

--- a/thunder/executors/transformer_engineex_impl.py
+++ b/thunder/executors/transformer_engineex_impl.py
@@ -277,7 +277,7 @@ def _linear_checker(
     if hasattr(recipe, "NVFP4BlockScaling"):
         suported_recipes.append(recipe.NVFP4BlockScaling)
 
-    if not isinstance(fp8_recipe, suported_recipes):
+    if not isinstance(fp8_recipe, tuple(suported_recipes)):
         import warnings
 
         warnings.warn(f"{type(fp8_recipe)} is not supported by TE executor, TE wont be used.")

--- a/thunder/executors/transformer_engineex_impl.py
+++ b/thunder/executors/transformer_engineex_impl.py
@@ -276,9 +276,15 @@ def _linear_checker(
         if fp8_recipe.delayed():
             return check_dim_for_fp8_exec(a)
 
-        assert fp8_recipe.mxfp8()
         shape = a.shape
-        return shape[0] % MXFP8_BLOCK_SCALING_SIZE == 0 and shape[1] % MXFP8_BLOCK_SCALING_SIZE == 0
+
+        if fp8_recipe.mxfp8():
+            return shape[0] % MXFP8_BLOCK_SCALING_SIZE == 0 and shape[1] % MXFP8_BLOCK_SCALING_SIZE == 0
+
+        if hasattr(fp8_recipe, "nvfp4") and fp8_recipe.nvfp4():
+            return shape[0] % MXFP8_BLOCK_SCALING_SIZE == 0 and shape[1] % MXFP8_BLOCK_SCALING_SIZE / 2 == 0
+
+        return False
 
     # Inputs must be on CUDA and
     # input sizes must satisfy size constraints based on the recipe.

--- a/thunder/executors/transformer_engineex_impl.py
+++ b/thunder/executors/transformer_engineex_impl.py
@@ -284,7 +284,7 @@ def _linear_checker(
         return False
 
     def check_valid_fp8_shapes(a):
-        # DelayedScaling and MXFP8BlockScaling have different shape requirements.
+        # Each recipe type has different shape requirements.
         if fp8_recipe.delayed():
             return check_dim_for_fp8_exec(a)
 
@@ -296,8 +296,13 @@ def _linear_checker(
         if hasattr(fp8_recipe, "nvfp4") and fp8_recipe.nvfp4():
             import math
             from transformer_engine.pytorch.constants import NVFP4_BLOCK_SCALING_SIZE
-            # https://github.com/ksivaman/TransformerEngine-1/blob/1af7dd88aae5afb45e82148089038e1d1de9675d/transformer_engine/pytorch/tensor/nvfp4_tensor.py#L176-L184 
-            return len(shape) > 2 and shape[-1] % NVFP4_BLOCK_SCALING_SIZE == 0 and math.prod(shape[:-1]) % NVFP4_BLOCK_SCALING_SIZE == 0
+
+            # https://github.com/ksivaman/TransformerEngine-1/blob/1af7dd88aae5afb45e82148089038e1d1de9675d/transformer_engine/pytorch/tensor/nvfp4_tensor.py#L176-L184
+            return (
+                len(shape) > 2
+                and shape[-1] % NVFP4_BLOCK_SCALING_SIZE == 0
+                and math.prod(shape[:-1]) % NVFP4_BLOCK_SCALING_SIZE == 0
+            )
 
         return False
 

--- a/thunder/executors/transformer_engineex_impl.py
+++ b/thunder/executors/transformer_engineex_impl.py
@@ -297,9 +297,9 @@ def _linear_checker(
             import math
             from transformer_engine.pytorch.constants import NVFP4_BLOCK_SCALING_SIZE
 
-            # https://github.com/ksivaman/TransformerEngine-1/blob/1af7dd88aae5afb45e82148089038e1d1de9675d/transformer_engine/pytorch/tensor/nvfp4_tensor.py#L176-L184
+            # Check inherited from TE https://github.com/ksivaman/TransformerEngine-1/blob/1af7dd88aae5afb45e82148089038e1d1de9675d/transformer_engine/pytorch/tensor/nvfp4_tensor.py#L176-L184
             return (
-                len(shape) > 2
+                len(shape) >= 2
                 and shape[-1] % NVFP4_BLOCK_SCALING_SIZE == 0
                 and math.prod(shape[:-1]) % NVFP4_BLOCK_SCALING_SIZE == 0
             )

--- a/thunder/executors/transformer_engineex_impl.py
+++ b/thunder/executors/transformer_engineex_impl.py
@@ -292,14 +292,13 @@ def _linear_checker(
             return shape[0] % MXFP8_BLOCK_SCALING_SIZE == 0 and shape[1] % MXFP8_BLOCK_SCALING_SIZE == 0
 
         if hasattr(fp8_recipe, "nvfp4") and fp8_recipe.nvfp4():
-            import math
             from transformer_engine.pytorch.constants import NVFP4_BLOCK_SCALING_SIZE
 
             # Check inherited from TE https://github.com/ksivaman/TransformerEngine-1/blob/1af7dd88aae5afb45e82148089038e1d1de9675d/transformer_engine/pytorch/tensor/nvfp4_tensor.py#L176-L184
             return (
                 len(shape) >= 2
-                and shape[-1] % NVFP4_BLOCK_SCALING_SIZE == 0
-                and math.prod(shape[:-1]) % NVFP4_BLOCK_SCALING_SIZE == 0
+                and shape[0] % NVFP4_BLOCK_SCALING_SIZE == 0
+                and shape[1] % NVFP4_BLOCK_SCALING_SIZE == 0
             )
 
         return False


### PR DESCRIPTION
This PR changes the input checks to enable NVFP4 using TE executor after PR https://github.com/NVIDIA/TransformerEngine/pull/2177 will be merged. 

This change makes Thunder ready to accept NVFP4 recipe, however a follow-up PR will be needed to add tests when the recipe API will be finalized on TE side(i.e. when their PR will merge) 

cc. @ksivaman shape requirement for the last dimension changed to be half of MXFP8. 

To test with the latest TransformerEngine repo on branch `nvfp4_recipe`(https://github.com/ksivaman/TransformerEngine-1/tree/nvfp4_recipe) run the snippet here:

```python
import torch
import thunder

from thunder.executors.transformer_engineex import transformer_engine_ex, TransformerEngineTransform
from transformer_engine.common import recipe
import transformer_engine.pytorch as te

def nvfp4_vanilla():
    nvfp4_recipe = recipe.NVFP4BlockScaling()
    nvfp4_recipe.fp4_quant_fwd_inp = recipe.QParams()
    nvfp4_recipe.fp4_quant_fwd_weight = recipe.QParams()
    nvfp4_recipe.fp4_quant_bwd_grad = recipe.QParams()
    return nvfp4_recipe

fp8_recipe = nvfp4_vanilla()

def foo(x, w):
    return thunder.torch.linear(x, w)

device = "cuda"
x = torch.randn(32, 32, device=device, requires_grad=True)
w = torch.randn(32, 32, device=device, requires_grad=True)

cfunc = thunder.jit(
    foo,
    executors=[transformer_engine_ex],
    transforms=[TransformerEngineTransform()],
)

with te.fp8_autocast(fp8_recipe=fp8_recipe):
    out = cfunc(x, w)

print(out)

print(thunder.last_traces(cfunc)[-1])
```