### PR TITLE
fix: call torch.cuda.is_available() in available_devices

### DIFF
--- a/thunder/core/devices.py
+++ b/thunder/core/devices.py
@@ -140,7 +140,7 @@ def available_devices() -> tuple[Device]:
     available_devices = [cpu]
 
     # Short-circuits if there are no CUDA devices
-    if not torch.cuda.is_available:
+    if not torch.cuda.is_available():
         return available_devices
 
     # NOTE torch.cuda.is_available, extends with CUDA devices


### PR DESCRIPTION
Fix always false issue in the branch where `torch.cuda.is_available` function is being checked instead of the checking of return value of this function 