### PR TITLE
fix(pre-commit.ci): pin pyupgrade to Python 3.13 to avoid crash on 3.14

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,7 @@ repos:
       - id: pyupgrade
         args: ["--py310-plus"]
         name: Upgrade code
+        language_version: python3.13
         exclude: "examples|thunder/tests/test_interpreter.py|thunder/tests/test_jit_general.py"
 
   - repo: https://github.com/codespell-project/codespell


### PR DESCRIPTION
## What does this PR do?

Pins `language_version: python3.13` on the `pyupgrade` pre-commit hook.

`pyupgrade v3.21.0` crashes on Python 3.14 with:

```
TypeError: cannot use a bytes pattern on a string-like object
```

This is caused by a breaking change in `tokenize.cookie_re` in Python 3.14. pre-commit.ci runs on 3.14, so every PR is currently failing the `Upgrade code` hook regardless of what changed.

Seen failing here: https://results.pre-commit.ci/run/github/773894671/1779979956.EqEwjW5-S9KLbyBMT9nrAA

Pinning to `python3.13` keeps the hook stable until pyupgrade ships 3.14 support upstream.