### PR TITLE
getattr should always be taken from the class and then bound

### DIFF
--- a/thunder/tests/test_interpreter.py
+++ b/thunder/tests/test_interpreter.py
@@ -3577,3 +3577,16 @@ def test_binary_subscr_on_types():
     jfn = thunder.jit(fn)
     out = jfn()
     assert out == ("list[int]", "dict[int, int]")
+
+
+def test_getattr_type(jit):
+    m = torch.nn.Linear(5, 2)
+
+    def fn():
+        return bool(m), getattr(m, "weight", None)
+
+    expected = fn()
+    actual = jit(fn)()
+
+    assert actual[0] == expected[0]
+    assert actual[1] is expected[1]


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ n/a ] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

</details>

## What does this PR do?

We take getattr from the type of the object and then bind. e.g. `getattr(klass, "foo")` should go use `type(klass).__getattr__` if present and needed, but not `class.__getattr__`.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
