### PR TITLE
Remove cuda checks from TE and Triton xentropy executors

### DIFF
--- a/thunder/executors/transformer_engineex.py
+++ b/thunder/executors/transformer_engineex.py
@@ -8,21 +8,19 @@ from thunder import Transform
 from thunder.extend import StatefulExecutor
 from thunder.core.trace import TraceCtx
 
-import torch
-
 __all__ = ["transformer_engine_ex", "TransformerEngineTransform", "_te_activation_checkpointing_transform"]
 
 transformer_engine_ex: None | StatefulExecutor = None
 TransformerEngineTransform: None | Transform = None
 _te_activation_checkpointing_transform: None | Callable[[TraceCtx], TraceCtx] = None
 
-if torch.cuda.is_available():
-    if package_available("transformer_engine"):
-        import thunder.executors.transformer_engineex_impl as impl
 
-        transformer_engine_ex = impl.transformer_engine_ex
-        TransformerEngineTransform = impl.TransformerEngineTransform
-        _te_activation_checkpointing_transform = impl._te_activation_checkpointing_transform
+if package_available("transformer_engine"):
+    import thunder.executors.transformer_engineex_impl as impl
 
-    else:
-        warnings.warn("transformer_engine module not found!")
+    transformer_engine_ex = impl.transformer_engine_ex
+    TransformerEngineTransform = impl.TransformerEngineTransform
+    _te_activation_checkpointing_transform = impl._te_activation_checkpointing_transform
+
+else:
+    warnings.warn("transformer_engine module not found!")

--- a/thunder/executors/triton_crossentropy.py
+++ b/thunder/executors/triton_crossentropy.py
@@ -1,20 +1,19 @@
 from thunder.executors import triton_utils
 from thunder.extend import OperatorExecutor
 
-import torch
 
 triton_version: None | str = triton_utils.triton_version()
 
 triton_ex: None | OperatorExecutor = None
 
-if torch.cuda.is_available():
-    if triton_version is not None:
-        try:
-            from thunder.executors.triton_crossentropy_impl import triton_ex as impl_ex
 
-            triton_ex = impl_ex
-        except Exception:
-            import warnings
+if triton_version is not None:
+    try:
+        from thunder.executors.triton_crossentropy_impl import triton_ex as impl_ex
 
-            warnings.warn("triton is present but cannot be initialized")
-            triton_version = None
+        triton_ex = impl_ex
+    except Exception:
+        import warnings
+
+        warnings.warn("triton is present but cannot be initialized")
+        triton_version = None


### PR DESCRIPTION
As per title, checks if cuda is available or not should not be done in the executor import file but outside. 

I don't see a strong motivation behind the change that happened in this unrelated PR here #2525, but I am open for discussion :) 
