### PR TITLE
Install CPU-only PyTorch for GitHub Actions

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -26,6 +26,7 @@ jobs:
     env:
       ARTIFACT_DAYS: 0
       PYPI_LOCAL_DIR: "pypi_pkgs/"
+      TORCH_URL: "https://download.pytorch.org/whl/cpu"
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
@@ -39,7 +40,7 @@ jobs:
         run: sudo apt-get install -y pandoc
       - name: Install package & dependencies
         timeout-minutes: 20
-        run: pip install . -U -r requirements/docs.txt
+        run: pip install . -U -r requirements/docs.txt --extra-index-url=${TORCH_URL}
 
       - name: Make ${{ matrix.target }}
         working-directory: docs/


### PR DESCRIPTION
Fixes #2809. We install CPU-only PyTorch.

This aligns with the `ci-testing` CI:

https://github.com/Lightning-AI/lightning-thunder/blob/a0d03353130895891ae151f928a9e61ccaa90148/.github/workflows/ci-testing.yml#L20-L21