### PR TITLE
fix output dtype for nvfuserex cumsum

### DIFF
--- a/thunder/executors/nvfuserex_impl.py
+++ b/thunder/executors/nvfuserex_impl.py
@@ -3268,11 +3268,12 @@ def cumsum_transform(
         mask = fd.ops.triu(mask)
 
         out = fd.ops.matmul(nv_a, mask)
-        out = fd.ops.cast(out, out_dtype)
     else:
         out = fd.ops.cast(nv_a, out_dtype)
         if a.ndim >= 1:
             out = fd.ops.cumsum(out, dim)
+    # restore output dtype in case nvfuser cumsum does implicit type promotion
+    out = fd.ops.cast(out, out_dtype)
     return out
 
 


### PR DESCRIPTION
### Context:

nvfuser can't do cumsum math in reduced precision. The implicit type promotion happening inside needs to be corrected to avoid promoting output dtype as a side effect.