### PR TITLE
[fix] Remove TE v1 from low precision options

### DIFF
--- a/thunder/benchmarks/benchmark_litgpt.py
+++ b/thunder/benchmarks/benchmark_litgpt.py
@@ -79,20 +79,18 @@ class LowPrecisionHandler:
     enabled: bool = False
 
     use_thunder_te: bool = True
-    use_legacy_thunder_te: bool = False
 
     @property
     def use_te_autocast(self) -> bool:
-        return self.enabled and not self.use_legacy_thunder_te
+        return self.enabled
 
     def check_and_add_compile_options(self, compile_options: str) -> str:
         if not self.enabled and "_transformerengine" in compile_options:
             raise ValueError("Low precision mode not specified but found transfomerengine in the compile options!")
 
         self.use_thunder_te = "thunder" in compile_options
-        self.use_legacy_thunder_te = "transformerengine_v1" in compile_options
 
-        if self.enabled and self.use_thunder_te and not self.use_legacy_thunder_te:
+        if self.enabled and self.use_thunder_te:
             compile_options += "_transformerengine"
         return compile_options
 
@@ -120,15 +118,13 @@ class LowPrecisionHandler:
     def executor_str(self) -> str:
         if not self.enabled:
             return "low precision is not enabled"
-        elif self.use_legacy_thunder_te:
-            return "Thunder TE executor v1"
         elif self.use_thunder_te:
             return "Thunder TE executor"
         else:
             return "TransformerEngine without Thunder"
 
     def maybe_apply_te_autocast(self):
-        if self.enabled and not self.use_legacy_thunder_te:
+        if self.enabled:
             return te.fp8_autocast(fp8_recipe=self.fp8_recipe)
         else:
             return nullcontext()
@@ -160,7 +156,7 @@ class LowPrecisionHandler:
             print("No updates were necessary.")
 
     def swap_linear_layers_for_te(self, model: torch.nn.Module, device: Any) -> None:
-        if not self.enabled or self.use_thunder_te:
+        if not self.enabled:
             return
 
         swap_layernorm = self.mode == "fp8-default-te-wo_layernorm"


### PR DESCRIPTION
This PR removes TE v1 leftovers from #2762 in the low precision class created in #2615

Makes the following combination matrix:


  | compile option | compile option | compile option | compile option
-- | -- | -- | -- | --
low precision mode | inductor | eager | thunder | dynamo_thunder
none | bf16 | bf16 | bf16 | bf16
fp8-default-te | fp8 TE | fp8 TE | fp8 ThunderTE ex | fp8 ThunderTE ex
fp8-default-te-wo_layernorm | fp8 TE + TE layernorm | fp8 TE + TE layernorm | jit broken | fp8 ThunderTEex + TE layernorm




