### PR TITLE
Wrap fallback submodules for Inductor in a new `nn.Module`

### DIFF
--- a/thunder/dynamo/compiler.py
+++ b/thunder/dynamo/compiler.py
@@ -135,10 +135,6 @@ class ThunderCompiler:
 
         remove_empty_autocast(gm)
 
-        # Dynamo uses lazy generation of the underlying Python code, so we need to
-        # force recompilation of the GraphModule before passing it to Thunder.
-        recompile_graph(gm)
-
         # The whole graph may not be supported by `thunder`, so we split it in `thunder` supported sections
         # and unsupported sections which are passed to `torch.compile(backend='inductor')`
         thunder_options = _with_prologue_pruning_transform(

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -866,10 +866,8 @@ def test_checkpoint_memory_use(op):
     y_ref = fn(x)
     torch.testing.assert_close(y, y_ref)
 
-    if op == torch.sin:
-        assert peak_mem_usage == x.nbytes * 2
-    else:
-        assert peak_mem_usage == x.nbytes * 3
+    assert peak_mem_usage == x.nbytes * 2
+    if op == torch.sinc:
         # Make sure the checkpointed region falled back to PyTorch
         sinfo = jfn._backend.subgraph_infos[-1]
         assert any(n.name.startswith("inductor") for n in sinfo.split_graph_module.graph.nodes)

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -857,7 +857,7 @@ def test_checkpoint_memory_use(op):
 
     initial_mem = torch.cuda.memory_allocated()
 
-    x = torch.randn((1024 // 4, 1024, 1024), device="cuda", requires_grad=True)
+    x = torch.randn((128, 128), device="cuda", requires_grad=True)
     jfn = thunderfx(checkpoint_fn)
     y = jfn(x)
 


### PR DESCRIPTION
Fixes #2539, which in turn fixes #2527 and #2501. This makes PR #2538 obsolete.

As in https://github.com/Lightning-AI/lightning-thunder/issues/2527#issuecomment-3334005768, when we pass a GraphModule to `torch.compile` it doesn't get lowered properly. As a workaround, this PR wraps the fallback GraphModule in a new `nn.Module`. This workaround was found in https://github.com/Lightning-AI/lightning-thunder/issues/2527#issuecomment-3345877210 (credit @mattteochen).

Alternatively we could call `torch._inductor.compile_fx.compile_fx` directly to compile the GraphModule, but as it returns a bare `forward` function instead of a `nn.Module` instance, it has troubles with registering as a submodule to the outer GraphModule.