### PR TITLE
Use nvfuser_direct for version checking

### DIFF
--- a/scripts/validate_build.py
+++ b/scripts/validate_build.py
@@ -12,7 +12,7 @@ def main():
     actual = os.path.abspath(torch.__file__)
     assert expected == actual, f"{expected} vs. {actual}"
 
-    import nvfuser
+    import nvfuser_direct as nvfuser
     from looseversion import LooseVersion
 
     assert LooseVersion(nvfuser.version()) >= LooseVersion("0.0.6"), nvfuser.version()


### PR DESCRIPTION
PyTorch 2.8 CIs have been using nvFuser 0.2.34, the version that supports direct bindings: https://github.com/Lightning-AI/lightning-thunder/blob/main/thunder/executors/nvfuserex_impl.py#L74

<img width="2517" height="463" alt="image" src="https://github.com/user-attachments/assets/f3515861-646e-44bd-a051-984ed5edd2d9" />
