### PR TITLE
fix: string -> f-string where intended

### DIFF
--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -1131,7 +1131,7 @@ def _general_custom_op_def_call_lookaside(wrapped_opoverload_packet, *args, **kw
         symbol is not None,
         lambda: (
             f"{opoverload_packet} is not registered. Register its `custom_op` output with `thunder.torch.register_custom_op` "
-            "`custom_op(name)(fn)` output, not `{opoverload_packet}` itself"
+            f"`custom_op(name)(fn)` output, not `{opoverload_packet}` itself"
         ),
     )
 


### PR DESCRIPTION
## What does this PR do?

Previously, the second line of this error statement was not properly formatted as an f-string. It contains a variable reference, so it was intended to be an f-string. This PR fixes it to provide a better error message.
