### PR TITLE
fix: working README.md example, support nvfuser for torch==2.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ pip install nvfuser-cu128-torch28 nvidia-cudnn-frontend  # if NVIDIA GPU is pres
   <summary>For older versions of <code>torch</code></summary>
 
 <code>torch==2.7</code> + CUDA 12.8
+
 ```bash
 pip install lightning-thunder
 
@@ -95,6 +96,7 @@ pip install nvfuser-cu128-torch27 nvidia-cudnn-frontend  # if NVIDIA GPU is pres
 ```
 
 <code>torch==2.6</code> + CUDA 12.6
+
 ```bash
 pip install lightning-thunder
 
@@ -103,6 +105,7 @@ pip install nvfuser-cu126-torch26 nvidia-cudnn-frontend  # if NVIDIA GPU is pres
 ```
 
 <code>torch==2.5</code> + CUDA 12.4
+
 ```bash
 pip install lightning-thunder
 

--- a/README.md
+++ b/README.md
@@ -79,10 +79,38 @@ Install Thunder via pip ([more options](https://lightning.ai/docs/thunder/latest
 ```bash
 pip install lightning-thunder
 
-pip install torch==2.7.0 torchvision==0.22  # for torch==2.7
-pip install torch==2.6.0 torchvision==0.21  # for torch==2.6
+pip install -U torch torchvision
+pip install nvfuser-cu128-torch28 nvidia-cudnn-frontend  # if NVIDIA GPU is present
+```
+
+<details>
+  <summary>For older versions of <code>torch</code></summary>
+
+<code>torch==2.7</code> + CUDA 12.8
+```bash
+pip install lightning-thunder
+
+pip install torch==2.7.0 torchvision==0.22
 pip install nvfuser-cu128-torch27 nvidia-cudnn-frontend  # if NVIDIA GPU is present
 ```
+
+<code>torch==2.6</code> + CUDA 12.6
+```bash
+pip install lightning-thunder
+
+pip install torch==2.6.0 torchvision==0.21
+pip install nvfuser-cu126-torch26 nvidia-cudnn-frontend  # if NVIDIA GPU is present
+```
+
+<code>torch==2.5</code> + CUDA 12.4
+```bash
+pip install lightning-thunder
+
+pip install torch==2.5.0 torchvision==0.20
+pip install nvfuser-cu124-torch25 nvidia-cudnn-frontend  # if NVIDIA GPU is present
+```
+
+</details>
 
 <details>
   <summary>Advanced install options</summary>

--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ For **performance experts**, Thunder is the most ergonomic framework for underst
 Install Thunder via pip ([more options](https://lightning.ai/docs/thunder/latest/fundamentals/installation.html)):
 
 ```bash
-pip install torch==2.6.0 torchvision==0.21 nvfuser-cu124-torch26
+pip install torch==2.7.0 torchvision==0.22 nvfuser-cu128-torch27  # for torch==2.7
+pip install torch==2.6.0 torchvision==0.21 nvfuser-cu124-torch26  # for torch==2.6
 
 pip install lightning-thunder
 ```
@@ -140,7 +141,7 @@ Optimize it with Thunder:
 import thunder
 import torch
 
-thunder_model = thunder.compile(model)
+thunder_model = thunder.jit(model)
 
 x = torch.randn(64, 2048)
 

--- a/README.md
+++ b/README.md
@@ -118,20 +118,7 @@ pip install nvfuser-cu124-torch25 nvidia-cudnn-frontend  # if NVIDIA GPU is pres
 <details>
   <summary>Advanced install options</summary>
 
-### Blackwell support
-
-For Blackwell you'll need CUDA 12.8
-
-```bash
-pip install --pre torch torchvision --index-url https://download.pytorch.org/whl/nightly/cu128
-pip install --pre nvfuser-cu128 --extra-index-url https://pypi.nvidia.com
-
-pip install lightning-thunder
-```
-
-### Install additional executors
-
-These are optional
+### Install optional executors
 
 ```bash
 # Float8 support (this will compile from source, be patient)

--- a/README.md
+++ b/README.md
@@ -77,10 +77,11 @@ For **performance experts**, Thunder is the most ergonomic framework for underst
 Install Thunder via pip ([more options](https://lightning.ai/docs/thunder/latest/fundamentals/installation.html)):
 
 ```bash
-pip install torch==2.7.0 torchvision==0.22 nvfuser-cu128-torch27  # for torch==2.7
-pip install torch==2.6.0 torchvision==0.21 nvfuser-cu124-torch26  # for torch==2.6
-
 pip install lightning-thunder
+
+pip install torch==2.7.0 torchvision==0.22  # for torch==2.7
+pip install torch==2.6.0 torchvision==0.21  # for torch==2.6
+pip install nvfuser-cu128-torch27 nvidia-cudnn-frontend  # if NVIDIA GPU is present
 ```
 
 <details>
@@ -99,12 +100,9 @@ pip install lightning-thunder
 
 ### Install additional executors
 
-These are optional, feel free to mix and match
+These are optional
 
 ```bash
-# cuDNN SDPA
-pip install nvidia-cudnn-frontend
-
 # Float8 support (this will compile from source, be patient)
 pip install "transformer_engine[pytorch]"
 ```
@@ -141,7 +139,7 @@ Optimize it with Thunder:
 import thunder
 import torch
 
-thunder_model = thunder.jit(model)
+thunder_model = thunder.compile(model)
 
 x = torch.randn(64, 2048)
 

--- a/thunder/executors/transformer_engineex.py
+++ b/thunder/executors/transformer_engineex.py
@@ -8,18 +8,21 @@ from thunder import Transform
 from thunder.extend import StatefulExecutor
 from thunder.core.trace import TraceCtx
 
+import torch
+
 __all__ = ["transformer_engine_ex", "TransformerEngineTransform", "_te_activation_checkpointing_transform"]
 
 transformer_engine_ex: None | StatefulExecutor = None
 TransformerEngineTransform: None | Transform = None
 _te_activation_checkpointing_transform: None | Callable[[TraceCtx], TraceCtx] = None
 
-if package_available("transformer_engine"):
-    import thunder.executors.transformer_engineex_impl as impl
+if torch.cuda.is_available():
+    if package_available("transformer_engine"):
+        import thunder.executors.transformer_engineex_impl as impl
 
-    transformer_engine_ex = impl.transformer_engine_ex
-    TransformerEngineTransform = impl.TransformerEngineTransform
-    _te_activation_checkpointing_transform = impl._te_activation_checkpointing_transform
+        transformer_engine_ex = impl.transformer_engine_ex
+        TransformerEngineTransform = impl.TransformerEngineTransform
+        _te_activation_checkpointing_transform = impl._te_activation_checkpointing_transform
 
-else:
-    warnings.warn("transformer_engine module not found!")
+    else:
+        warnings.warn("transformer_engine module not found!")

--- a/thunder/executors/triton_crossentropy.py
+++ b/thunder/executors/triton_crossentropy.py
@@ -1,16 +1,20 @@
 from thunder.executors import triton_utils
 from thunder.extend import OperatorExecutor
 
+import torch
+
 triton_version: None | str = triton_utils.triton_version()
 
 triton_ex: None | OperatorExecutor = None
-if triton_version is not None:
-    try:
-        from thunder.executors.triton_crossentropy_impl import triton_ex as impl_ex
 
-        triton_ex = impl_ex
-    except Exception:
-        import warnings
+if torch.cuda.is_available():
+    if triton_version is not None:
+        try:
+            from thunder.executors.triton_crossentropy_impl import triton_ex as impl_ex
 
-        warnings.warn("triton is present but cannot be initialized")
-        triton_version = None
+            triton_ex = impl_ex
+        except Exception:
+            import warnings
+
+            warnings.warn("triton is present but cannot be initialized")
+            triton_version = None

--- a/thunder/recipes/base.py
+++ b/thunder/recipes/base.py
@@ -13,6 +13,7 @@ def get_nvfuser_package_hint() -> str:
         "2.5": "nvfuser-cu124-torch25",
         "2.6": "nvfuser-cu126-torch26",
         "2.7": "nvfuser-cu128-torch27",
+        "2.8": "nvfuser-cu128-torch28",
     }
 
     torch_key = ".".join(torch_version.split(".")[:2])

--- a/thunder/recipes/base.py
+++ b/thunder/recipes/base.py
@@ -73,8 +73,17 @@ class BaseRecipe(Recipe):
         plugins=None,
     ):
         super().__init__(interpreter=interpreter, plugins=plugins)
-        self.executor_names = ["cudnn", "sdpa", "torchcompile_xentropy"]
         self.fuser = fuser
+        self.executor_names = []
+
+        if torch.cuda.is_available():
+            self.executor_names = ["cudnn", "sdpa"]
+            if self.fuser == "nvfuser":
+                self.executor_names.append("torchcompile_xentropy")
+        else:
+            print("GPU not found, nvFuser not available. Setting fusing executor to torch.compile")
+            self.fuser = "torch.compile"
+
         self.setup_fuser()
         self.show_progress = show_progress
 
@@ -114,8 +123,6 @@ class BaseRecipe(Recipe):
             if "nvfuser" not in self.executor_names:
                 self.executor_names.append("nvfuser")
         elif self.fuser == "torch.compile":
-            if "torchcompile_xentropy" in self.executor_names:
-                self.executor_names.remove("torchcompile_xentropy")
             if "torchcompile" not in self.executor_names:
                 self.executor_names.append("torchcompile")
         else:


### PR DESCRIPTION
## What does this PR do?

Provides working "Quick start" example for new users. The default fuser for `thunder.compile` is `nvFuser`, so this change creates a working example that [runs on any machine](https://github.com/Lightning-AI/lightning-thunder/pull/427#discussion_r1604777732). Further, `thunder.compile` has `cudnn` in its default executor list, while cuDNN is listed as an optional executor in the "Advanced install options" section. An alternative would be to change the default fuser for `thunder.compile` to `torch.compile` and move `pip install nvidia-cudnn-frontend` to the main `pip install` list, but I assumed functionality is more important to maintain than documentation. Happy to make any change!
