### PR TITLE
avoid `torch.float4_e2m1fn_x2` in `_get_min_and_val`

### DIFF
--- a/thunder/dynamo/utils.py
+++ b/thunder/dynamo/utils.py
@@ -533,10 +533,7 @@ def _get_min_and_val(t: torch.Tensor) -> tuple[Number | None, Number | None]:
         or t.device.type == "meta"
         or t.numel() == 0
         or t.dtype.is_complex
-        or (
-            not hasattr(torch, "float4_e2m1fn_x2")
-            or (hasattr(torch, "float4_e2m1fn_x2") and t.dtype == torch.float4_e2m1fn_x2)
-        )
+        or (hasattr(torch, "float4_e2m1fn_x2") and t.dtype == torch.float4_e2m1fn_x2)
     ):
         return None, None
     if t.dtype in (torch.float8_e4m3fn, torch.float8_e4m3fnuz, torch.float8_e5m2, torch.float8_e5m2fnuz):


### PR DESCRIPTION
## What does this PR do?

As per title. We might want to upcast packed fp4 tensors to 16/32-bit to get min and max but for now just avoiding errors from thunderfx `_splitter`