### PR TITLE
Add requires_grad in test_div_exact

### DIFF
--- a/thunder/tests/test_ops.py
+++ b/thunder/tests/test_ops.py
@@ -536,7 +536,7 @@ def test_div_exact():
     jfn = thunder.jit(fn)
     a = torch.randint(1, 5, (5,))
     b = torch.ones(5, dtype=torch.int32)
-    c = torch.randn(5, 5)
+    c = torch.randn((5, 5), requires_grad=True)
     assert_close(fn(a, b, c), jfn(a, b, c))
     trc = thunder.last_traces(jfn)[-1]
     for bsym in trc.bound_symbols:


### PR DESCRIPTION
Somehow the `require_grad` attribute evaporated between iterations of this test.  It is necessary to trigger the code path that would result in ints rather than floats in the calculation of `indices` if `div_exact` didn't exist.
