### PR TITLE
fix: correct typos in comments and docstrings

### DIFF
--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -1888,7 +1888,7 @@ def unpack_inputs(ctx, prologue_trace, pro_to_comp_inps, pro_to_epi_inps, args, 
             try:
                 from_provenance(p.history)
             except Exception as e:
-                raise NotImplementedError(f"Exception occured unpacking object from {p.history}") from e
+                raise NotImplementedError(f"Exception occurred unpacking object from {p.history}") from e
 
         already_unpacked[id(p)] = p
 

--- a/thunder/core/prims.py
+++ b/thunder/core/prims.py
@@ -3912,7 +3912,7 @@ prod = make_prim(PrimIDs.PROD, "prod", meta=_reduction_meta, tags=(OpTags.REDUCT
 sum = make_prim(PrimIDs.SUM, "sum", meta=_reduction_meta, tags=(OpTags.REDUCTION_OP,))
 
 
-# Note: We have seperate meta function for `argmin/argmax` instead of
+# Note: We have separate meta function for `argmin/argmax` instead of
 #       reusing `_reduction_meta` as these operations expect Optional[int] for `dim`
 #       and return output with integer dtype.
 #

--- a/thunder/core/utils.py
+++ b/thunder/core/utils.py
@@ -1141,7 +1141,7 @@ def find_producer_symbols(trace: TraceCtx, proxies: Sequence[Proxy], stop_proxie
                 if arg_name not in map(lambda x: x.name, stop_proxies) and arg_name not in seen:
                     queue.append(arg)
                     seen.add(arg_name)
-    # original_order maps from bound_symbol to the index/order of its occurence in the trace. The order is
+    # original_order maps from bound_symbol to the index/order of its occurrence in the trace. The order is
     # used to sort producer bound symbols to preserve the correctness of data dependency.
     original_order = dict()
     for i, bsym in enumerate(trace.bound_symbols):

--- a/thunder/distributed/transforms/ddp_v2.py
+++ b/thunder/distributed/transforms/ddp_v2.py
@@ -56,7 +56,7 @@ class DDPTransform(Transform):
 
         # NOTE: Shared Parameters in Trace
         # Shared parameters in PyTorch eager are parameters of module which have different name but share the underlying tensor.
-        # For shared parameter, we replace all occurence shared parameter with it's corresponding `base` parameter.
+        # For shared parameter, we replace all occurrences shared parameter with it's corresponding `base` parameter.
         # In our implementation `base` parameter is the parameter and corresponding name which we see the first time while
         # iterating our parameters (see below). We track subsequent parameter which share the underlying Tensor with this `base` parameter
         # in `shared_params_name` dictionary.

--- a/thunder/distributed/transforms/fsdp_v2.py
+++ b/thunder/distributed/transforms/fsdp_v2.py
@@ -144,7 +144,7 @@ class FSDPTransform(Transform):
 
         # NOTE: Shared Parameters in Trace
         # Shared parameters in PyTorch eager are parameters of module which have different name but share the underlying tensor.
-        # For shared parameter, we replace all occurence shared parameter with it's corresponding `base` parameter.
+        # For shared parameter, we replace all occurrences shared parameter with it's corresponding `base` parameter.
         # In our implementation `base` parameter is the parameter and corresponding name which we see the first time while
         # iterating our parameters (see below). We track subsequent parameter which share the underlying Tensor with this `base` parameter
         # in `shared_params_name` dictionary.

--- a/thunder/tests/distributed/test_dtensor.py
+++ b/thunder/tests/distributed/test_dtensor.py
@@ -31,7 +31,7 @@ from thunder.core.pytree import tree_flatten
 from thunder.dynamo import thunderfx
 
 
-# NOTE: We run all these similar functions seperately
+# NOTE: We run all these similar functions separately
 #       as we want to avoid nvfuser issue (https://github.com/NVIDIA/Fuser/issues/4507)
 #       where trying to create FusionDefinition with same math operation can fail.
 functions_to_test = {

--- a/thunder/tests/opinfos.py
+++ b/thunder/tests/opinfos.py
@@ -5964,8 +5964,8 @@ def max_sample_generator(op, device, dtype, requires_grad, **kwargs):
         if dtype is not torch.bool:  # argmax is not supported on `bool`
             # overload: torch_max(a: TensorLike, /, dim: int | tuple[int], keepdim: bool = False) -> TensorLike, TensorLike
             # This overload corresponds to taking the max along the specified dimension `dim`.
-            # It returns first occurence of the maximum value along the dimension and it's corresponding index.
-            # NOTE: When same values are present, the first occurence of the `value` and corresponding index is returned
+            # It returns first occurrence of the maximum value along the dimension and it's corresponding index.
+            # NOTE: When same values are present, the first occurrence of the `value` and corresponding index is returned
             yield SampleInput(make_t(shape), dim)
             yield SampleInput(make_t(shape), dim, keepdim)
 

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -3197,7 +3197,7 @@ def torch_max(
 
     # overload - torch_max(a: TensorLike, /, dim: int | tuple[int], keepdim: bool = False) -> TensorLike, TensorLike
     # This overload corresponds to taking the max along the specified dimension `dim`.
-    # NOTE: It returns first occurence of the maximum value along the dimension and it's corresponding index.
+    # NOTE: It returns first occurrence of the maximum value along the dimension and it's corresponding index.
     utils.check_type(dim, NumberLike)
     max_vals = amax(a, dim, keepdim)
     argmax_vals = argmax(a, dim, keepdim)

--- a/thunder/transforms/materialization.py
+++ b/thunder/transforms/materialization.py
@@ -33,7 +33,7 @@ def module_init_from_original_module_init(
     processed_names = set()
 
     # Shared parameters in PyTorch eager are parameters of module which have different name but share the underlying tensor.
-    # For shared parameter, we replace all occurence shared parameter with its corresponding `base` parameter.
+    # For shared parameter, we replace all occurrences shared parameter with its corresponding `base` parameter.
     # In our implementation `base` parameter is the parameter and corresponding name which we see the first time while
     # iterating our parameters (see below). We track subsequent parameter which share the underlying Tensor with this `base` parameter
     # in `shared_params_name` dictionary.


### PR DESCRIPTION
Fix typos across 9 files:
- 'occured' → 'occurred'
- 'seperate' → 'separate'
- 'occurence' → 'occurrence'