### PR TITLE
Reset peak memory stats before measurement

### DIFF
--- a/thunder/benchmarks/benchmark_inference.py
+++ b/thunder/benchmarks/benchmark_inference.py
@@ -470,6 +470,9 @@ class InferenceBenchmark:
         print(f"\nRunning {self.config.num_iterations} benchmark iterations...")
         all_metrics = []
 
+        if torch.cuda.is_available():
+            torch.cuda.reset_peak_memory_stats()
+
         for _ in tqdm(range(self.config.num_iterations), disable=LOCAL_RANK != 0):
             past_key_values.reset()
             iter_metrics = self.measure_inference_step(input_ids, past_key_values, self.config.output_length)


### PR DESCRIPTION
With this, benchmark_inference.py starts to show memory-usage differences between 2 GPUs (20GB) and 4 GPUs (12GB). 

```
$ torchrun --local-ranks-filter 0 --nproc-per-node 2 thunder/benchmarks/benchmark_inference.py --input-length 32 --output-length 32 --mode eager --num-iterations 10

============================================================
BENCHMARK RESULTS - meta-llama/Llama-4-Maverick-17B-128E eager
============================================================

Throughput Metrics:
  Overall Throughput: 21.77 tokens/sec
  Prefill Throughput: 688.79 tokens/sec
  Decode Throughput: 21.78 tokens/sec
  Latency: 45.94 ms/token

Latency Breakdown:
  Time to First Token (TTFT): 46.46 ms
  Time Between Output Tokens (TBOT): 45.92 ms
  Prefill Time: 46.46 ms
  Decode Time: 1423.53 ms
  Total Generation Time: 1469.99 ms

Memory Usage:
  Current Memory: 20.76 GB
  Peak Memory: 20.78 GB

Variance Analysis:
  Throughput Std Dev: 3.74 ms
  TTFT Std Dev: 0.25 ms
```

```
$ torchrun --local-ranks-filter 0 --nproc-per-node 4 thunder/benchmarks/benchmark_inference.py --input-length 32 --output-length 32 --mode eager --num-iterations 10

============================================================
BENCHMARK RESULTS - meta-llama/Llama-4-Maverick-17B-128E eager
============================================================

Throughput Metrics:
  Overall Throughput: 21.61 tokens/sec
  Prefill Throughput: 682.74 tokens/sec
  Decode Throughput: 21.62 tokens/sec
  Latency: 46.27 ms/token

Latency Breakdown:
  Time to First Token (TTFT): 46.87 ms
  Time Between Output Tokens (TBOT): 46.25 ms
  Prefill Time: 46.87 ms
  Decode Time: 1433.80 ms
  Total Generation Time: 1480.68 ms

Memory Usage:
  Current Memory: 12.45 GB
  Peak Memory: 12.47 GB

Variance Analysis:
  Throughput Std Dev: 4.36 ms
  TTFT Std Dev: 0.32 ms
```