### PR TITLE
benchmark_inference: set requires_grad=False on params

### DIFF
--- a/thunder/benchmarks/benchmark_inference.py
+++ b/thunder/benchmarks/benchmark_inference.py
@@ -262,7 +262,7 @@ class InferenceBenchmark:
         model.to_empty(device=DEVICE)
         assert all(p.device == DEVICE for p in model.parameters())
 
-        # Required as that doesn't understand inference mode
+        # Required as thunder doesn't understand inference mode
         # And some prims like `prims._grouped_mm` don't have grad rule defined yet.
         for p in model.parameters():
             p.requires_grad_(False)


### PR DESCRIPTION
While adding support for DTensor, settings `requires_grad=False` was moved and not applied on the single-GPU path.