### PR TITLE
Propagated requires_grad to torch tensor

### DIFF
--- a/thunder/tests/test_grad.py
+++ b/thunder/tests/test_grad.py
@@ -155,9 +155,17 @@ def _from_numpy(x, like):
     """
     assert isinstance(like, torch.Tensor), f"_from_numpy: Unsupported type of the second argument {type(like)}"
     if isinstance(x, np.ndarray):
-        return torch.from_numpy(x).to(device=like.device)
+        t = torch.from_numpy(x).to(device=like.device, dtype=like.dtype)
+        # Preserve the requires_grad property to avoid cache mismatches
+        t.requires_grad_(getattr(like, "requires_grad", False))
+        return t
     if isinstance(x, torch.Tensor) or isinstance(x, np.float64):
-        return torch.tensor(x, device=like.device, dtype=like.dtype)
+        return torch.tensor(
+            x,
+            device=like.device,
+            dtype=like.dtype,
+            requires_grad=getattr(like, "requires_grad", False),
+        )
     raise ValueError(f"_from_numpy: Unsupported type of the first argument {type(x)}")
 
 


### PR DESCRIPTION
## What does this PR do?

Propagates the `requires_grad` attribute during tensor conversion from numpy to torch.
