### PR TITLE
Fix thunderjit in inference benchmark

### DIFF
--- a/thunder/benchmarks/benchmark_inference.py
+++ b/thunder/benchmarks/benchmark_inference.py
@@ -345,7 +345,9 @@ class InferenceBenchmark:
 
         return input_ids, past_key_values
 
-    def get_next_token(self, input_ids: torch.Tensor, past_key_values: HybridChunkedCache | StaticCache) -> torch.Tensor:
+    def get_next_token(
+        self, input_ids: torch.Tensor, past_key_values: HybridChunkedCache | StaticCache
+    ) -> torch.Tensor:
         start_pos = past_key_values.get_seq_length()
         cache_position = start_pos + torch.arange(0, input_ids.shape[1], device=start_pos.device, dtype=start_pos.dtype)
         with torch.no_grad():


### PR DESCRIPTION
## What does this PR do?

Fixes thunderjit runs on benchmark. Relies on #2639 and transformers 4.55.4 was used to test.

I've put most things behind checking for thunderjit, except one (likely graph break) data dependent control flow workaround (the cache_positions).
Note that thunderjit uses StaticCache, my understanding is that HybridChunkedCache is deprecated in favour of using StaticCache, but I did not want to interfere with the thunderfx benchmarking. 

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
