### PR TITLE
Use signature (*args, **kwargs) when signature is unavailable

### DIFF
--- a/thunder/core/codeutils.py
+++ b/thunder/core/codeutils.py
@@ -436,7 +436,10 @@ def get_siginfo(fn: Callable, args, kwargs, *, _make_named_inputs: bool = False)
         fn_ = fn_.meta
 
     # Binds args and kwargs to signature
-    sig = inspect.signature(fn_)
+    try:
+        sig = inspect.signature(fn_)
+    except ValueError:
+        sig = inspect.signature(lambda *args, **kwargs: None)
     kwargs.update(partial_kwargs)
     ba = sig.bind(*args, **kwargs)
 

--- a/thunder/tests/test_core.py
+++ b/thunder/tests/test_core.py
@@ -1620,6 +1620,19 @@ def test_nested_trace_no_name_collision(executor, device, _):
     thunder.trace()(bar, a, b)
 
 
+# Tests if Thunder can trace a function without a valid signature
+@instantiate(dtypes=NOTHING)
+def test_no_signature(executor, device, _):
+    a = make_tensor((2, 3), device=device, dtype=torch.float32)
+
+    fn_trace = thunder.trace()(getattr, a, "mT")
+
+    jfn = executor.make_callable(fn_trace)
+    actual = jfn(a, "mT")
+    expected = getattr(a, "mT")
+    assert_close(actual, expected)
+
+
 @instantiate(dtypes=NOTHING)
 def test_trace_args_no_name_collision(executor, device, _):
     from thunder.core.trace import detached_trace


### PR DESCRIPTION
We use `inspect.signature(fn)` to get the function's signature, particularly the names of its parameters. This raises ValueError when the signature is unavailable, so we guard this and give it a default signature `(*args, **kwargs)`.

## What this fixes
Although Thunder has been able to trace functions containing `getattr(a, "mT")` or `a.mT`, tracing `getattr` itself was impossible.
```py
import torch, thunder

a = torch.randn((2, 3))
print(thunder.trace()(getattr, a, "mT"))
```
`main` 70c0421126b92450c3c3945b7213325f478be2c1
```
  File "/usr/lib/python3.12/inspect.py", line 2224, in _signature_fromstr
    raise ValueError("{!r} builtin has invalid signature".format(obj))
ValueError: <built-in function getattr> builtin has invalid signature
```
This PR (56f4b7cb2901c7714799f6308b32faa6b338ff8c)
```py
# Constructed by Dead Code Elimination (took 0 milliseconds)
import thunder
import thunder.core.prims as prims
import torch
from thunder.executors.torchex import no_autocast

@torch.no_grad()
@no_autocast
def getattr(*args):
  # args: "Collection"
  t0, _, = args
  # t0: "cpu f32[2, 3]"
  # 'mT'
  t1 = prims.transpose(t0, (1, 0))  # t1: "cpu f32[3, 2]"
  return t1
```

## Why this matters
`value_and_grad(getattr)(a, "mT")` raises the same ValueError, which makes ThunderFX think that it doesn't support `getattr`, causing graph break every time it sees `a.mT`. This PR removes such graph breaks.
https://github.com/Lightning-AI/lightning-thunder/blob/70c0421126b92450c3c3945b7213325f478be2c1/thunder/dynamo/utils.py#L312-L322

### Note
1. Trace body and runtime behavior are unaffected.
2. Default signature does not affect what can actually be passed to the function. For example,
```py
thunder.trace()(getattr, a, "mT", None, None)  # TypeError: getattr expected at most 3 arguments, got 4
thunder.trace()(getattr, a, attr="mT")  # TypeError: getattr() takes no keyword arguments
```