### PR TITLE
Convert functions to modules for autograd_function_apply

### DIFF
--- a/thunder/tests/test_jit_general.py
+++ b/thunder/tests/test_jit_general.py
@@ -1238,7 +1238,7 @@ def test_autograd_function_apply():
     # see https://github.com/Lightning-AI/lightning-thunder/issues/1248#issuecomment-2388655917
     # for why `torch.foo` instead of `torch.Tensor.foo`
 
-    # Since https://github.com/pytorch/pytorch/pull/169528 `torch.ops.higher_order.autograd_function_apply`
+    # since https://github.com/pytorch/pytorch/pull/169528 `torch.ops.higher_order.autograd_function_apply`
     # no longer accepts simple callables, but rather `torch.fx.GraphModule`s.
 
     class FwdModule(torch.nn.Module):


### PR DESCRIPTION
[PyTorch recently made changes](https://github.com/pytorch/pytorch/pull/169528) to `autograd_function_apply` which now requires the `fwd` and `bwd` input to be `torch.fx.GraphModule`s rather than callables.  Thunder's test `test_autograd_function_apply` currently uses callables and not modules.  This PR converts the callables to modules.  
