### PR TITLE
[benchmark_inference] Reshape the output from run_routed_experts

### DIFF
--- a/thunder/benchmarks/layers_for_inference_benchmark.py
+++ b/thunder/benchmarks/layers_for_inference_benchmark.py
@@ -605,7 +605,7 @@ class Llama4MoE(nn.Module):
         token_ids_sorted_by_expert_inverse_id = torch.argsort(token_ids_sorted_by_expert_id)
         outs_sorted_by_token_id = outs_sorted_by_expert_id[token_ids_sorted_by_expert_inverse_id]
 
-        return outs_sorted_by_token_id, router_logits
+        return outs_sorted_by_token_id.view(batch_size, seq_len, -1), router_logits.view(batch_size, seq_len, -1)
 
     def forward(self, hidden_states: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
         outs_sorted_by_token_id, router_logits = self.run_routed_experts(hidden_states)


### PR DESCRIPTION
CMD: `python thunder/benchmarks/benchmark_inference.py --input-length 32 --output-length 32 --mode eager --num-iterations 10 --batch-size 32`

Fails without the patch
```python
File "/opt/pytorch/lightning-thunder/thunder/benchmarks/layers_for_inference_benchmark.py", line 612, in forward
    return self.shared_experts(hidden_states) + outs_sorted_by_token_id, router_logits
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
RuntimeError: The size of tensor a (32) must match the size of tensor b (1024) at non-singleton dimension 1
```