### PR TITLE
Fixes function name is not defined when using `DebugTransform`

### DIFF
--- a/thunder/dev_utils/debug_transform.py
+++ b/thunder/dev_utils/debug_transform.py
@@ -52,6 +52,7 @@ class DebugTransform(thunder.core.transforms.Transform):
         new_bsyms: list[BoundSymbol] = []
         for bsym in trace.bound_symbols:
             sym_name = bsym.sym.name
+            sym_name = sym_name.replace(".", "_")
 
             if bsym.sym.id in NON_COMPUTATION_PRIMS:
                 new_bsyms.append(bsym)


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [ ] Was this discussed/approved via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

</details>

## What does this PR do?

when using `DebugTransform`, there's error when the symbol name contains `.`, here's an example:
```
File "thunder.backward_fn_2", line 863, in backward_fn
    debug_post_torch.ops.aten.embedding_backward289(t1585, t1583, l_idx_, 320, -1, False, False)
    ^^^^^^^^^^^^^^^^
NameError: name 'debug_post_torch' is not defined. Did you mean: 'debug_post_pow22'?
```

