### PR TITLE
Add TE's NVFP4 recipe to the test suite

### DIFF
--- a/thunder/executors/transformer_engineex_impl.py
+++ b/thunder/executors/transformer_engineex_impl.py
@@ -294,7 +294,7 @@ def _linear_checker(
         if hasattr(fp8_recipe, "nvfp4") and fp8_recipe.nvfp4():
             from transformer_engine.pytorch.constants import NVFP4_BLOCK_SCALING_SIZE
 
-            # Check inherited from TE https://github.com/ksivaman/TransformerEngine-1/blob/1af7dd88aae5afb45e82148089038e1d1de9675d/transformer_engine/pytorch/tensor/nvfp4_tensor.py#L176-L184
+            # Check inherited from TE https://github.com/NVIDIA/TransformerEngine/blob/7e45be73bb8d513abe8785ee078ac88719bcd9f1/transformer_engine/pytorch/tensor/nvfp4_tensor.py#L180-L188
             return (
                 len(shape) >= 2
                 and shape[0] % NVFP4_BLOCK_SCALING_SIZE == 0

--- a/thunder/tests/test_transformer_engine_executor.py
+++ b/thunder/tests/test_transformer_engine_executor.py
@@ -3,6 +3,7 @@ from functools import partial
 import pytest
 import torch
 from torch.testing import assert_close
+from looseversion import LooseVersion
 
 import thunder
 from thunder.tests.framework import requiresCUDA
@@ -16,6 +17,7 @@ transformer_engine_module = pytest.importorskip(
 )
 
 from thunder.executors.transformer_engineex import transformer_engine_ex, TransformerEngineTransform
+
 from transformer_engine.common import recipe
 import transformer_engine.pytorch as te
 
@@ -24,6 +26,9 @@ import transformer_engine.pytorch as te
 # Skip the tests if current hardware is not supported.
 is_fp8_supported, msg_fp8 = te.fp8.check_fp8_support()
 is_mxfp8_supported, msg_mxfp8 = te.fp8.check_mxfp8_support()
+
+# check_fp8_support is a subset of check_nvfp4_support, therefore even NVFP4 tests can be skipped if fp8 is not available
+# https://github.com/NVIDIA/TransformerEngine/blob/dfe5b7dfc2288afc5d2f247709b1e0328af331e4/transformer_engine/pytorch/fp8.py#L58
 if not is_fp8_supported:
     pytest.skip(msg_fp8, allow_module_level=True)
 
@@ -96,6 +101,69 @@ def test_te_linear_forward_backward(fp8_recipe: recipe.Recipe):
 
     assert any(bsym.sym.name.startswith("te_functional_linear") for bsym in forward_trace[-1].bound_symbols)
     assert any(bsym.sym.name.startswith("te_functional_linear_bwd") for bsym in backward_trace[-1].bound_symbols)
+    # and only two
+    assert 2 == len(
+        tuple(filter(lambda bsym: bsym.sym.name.startswith("te_functional_linear"), forward_trace[-1].bound_symbols))
+    )
+
+
+@requiresCUDA
+@skip_on_sm120_and_sm121
+def test_te_linear_nvfp4_forward():
+    import transformer_engine
+    # NVFP4 is available from TE 2.8 onwards and supported only for arch 10.0 onwards.
+    is_nvfp4_available = LooseVersion(transformer_engine.__version__) >= LooseVersion("2.8")
+
+    if not is_nvfp4_available:
+        pytest.skip("TE NVFP4 recipe is not available")
+
+    is_nvfp4_supported, msg_nvfp4 = te.fp8.check_nvfp4_support()
+
+    if not is_nvfp4_supported:
+        pytest.skip(msg_nvfp4)
+
+    nvfp4_e2m1_recipe = recipe.NVFP4BlockScaling()
+
+    # Test Description:
+    # Verify that `torch.nn.functional.linear` is replaced with `te_linear_*`
+    # and the output as well as the gradients match for thunder compiled code.
+    dtype = torch.bfloat16
+    device = "cuda"
+
+    # TE inputs (3D input)
+    x_te = torch.randn(3, 768, 4096, device=device, dtype=dtype, requires_grad=False)
+    te_linear1 = te.Linear(4096, 4096, params_dtype=dtype)
+    te_linear2 = te.Linear(4096, 2048, params_dtype=dtype)
+
+    # thunder inputs
+    x = x_te.detach().clone()
+    w1 = te_linear1.weight.detach().clone()
+    w1.requires_grad_(True)
+    w2 = te_linear2.weight.detach().clone()
+    w2.requires_grad_(True)
+
+    def fn(x, w1, w2):
+        o = torch.nn.functional.linear(x, w1)
+        return torch.nn.functional.linear(o + x, w2)
+
+    cfn = thunder.jit(fn, executors=[transformer_engine_ex], transforms=[TransformerEngineTransform()])
+
+    # Enable autocasting for the forward pass
+    with te.fp8_autocast(fp8_recipe=nvfp4_e2m1_recipe):
+        thunder_result = cfn(x, w1, w2)
+
+    # Enable autocasting for the forward pass
+    with te.fp8_autocast(fp8_recipe=nvfp4_e2m1_recipe):
+        inter_result = te_linear1(x_te)
+        te_result = te_linear2(inter_result + x_te)
+
+    # Verifies the result is close to TE
+    assert_close(thunder_result, te_result)
+
+    # Verifies te_linear was called
+    forward_trace = thunder.last_traces(cfn)
+
+    assert any(bsym.sym.name.startswith("te_functional_linear") for bsym in forward_trace[-1].bound_symbols)
     # and only two
     assert 2 == len(
         tuple(filter(lambda bsym: bsym.sym.name.startswith("te_functional_linear"), forward_trace[-1].bound_symbols))

--- a/thunder/tests/test_transformer_engine_executor.py
+++ b/thunder/tests/test_transformer_engine_executor.py
@@ -39,7 +39,7 @@ recipe_ids = ("default", "delayed_scaling", "mxfp8_e4m3")
 @pytest.mark.parametrize("fp8_recipe", recipes, ids=recipe_ids)
 @skip_on_sm120_and_sm121
 def test_te_linear_forward_backward(fp8_recipe: recipe.Recipe):
-    if fp8_recipe and not (fp8_recipe.delayed() or is_mxfp8_supported):
+    if fp8_recipe and fp8_recipe.mxfp8() and not is_mxfp8_supported:
         pytest.skip(msg_mxfp8)
 
     if is_sm120_orsm121 and fp8_recipe is None:
@@ -111,7 +111,7 @@ def test_te_linear_forward_backward_multiple_iteration(fp8_recipe: recipe.Recipe
             "When recipe is None a new recipe is created for each iteration. This makes the results not numerically comparable."
         )
 
-    if fp8_recipe and not (fp8_recipe.delayed() or is_mxfp8_supported):
+    if fp8_recipe and fp8_recipe.mxfp8() and not is_mxfp8_supported:
         pytest.skip(msg_mxfp8)
 
     # Test Description:
@@ -396,7 +396,7 @@ def test_te_grad_computation_with_intermediate():
 @pytest.mark.parametrize("fp8_recipe", recipes, ids=recipe_ids)
 @skip_on_sm120_and_sm121
 def test_te_trace_correctness(fp8_recipe: recipe.Recipe):
-    if fp8_recipe and not (fp8_recipe.delayed() or is_mxfp8_supported):
+    if fp8_recipe and fp8_recipe.mxfp8() and not is_mxfp8_supported:
         pytest.skip(msg_mxfp8)
 
     def foo(x, w):
@@ -467,7 +467,7 @@ def test_te_trace_correctness(fp8_recipe: recipe.Recipe):
 @pytest.mark.parametrize("compile_path", ["jit", "ThunderFX"])
 @skip_on_sm120_and_sm121
 def test_te_activation_checkpointing_trace(fp8_recipe: recipe.Recipe, compile_path: str):
-    if fp8_recipe and not (fp8_recipe.delayed() or is_mxfp8_supported):
+    if fp8_recipe and fp8_recipe.mxfp8() and not is_mxfp8_supported:
         pytest.skip(msg_mxfp8)
 
     if not fp8_recipe:
@@ -527,7 +527,7 @@ def test_te_activation_checkpointing_correctness(fp8_recipe: recipe.Recipe, comp
             "When recipe is None a new recipe is created for each iteration. This makes the results not numerically comparable."
         )
 
-    if fp8_recipe and not (fp8_recipe.delayed() or is_mxfp8_supported):
+    if fp8_recipe and fp8_recipe.mxfp8() and not is_mxfp8_supported:
         pytest.skip(msg_mxfp8)
 
     dtype = torch.bfloat16


### PR DESCRIPTION
## What does this PR do?

Now that the PR was merged in TE we can enable NVFP4BlockScaling recipe testing in Thunder. 

This recipe is available only from TE v2.8 and for compute capability >= 10.0 . Therefore I've added two variables that do the both of the checks. Availability is important because for TE < 2.8 the `recipe.nvfp4()` method is not available. 

I've also disabled all randomness from the recipe otherwise the results wouldn't be deterministic/precise.
