### PR TITLE
Change the entrypoint for Inductor on submodules to `compile_fx`

### DIFF
--- a/thunder/dynamo/compiler.py
+++ b/thunder/dynamo/compiler.py
@@ -135,10 +135,6 @@ class ThunderCompiler:
 
         remove_empty_autocast(gm)
 
-        # Dynamo uses lazy generation of the underlying Python code, so we need to
-        # force recompilation of the GraphModule before passing it to Thunder.
-        recompile_graph(gm)
-
         # The whole graph may not be supported by `thunder`, so we split it in `thunder` supported sections
         # and unsupported sections which are passed to `torch.compile(backend='inductor')`
         thunder_options = _with_prologue_pruning_transform(

--- a/thunder/dynamo/compiler.py
+++ b/thunder/dynamo/compiler.py
@@ -8,6 +8,7 @@ import copy
 
 import torch
 from torch._guards import CompileContext as TorchCompileContext
+from torch._inductor.compile_fx import compile_fx
 from torch.utils import _pytree as torch_pytree
 
 from thunder.dynamo.utils import (
@@ -128,7 +129,6 @@ class ThunderCompiler:
             "thunderfx_disable_split_autograd", _DEFAULT_THUNDERFX_DISABLE_SPLIT_AUTOGRAD
         )
         self.thunder_options = thunder_options
-        self._torch_compile = torch.compile
 
     def __call__(self, gm: torch.fx.GraphModule, sample_args: list[torch.SymInt, torch.Tensor]):
         from thunder import jit
@@ -144,7 +144,7 @@ class ThunderCompiler:
         split_module, subgraph_info = _splitter(
             gm,
             partial(jit, **thunder_options),
-            self._torch_compile,
+            compile_fx,
             sample_args,
         )
         self.subgraph_infos.append(subgraph_info)

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -155,6 +155,24 @@ def test_basic_splitter(executor, device: str, dtype: dtypes.dtype, dynamic: boo
     assert any(target.startswith("thunder_") for target in targets)  # Verify that the submodules have name `thunder_*`
 
 
+@instantiate(dtypes=NOTHING)
+def test_fallback_to_inductor(executor, device, dtype):
+    x = torch.randn(3, 3, device=device, dtype=dtype)
+
+    def func(x):
+        return x.sinc().cos().sinc().sinc()
+
+    def trivial_compile(model, *args, **kwargs):
+        return model
+
+    cfunc = thunderfx(func)
+    with patch("torch._inductor.compile_fx.compile_fx", side_effect=trivial_compile) as mock_call:
+        cfunc(x)
+
+    # Once for sinc() and once for sinc().sinc()
+    assert mock_call.call_count == 2
+
+
 @instantiate(
     dtypes=NOTHING,
     executors=[DynamoThunderExecutor],

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -866,10 +866,8 @@ def test_checkpoint_memory_use(op):
     y_ref = fn(x)
     torch.testing.assert_close(y, y_ref)
 
-    if op == torch.sin:
-        assert peak_mem_usage == x.nbytes * 2
-    else:
-        assert peak_mem_usage == x.nbytes * 3
+    assert peak_mem_usage == x.nbytes * 2
+    if op == torch.sinc:
         # Make sure the checkpointed region falled back to PyTorch
         sinfo = jfn._backend.subgraph_infos[-1]
         assert any(n.name.startswith("inductor") for n in sinfo.split_graph_module.graph.nodes)

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -857,7 +857,7 @@ def test_checkpoint_memory_use(op):
 
     initial_mem = torch.cuda.memory_allocated()
 
-    x = torch.randn((1024 // 4, 1024, 1024), device="cuda", requires_grad=True)
+    x = torch.randn((128, 128), device="cuda", requires_grad=True)
     jfn = thunderfx(checkpoint_fn)
     y = jfn(x)
 


### PR DESCRIPTION
Fixes #2539, which in turn fixes #2527 and #2501. This makes PR #2538 obsolete.

We use `compile_fx` to compile the fallback GraphModule. Unlike bare `torch.compile`, `compile_fx` properly lowers the GraphModule as https://github.com/Lightning-AI/lightning-thunder/issues/2527#issuecomment-3334618852 points out.

cc @kiya00 @kshitij12345 