### PR TITLE
add mask lookaside into transformers recipe

### DIFF
--- a/thunder/benchmarks/benchmark_inference.py
+++ b/thunder/benchmarks/benchmark_inference.py
@@ -279,6 +279,7 @@ class InferenceBenchmark:
             res = {"nv_enable_linear": True, "nv_enable_matmul": True}
         if self.config.mode == "thunderjit":
             from thunder.recipes.hf_transformers import SDPAMaskTransform
+
             if not hasattr(self, "_mask_transform"):
                 self._mask_transform = SDPAMaskTransform()
             res["transforms"] = [self._mask_transform]

--- a/thunder/recipes/hf_transformers.py
+++ b/thunder/recipes/hf_transformers.py
@@ -1,7 +1,7 @@
 from distutils.version import LooseVersion
 from functools import partial
 import warnings
-from typing import Callable
+from collections.abc import Callable
 
 import torch
 


### PR DESCRIPTION
## What does this PR do?

This adds a mask lookaside into the transformers recipe.
The mask generation in transformers is tricky as it uses vmap, which thunder does not support yet.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
