### PR TITLE
feat: provide guidance when registering custom op

### DIFF
--- a/thunder/torch/custom_op.py
+++ b/thunder/torch/custom_op.py
@@ -249,6 +249,11 @@ def _convert_to_meta_function(func):
 
 
 def _get_meta_function_from(custom_op: CustomOpDef) -> Callable[[Any], TensorProxy | tuple[TensorProxy, ...]]:
+    if custom_op._abstract_fn is None:
+        raise ValueError(
+            f"Custom op {custom_op._qualname} has no _abstract_fn defined. "
+            "You must provide an abstract function (using @torch.library.register_fake) when defining the custom op."
+        )
     return _convert_to_meta_function(custom_op._abstract_fn)
 
 


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

Previously, if a user tried to register a custom function like

```python
import thunder
import torch
from typing import List

@torch.library.custom_op(
    "mynamespace::func",
    mutates_args=(),
)
def my_func(x: torch.Tensor) -> torch.Tensor:
    return x.clone()

thunder.torch.custom_op._register_custom_op(my_func)

def use_func():
    a = torch.tensor([0, 1, 2])
    ret = torch.ops.mynamespace.func(a)
    print(ret)

use_func_compiled = thunder.compile(use_func)
print("successfully compiled")

assert use_func() == use_func_compiled()
print("successfully ran")
```

but forgot to add an abstract function
```python
@torch.library.register_fake("my_custom_op::func")
def _(x: torch.Tensor) -> torch.Tensor:
    return torch.empty_like(x)
```
the output from Thunder was
```Traceback (most recent call last):
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/thunder/torch/__init__.py", line 6812, in meta_func
    fake_outs = torch_func(*fake_args, **fake_kwargs)
TypeError: 'NoneType' object is not callable

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/thunder/core/interpreter.py", line 7544, in fn_
    interpretation_result: Any = _interpret_call(wrapped_fn_2, args, kwargs)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/thunder/core/interpreter.py", line 6803, in _interpret_call
    rval = _call_dispatch(compilectx, runtimectx, fn, *args, **kwargs)  # type: ignore
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/thunder/core/interpreter.py", line 7005, in _call_dispatch
    return _setup_frame_and_run_python_function(compilectx, runtimectx, wrapped_fn, *args, **kwargs)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/thunder/core/interpreter.py", line 7206, in _setup_frame_and_run_python_function
    res, status = _run_frame(frame, compilectx, runtimectx)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/thunder/core/interpreter.py", line 7256, in _run_frame
    interpretation_result: None | int | INTERPRETER_SIGNALS = compilectx.interpret(
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/thunder/core/interpreter.py", line 410, in interpret
    return self._opcode_interpreter(inst, **interpreter_state)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/thunder/core/interpreter.py", line 1249, in default_opcode_interpreter
    return handler(inst, **interpreter_state)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/thunder/core/interpreter.py", line 3856, in _call_function_ex_handler
    return check_and_append(stack, _interpret_call(func, *args, **kwargs))
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/thunder/core/interpreter.py", line 6803, in _interpret_call
    rval = _call_dispatch(compilectx, runtimectx, fn, *args, **kwargs)  # type: ignore
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/thunder/core/interpreter.py", line 7005, in _call_dispatch
    return _setup_frame_and_run_python_function(compilectx, runtimectx, wrapped_fn, *args, **kwargs)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/thunder/core/interpreter.py", line 7206, in _setup_frame_and_run_python_function
    res, status = _run_frame(frame, compilectx, runtimectx)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/thunder/core/interpreter.py", line 7256, in _run_frame
    interpretation_result: None | int | INTERPRETER_SIGNALS = compilectx.interpret(
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/thunder/core/interpreter.py", line 410, in interpret
    return self._opcode_interpreter(inst, **interpreter_state)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/thunder/core/interpreter.py", line 1249, in default_opcode_interpreter
    return handler(inst, **interpreter_state)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/thunder/core/interpreter.py", line 3979, in _call_method_handler
    res = _interpret_call(meth, *args)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/thunder/core/interpreter.py", line 6803, in _interpret_call
    rval = _call_dispatch(compilectx, runtimectx, fn, *args, **kwargs)  # type: ignore
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/thunder/core/interpreter.py", line 7001, in _call_dispatch
    return _interpret_call(wrapped_call, *args, **kwargs)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/thunder/core/interpreter.py", line 6803, in _interpret_call
    rval = _call_dispatch(compilectx, runtimectx, fn, *args, **kwargs)  # type: ignore
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/thunder/core/interpreter.py", line 6860, in _call_dispatch
    return _interpret_call(_impl, wrapped_fn, *args, **kwargs)  # type: ignore
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/thunder/core/interpreter.py", line 6803, in _interpret_call
    rval = _call_dispatch(compilectx, runtimectx, fn, *args, **kwargs)  # type: ignore
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/thunder/core/interpreter.py", line 7005, in _call_dispatch
    return _setup_frame_and_run_python_function(compilectx, runtimectx, wrapped_fn, *args, **kwargs)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/thunder/core/interpreter.py", line 7206, in _setup_frame_and_run_python_function
    res, status = _run_frame(frame, compilectx, runtimectx)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/thunder/core/interpreter.py", line 7256, in _run_frame
    interpretation_result: None | int | INTERPRETER_SIGNALS = compilectx.interpret(
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/thunder/core/interpreter.py", line 410, in interpret
    return self._opcode_interpreter(inst, **interpreter_state)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/thunder/core/interpreter.py", line 1249, in default_opcode_interpreter
    return handler(inst, **interpreter_state)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/thunder/core/interpreter.py", line 3856, in _call_function_ex_handler
    return check_and_append(stack, _interpret_call(func, *args, **kwargs))
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/thunder/core/interpreter.py", line 6803, in _interpret_call
    rval = _call_dispatch(compilectx, runtimectx, fn, *args, **kwargs)  # type: ignore
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/thunder/core/interpreter.py", line 6962, in _call_dispatch
    res = lookaside_fn(*args, **kwargs)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/thunder/core/jit_ext.py", line 1139, in _general_custom_op_def_call_lookaside
    output = symbol(*u_args, **u_kwargs)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/thunder/core/symbol.py", line 314, in __call__
    result = self.meta(*args, **kwargs)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/thunder/core/langctxs.py", line 135, in _fn
    result = fn(*args, **kwargs)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/thunder/torch/__init__.py", line 6814, in meta_func
    msg = f"Exception encountered when doing automatic registration for {torch_func.__name__}, please use manual registration: {repr(e)}"
AttributeError: 'NoneType' object has no attribute '__name__'. Did you mean: '__ne__'?

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/teamspace/studios/this_studio/examples/test.py", line 22, in <module>
    assert use_func() == use_func_compiled()
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/thunder/__init__.py", line 839, in wrapped
    return fn(*args, **kwargs)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/thunder/__init__.py", line 887, in fn_
    cache_entry, inps, pro_to_epi = get_computation_and_inputs(*args, **kwargs)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/thunder/__init__.py", line 815, in wrapped
    cache_entry, inps, pro_to_epi = get_computation_and_inputs_fn(*args, **kwargs)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/thunder/core/langctxs.py", line 135, in _fn
    result = fn(*args, **kwargs)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/thunder/__init__.py", line 237, in cache_info_wrapper
    res = fn(*args, **kwargs)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/thunder/__init__.py", line 774, in get_computation_and_inputs
    prologue_trc, computation_trc, epilogue_trc = acquire_initial_trace(fn, args, kwargs, cd, cs, ad_hoc_executor)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/thunder/__init__.py", line 445, in acquire_initial_trace
    jit_results: TraceResults = thunder_general_jit(
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/thunder/core/jit_ext.py", line 2173, in thunder_general_jit
    result = jfn(*args, **kwargs)
  File "/home/zeus/miniconda3/envs/cloudspace/lib/python3.10/site-packages/thunder/core/interpreter.py", line 7555, in fn_
    raise InterpreterError(msg) from e
thunder.core.interpreter.InterpreterError: Encountered exception AttributeError: 'NoneType' object has no attribute '__name__' while tracing <function use_func at 0x7a380bf36680>:
```

Now, it is
```
Traceback (most recent call last):
  File "/teamspace/studios/this_studio/examples/test.py", line 12, in <module>
    thunder.torch.custom_op._register_custom_op(my_func)
  File "/teamspace/studios/this_studio/lightning-thunder/thunder/torch/custom_op.py", line 351, in _register_custom_op
    meta_fn = _get_meta_function_from(custom_op)
  File "/teamspace/studios/this_studio/lightning-thunder/thunder/torch/custom_op.py", line 253, in _get_meta_function_from
    raise ValueError(f"Custom op {custom_op._qualname} has no _abstract_fn defined. "
ValueError: Custom op mynamespace::func has no _abstract_fn defined. You must provide an abstract function (using @torch.library.register_fake) when defining the custom op.
```

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
