### PR TITLE
Add an option to profile only non-warmup iterations

### DIFF
--- a/thunder/benchmarks/benchmark_inference.py
+++ b/thunder/benchmarks/benchmark_inference.py
@@ -153,6 +153,7 @@ class InferenceBenchmarkConfig:
     enable_nv_linear: bool
     mode: str
     disable_moe_replacement: bool
+    profile: bool
 
 
 @dataclass
@@ -474,7 +475,13 @@ class InferenceBenchmark:
 
         for _ in tqdm(range(self.config.num_iterations), disable=LOCAL_RANK != 0):
             past_key_values.reset()
+
+            if self.config.profile:
+                torch.cuda.cudart().cudaProfilerStart()
             iter_metrics = self.measure_inference_step(input_ids, past_key_values, self.config.output_length)
+            if self.config.profile:
+                torch.cuda.cudart().cudaProfilerStop()
+
             all_metrics.append(iter_metrics)
 
             # Track metrics
@@ -661,6 +668,11 @@ Examples:
         action="store_true",
         help="let nvfuser take care of linear and matmul, note that this might fail with distributed run. See: https://github.com/NVIDIA/Fuser/issues/4507",
     )
+    parser.add_argument(
+        "--profile",
+        action="store_true",
+        help="Wrap each non-warmup iteration with cudaProfilerStart() and cudaProfilerStop(). This allows us to run `nsys profile --capture-range=cudaProfilerApi --capture-range-end=repeat:<N> ... --profile` to record only the non-warmup iterations.",
+    )
 
     parser.add_argument("--save-results", action="store_true", help="Save results to JSON file")
     parser.add_argument("--output-dir", type=str, default="./results", help="Directory to save results")
@@ -696,6 +708,7 @@ def main():
         fx_report_folder=args.fx_report_folder,
         enable_nv_linear=args.enable_nv_linear,
         disable_moe_replacement=args.disable_moe_replacement,
+        profile=args.profile,
     )
     benchmark = InferenceBenchmark(config)
 


### PR DESCRIPTION
It's useful for performance debugging. A common recipe for me is

```
$ nsys profile --capture-range=cudaProfilerApi --capture-range-end=repeat:1 torchrun --local-ranks-filter 0 --nproc-per-node 2 thunder/benchmarks/benchmark_inference.py --input-length 32 --output-length 2 --mode thunder --profile
$ nsys stats -r cuda_gpu_kern_sum report1.nsys-rep
```