### PR TITLE
Use torch._grouped_mm in eager mode

### DIFF
--- a/thunder/benchmarks/layers_for_inference_benchmark.py
+++ b/thunder/benchmarks/layers_for_inference_benchmark.py
@@ -355,7 +355,7 @@ else:
 
 
 def grouped_mm(a: torch.Tensor, b: torch.Tensor, offsets: torch.Tensor) -> torch.Tensor:
-    if _grouped_mm:
+    if _grouped_mm is not None:
         return _grouped_mm(a, b, offsets)
 
     group_sizes = _group_sizes_from_offsets(offsets)


### PR DESCRIPTION
This gives a fair comparison between eager and other modes.

The constraints mentioned in the comment seem to have been fixed by https://github.com/pytorch/pytorch/pull/161407

`python thunder/benchmarks/benchmark_inference.py` at head runs fine on both Blackwell and Ampere. 