### PR TITLE
Use `torch._inductor.compile` for ThunderFX fallback entrypoint

### DIFF
--- a/thunder/dynamo/compiler.py
+++ b/thunder/dynamo/compiler.py
@@ -128,7 +128,6 @@ class ThunderCompiler:
             "thunderfx_disable_split_autograd", _DEFAULT_THUNDERFX_DISABLE_SPLIT_AUTOGRAD
         )
         self.thunder_options = thunder_options
-        self._torch_compile = torch.compile
 
     def __call__(self, gm: torch.fx.GraphModule, sample_args: list[torch.SymInt, torch.Tensor]):
         from thunder import jit
@@ -148,7 +147,7 @@ class ThunderCompiler:
         split_module, subgraph_info = _splitter(
             gm,
             partial(jit, **thunder_options),
-            self._torch_compile,
+            torch._inductor.compile,
             sample_args,
         )
         self.subgraph_infos.append(subgraph_info)

--- a/thunder/dynamo/report.py
+++ b/thunder/dynamo/report.py
@@ -1107,7 +1107,7 @@ def analyze_thunder_splits(
             thunder_options[k] = v
 
     thunder_jit = partial(jit, **thunder_options, nv_save_fake_inputs=True)
-    _, subgraph_info = _splitter(gm, thunder_jit, torch.compile, _unused_sample_args=None)
+    _, subgraph_info = _splitter(gm, thunder_jit, torch._inductor.compile, _unused_sample_args=None)
 
     thunder_module_names = [f"{report.graph_name}_{name}" for name in get_thunder_module_names(subgraph_info)]
     original_modules_to_thunder_modules = (

--- a/thunder/dynamo/splitter.py
+++ b/thunder/dynamo/splitter.py
@@ -238,6 +238,9 @@ def _splitter(
                     # This exception is meant to be handled by Dynamo, which is responsible for graph break
                     jit_fn = fallback_torch_compile(f"Dynamic output shape operator encountered: {e}.")
 
+            # This is for ease of debugging. We add graph attribute so GraphModule.print_readable will print it
+            jit_fn.graph = graph_module.graph
+
             # Update the node name from "submod_*" to "inductor_*" for more user-friendly names
             update_node_and_submodule(split_gm, node, node.name.replace("submod", "inductor"), jit_fn)
             submodule_to_compiled_fns[getattr(original_split_gm, node_name)] = CompiledFunction(

--- a/thunder/dynamo/utils.py
+++ b/thunder/dynamo/utils.py
@@ -12,6 +12,8 @@ from collections import namedtuple
 import torch
 from torch.nn.modules.module import _addindent
 from torch.utils.weak import TensorWeakRef
+from torch._guards import detect_fake_mode
+from torch._subclasses.fake_tensor import FakeTensorMode, FakeTensor
 
 if torch.distributed.is_available():
     from torch.distributed.tensor import DTensor
@@ -1050,3 +1052,20 @@ def default_optimizer(gm: torch.fx.GraphModule, stats: ProfileStats) -> Callable
         err_msg = ", ".join([f"{x.name} raised exception: {x.compiled_fn}" for x in sorted_compiled_gm_to_measurement])
         raise RuntimeError(f"No compiler was able to compile the graph module, {err_msg}")
     return sorted_compiled_gm_to_measurement[0].compiled_fn
+
+
+def make_fake_arguments(gm: torch.fx.GraphModule) -> list[FakeTensor] | None:
+    fake_mode = detect_fake_mode()
+    if fake_mode is None:
+        fake_mode = FakeTensorMode()
+    args = []
+    for node in gm.graph.nodes:
+        if node.op == "placeholder":
+            meta_val = node.meta.get("example_value")
+            if meta_val is None:
+                return None
+            if isinstance(meta_val, torch.Tensor):
+                # Tie to the currently enabled fake mode
+                meta_val = fake_mode.fake_tensor_converter.from_real_tensor(fake_mode, meta_val)
+            args.append(meta_val)
+    return args

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -1633,7 +1633,8 @@ def test_spliter_bwd():
     val = torch.randn(nz, dtype=torch.bfloat16, requires_grad=True)
 
     cfn = thunderfx(fn)
-    cfn(x, idx, val)
+    with pytest.warns(match="Dynamic output shape operator"):
+        cfn(x, idx, val)
     reason = cfn._backend.subgraph_infos[0].split_reasons
     assert len(reason) == 1
     assert "Failed while running meta for node with name: setitem" in reason[0].info


### PR DESCRIPTION
Fixes #2539 and other issues it caused.

## What this fixes

`torch.compile` skips the lowering of `GraphModule` that Thunder's splitter emits. This PR passes the `GraphModule` to `torch._inductor.compile` instead, which then calls `torch._inductor.compile_fx.compile_fx`, to make sure Inductor lowers it.

Although it is found in https://github.com/Lightning-AI/lightning-thunder/issues/2527#issuecomment-3345877210 that wrapping the `GraphModule` in a new `Module` is sufficient, it was found in https://github.com/Lightning-AI/lightning-thunder/pull/2551#issuecomment-3347809603 that Dynamo cannot trace the enter/exit of `torch.autocast()` region.

### Why this is more than just replacing the `torch.compile` call

#### (A) Graph Splitting
Inductor assumes that the output node of the `GraphModule` has the form `return (t0, ..., tN)`. Usually `torch.fx.passes.split_module.split_module` (the underlying algorithm of the graph splitter) makes sure this holds for the submodules it creates, but when the splitter cuts out a node that returns a tuple, the output value will look like `return tuple_value`. This breaks Inductor.

<details><summary>Example</summary>

```py
import torch, thunder

def fn(x): return x.sinc()

@thunder.dynamo.thunderfx
def checkpointed_fn(x):
    return torch.utils.checkpoint.checkpoint(fn, x)

checkpointed_fn(torch.randn(2, 3))
```
```py
class GraphModule(torch.nn.Module):
    def forward(self, l_x_: "f32[2, 3]"):
        # No stacktrace found for following nodes
        submod_0 = self.submod_0(l_x_);  l_x_ = None
        submod_1 = self.submod_1(submod_0);  submod_0 = None
        return (submod_1,)
        
    class submod_0(torch.nn.Module):
        def forward(self, l_x_: "f32[2, 3]"):
             # File: /opt/pytorch/lightning-thunder/tmp/main.py:8 in checkpointed_fn, code: return torch.utils.checkpoint.checkpoint(fn, x)
            wrap_body_0 = self.wrap_body_0
            tag_activation_checkpoint = torch.ops.higher_order.tag_activation_checkpoint(wrap_body_0, l_x_);  wrap_body_0 = l_x_ = None
            return tag_activation_checkpoint
            
        class wrap_body_0(torch.nn.Module):
            def forward(self, l_x_: "f32[2, 3]"):
                 # File: /opt/pytorch/lightning-thunder/tmp/main.py:5 in fn, code: def fn(x): return x.sinc()
                sinc: "f32[2, 3]" = l_x_.sinc();  l_x_ = None
                return (sinc,)
                
    class submod_1(torch.nn.Module):
        def forward(self, tag_activation_checkpoint):
             # File: /opt/pytorch/lightning-thunder/tmp/main.py:8 in checkpointed_fn, code: return torch.utils.checkpoint.checkpoint(fn, x)
            getitem: "f32[2, 3]" = tag_activation_checkpoint[0];  tag_activation_checkpoint = None
            return getitem
```
```
  File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/_aot_autograd/utils.py", line 555, in call_and_expect_output_descs
    assert out_spec == out_desc_spec, (
           ^^^^^^^^^^^^^^^^^^^^^^^^^
torch._dynamo.exc.BackendCompilerFailed: backend='<thunder.dynamo.compiler.ThunderCompiler object at 0x7c1a8fe84410>' raised:
AssertionError: ([<function aot_stage1_graph_capture.<locals>.orig_flat_fn2 at 0x7c1a5434ede0>, <function create_functional_call.<locals>.functional_call at 0x7c1a5423ab60>, GraphModule(
  (wrap_body_0): GraphModule()
)], [(FunctionalTensor(_to_functional_tensor(FakeTensor(..., size=(2, 3)))),)], [PlainAOTOutput(idx=0)], TreeSpec(immutable_list, None, [TreeSpec(tuple, None, [*])]), TreeSpec(immutable_list, None, [*]))
```
This is a complaint for `return tag_activation_checkpoint`, which `compile_fx.make_graph_return_tuple` converts to `return [tag_activation_checkpoint]`.

</details>

We work around this by grouping the subsequent `getitem` node together into the node that was cut out. This hack is applied to nodes whose `example_value` is a tuple, which includes `torch.ops.higher_order.tag_activation_checkpoint` and `torch.ops.higher_order.autograd_function_apply`.

#### (B) Graph break inside Inductor's fallback submodule

Inductor is not responsible for breaking the graph, so it raises an exception when it encounters something it cannot compile. 

<details><summary>Example</summary>

```py
import torch, thunder.dynamo

@thunder.dynamo.thunderfx
def fn(x, idx, val):
    x = x.clone()
    x[idx] = val
    return x

x = torch.randn(3, requires_grad=True)
idx = x > 0.5
val = torch.randn(torch.count_nonzero(idx), requires_grad=True)

fn(x, idx, val)
```
```py
class GraphModule(torch.nn.Module):
    def forward(self, l_x_: "f32[3]", l_idx_: "b8[3]", l_val_: "f32[2]"):
        # No stacktrace found for following nodes
        submod_0 = self.submod_0(l_x_);  l_x_ = None
        submod_1 = self.submod_1(submod_0, l_idx_, l_val_);  l_idx_ = l_val_ = submod_1 = None
        return (submod_0,)
        
    class submod_0(torch.nn.Module):
        def forward(self, l_x_: "f32[3]"):
             # File: /opt/pytorch/lightning-thunder/tmp/main.py:7 in fn, code: x = x.clone()
            x: "f32[3]" = l_x_.clone();  l_x_ = None
            return x
            
    class submod_1(torch.nn.Module):
        def forward(self, x: "f32[3]", l_idx_: "b8[3]", l_val_: "f32[2]"):
             # File: /opt/pytorch/lightning-thunder/tmp/main.py:8 in fn, code: x[idx] = val
            x[l_idx_] = l_val_;  setitem = x;  x = l_idx_ = l_val_ = setitem = None
            return ()         
```
```
torch._subclasses.fake_tensor.DynamicOutputShapeException: aten.nonzero.default
```

</details>

We must catch the exception and let Dynamo handle it by falling further back to `torch.compile`. I except there are a lot more exceptions that `torch._inductor.compiler` may raise. There are no common supertype for such exceptions, so we will have to cover each of them when it pops up.

#### (C) Lack of `example_value`

Inductor requires instances of `FakeTensor`s representing the inputs. This is sometimes unavailable: see #2429. We will simply fall back to `torch.compile` in such cases.

## Concern

This PR does not cover cases where a submodule containing `torch.autocast()` region falls back to `torch.compile` (when (B) or (C) applies). `AssertionError` is raised in such cases (see the new test which is xfailed).

Should we catch such errors and resort to eager mode? I wonder how big the impact will be.