### PR TITLE
Support PyTorch 2.12 (fx codegen, autograd_function_apply)

### DIFF
--- a/requirements/devel.txt
+++ b/requirements/devel.txt
@@ -6,4 +6,3 @@ datasets>=3.5.0
 peft>=0.15.2
 
 torchvision
-torchaudio

--- a/thunder/core/interpreter.py
+++ b/thunder/core/interpreter.py
@@ -195,7 +195,20 @@ class WrappedValue:
 # Note: Use these with care!
 #       In some situations - in particular *args/**kwargs, Python creates tuples and dicts for us,
 #       these functions are intended to do the appropriate wrapping for them.
-def wrap_args_from_list(lst):  # returns a new list!
+def wrap_args_from_list(lst):  # returns a new list (or an INTERPRETER_SIGNALS on error)!
+    # `*args` unpacking (CALL_FUNCTION_EX) may receive any iterable, including a
+    # generator (e.g. ``f(*(x for x in xs))``), which supports neither len() nor
+    # indexing. Materialize such iterables into a list via interpreted iteration
+    # so element wrappers and provenance are tracked, then index as usual.
+    if not isinstance(unwrap(lst), (list, tuple)):
+
+        def impl(iterable):
+            return list(iterable)
+
+        lst = _interpret_call(impl, lst)
+        if lst is INTERPRETER_SIGNALS.EXCEPTION_RAISED:
+            return lst
+
     res = [_interpret_call(lambda seq, i: seq[i], lst, wrap_const(i)) for i in range(len(unwrap(lst)))]
     return res
 
@@ -2370,7 +2383,20 @@ class MutSequenceWrapperMethods(SequenceWrapperMethods):
 
     def insert(self, i, x, /):
         self.track_items()
-        raise NotImplementedError("Sequence.insert, please file an issue")
+        assert self.item_wrappers is not None
+
+        uindex = i.value
+        if not isinstance(uindex, int):
+            return do_raise(TypeError(f"'{type(uindex)}' object cannot be interpreted as an integer"))
+        uindex = int(uindex)  # if it was a subclass like IntProxy
+
+        pr = ProvenanceRecord(PseudoInst.LIST_APPEND, inputs=[self.provenance, x.provenance])
+        self.provenance = pr  # should have an update method
+        self.value.insert(uindex, x.value)
+        assert type(self.item_wrappers) is list
+        self.item_wrappers.insert(uindex, x)
+        assert len(self.value) == len(self.item_wrappers)
+        return wrap_const(None)
 
     def pop(self, index=-1, /):
         self.track_items()
@@ -2442,6 +2468,9 @@ class MappingKeysView(ThunderInterpreterObject):
     def __init__(self, mapping):
         self._mapping = mapping
 
+    def __len__(self):
+        return len(self._mapping)
+
     @property
     def mapping(self):
         return self._mapping  # a should be a MappingProxy...
@@ -2487,6 +2516,9 @@ class MappingValuesWrapper(ThunderInterpreterObject):
     def __init__(self, mapping):
         self._mapping = mapping
 
+    def __len__(self):
+        return len(self._mapping)
+
     def __iter__(self):
         return MappingValuesIterator(self._mapping)
 
@@ -2510,6 +2542,9 @@ class MappingItemsIterator(ThunderInterpreterObject):
 class MappingItemsWrapper(ThunderInterpreterObject):
     def __init__(self, mapping):
         self._mapping = mapping
+
+    def __len__(self):
+        return len(self._mapping)
 
     def __iter__(self):
         return MappingItemsIterator(self._mapping)
@@ -3872,6 +3907,8 @@ def _call_function_ex_handler(
     ctx: InterpreterCompileCtx = get_interpretercompilectx()
     if ctx._with_provenance_tracking:
         args = wrap_args_from_list(args)
+        if args is INTERPRETER_SIGNALS.EXCEPTION_RAISED:
+            return args
         kwargs = wrap_kwargs_from_dict(kwargs)
     return check_and_append(stack, _interpret_call(func, *args, **kwargs))
 

--- a/thunder/core/jit_ext.py
+++ b/thunder/core/jit_ext.py
@@ -103,6 +103,19 @@ MODULE_MEMBER_DICT_ATTRS = {
 }
 
 
+def _is_recordable_module_member_value(value) -> bool:
+    # Writes to a module's member dicts are replayed in the epilogue (via pack_attr /
+    # pack_buffer), which only handle trackable computational state: proxies, submodules,
+    # and simple scalars/containers. Framework-internal bookkeeping written as a side
+    # effect of interpreting through library internals must not be recorded -- e.g.
+    # torch >= 2.12's fx GraphModule codegen assigns `_code` (a source string) and
+    # `_graph` (an fx.Graph) into `__dict__` while thunder traces the GraphModule.
+    return isinstance(
+        unwrap(value),
+        (Proxy, torch.Tensor, torch.nn.Module, int, float, tuple, NoneType, torch.device, thunder.devices.Device),
+    )
+
+
 class JITSharpEdgeError(RuntimeError):
     """
     Thrown when the program cannot be safely translated to a thunder program,
@@ -494,7 +507,7 @@ def _general_jit_dict_setitem(d, key, value):
     dict_setitem_lookaside = default_lookaside(dict.__setitem__)
     assert dict_setitem_lookaside is not None
 
-    if d.provenance.ext_flag & EXT_FLAG_IS_MODULE_MEMBER_DICT:
+    if d.provenance.ext_flag & EXT_FLAG_IS_MODULE_MEMBER_DICT and _is_recordable_module_member_value(value):
         ctx: JitCtx = get_jit_ctx()
         if d.original_value is d.nothing:
             ctx.proxify(d)
@@ -508,7 +521,7 @@ def _general_jit_ordered_dict_setitem(d, key, value):
     dict_setitem_lookaside = default_lookaside(collections.OrderedDict.__setitem__)
     assert dict_setitem_lookaside is not None
 
-    if d.provenance.ext_flag & EXT_FLAG_IS_MODULE_MEMBER_DICT:
+    if d.provenance.ext_flag & EXT_FLAG_IS_MODULE_MEMBER_DICT and _is_recordable_module_member_value(value):
         ctx: JitCtx = get_jit_ctx()
         if d.original_value is d.nothing:
             ctx.proxify(d)
@@ -1000,7 +1013,11 @@ def _general_jit_torch_ops_higher_order_autograd_function_apply(fwd, bwd, *fwd_a
             continue
         trace_of_forward.bound_symbols.append(bsym.from_bsym())
     with tracectx(trace_of_forward):
-        prims.python_return(*(sequencify(output)))
+        # Return the forward output preserving its structure so the result matches
+        # torch.ops.higher_order.autograd_function_apply. torch >= 2.12's dynamo graphs
+        # wrap the output in a tuple (e.g. `((y,), saved)`) and index it (`apply(...)[0]`);
+        # unpacking a single-element output here would collapse it and break that indexing.
+        prims.python_return(output)
 
     # See NOTE: `autograd_function_apply` and `no_grad` interaction for details about
     # `thunder.torch.call_higher_order_function_and_consider_outer_autograd_setting`

--- a/thunder/tests/framework.py
+++ b/thunder/tests/framework.py
@@ -77,44 +77,6 @@ def _bitsandbytes_available():
 BITSANDBYTES_AVAILABLE = _bitsandbytes_available()
 
 
-# TODO This change should be handled properly, this is a temporary fix to allow the CI to progress.
-# See https://github.com/Lightning-AI/lightning-thunder/issues/2807
-def _pytorch_removed_args_tensor_mask() -> bool:
-    """Check if PyTorch removed args_tensor_mask from autograd_function_apply.
-
-    PyTorch removed args_tensor_mask in https://github.com/pytorch/pytorch/pull/166788
-    (commit 5cf15aef144fd03379a5796e37698eee5e4575b8, Dec 12, 2025).
-
-    Returns True if args_tensor_mask is NO LONGER accepted (new PyTorch).
-    """
-    import re
-
-    version = torch.__version__
-    # Nightly versions look like: 2.6.0.dev20251212+cpu
-    match = re.search(r"\.dev(\d{8})", version)
-    if match:
-        nightly_date = int(match.group(1))
-        # args_tensor_mask removed around Dec 12, 2025
-        return nightly_date >= 20251212
-
-    # Lightning AI nightly builds have version strings like: 2.10.0a0+git62c80e7
-    # We conservatively check against the base version (the portion before "+")
-    # because we do not know whether the problematic commit removing args_tensor_mask
-    # is before or after 2.10.0a0+git62c80e7. Therefore, we return True (masked as removed)
-    # if we are on version 2.10.0a0 or later.
-    base_version = packaging.version.parse(version.split("+")[0])
-    if base_version >= packaging.version.parse("2.10.0a0"):
-        return True
-
-    return False
-
-
-xfail_if_args_tensor_mask_removed = pytest.mark.xfail(
-    _pytorch_removed_args_tensor_mask(),
-    reason="PyTorch >= 2.10.0a0+git62c80e7 or nightly >= 20251212 removed args_tensor_mask from autograd_function_apply (PR #166788)",
-)
-
-
 def version_between(version: str, *, min_ver: str | None = None, max_ver: str | None = None):
     v = packaging.version.parse(version)
     if min_ver is not None and v < packaging.version.parse(min_ver):

--- a/thunder/tests/test_dynamo.py
+++ b/thunder/tests/test_dynamo.py
@@ -32,7 +32,6 @@ from thunder.tests.framework import (
     DynamoThunderExecutor,
     IS_WINDOWS,
     requiresCUDA,
-    xfail_if_args_tensor_mask_removed,
 )
 from thunder.tests.make_tensor import make_tensor
 from thunder.dynamo.report import (
@@ -370,7 +369,6 @@ def test_splitter_autocast_ctx_with_split(executor, device: str, dtype: dtypes.d
             strict=True,
             reason="torch.compile Windows support is still WIP - https://github.com/pytorch/pytorch/issues/122094",
         ),
-        xfail_if_args_tensor_mask_removed,
     ),
 )
 def test_splitter_autograd_function(executor, device: str, dtype: dtypes.dtype, dynamic: bool | None):

--- a/thunder/tests/test_interpreter.py
+++ b/thunder/tests/test_interpreter.py
@@ -1877,6 +1877,38 @@ def test_len_lookaside(jit):
         jfoo(o)
 
 
+def test_call_function_ex_with_generator(jit):
+    # CALL_FUNCTION_EX may unpack an arbitrary iterable as ``*args``. A generator has
+    # no ``len()`` / indexing, so it must be materialized before wrapping. This pattern
+    # is emitted by torch >= 2.12's fx codegen, e.g. ``"{}".format(*(x for x in xs))``.
+    def foo(xs):
+        return "{} {} {}".format(*(str(x) for x in xs))
+
+    jfoo = jit(foo)
+    assert jfoo([1, 2, 3]) == foo([1, 2, 3])
+
+
+def test_list_insert(jit):
+    def foo():
+        values = ["b", "c"]
+        values.insert(0, "a")  # torch >= 2.12 fx codegen uses ``free_vars.insert(0, "self")``
+        values.insert(-1, "x")
+        values.insert(100, "d")  # index past the end clamps, like list.insert
+        return values
+
+    jfoo = jit(foo)
+    assert jfoo() == foo()
+
+
+def test_mapping_view_len(jit):
+    def foo(d):
+        return len(d.keys()), len(d.values()), len(d.items())
+
+    jfoo = jit(foo)
+    d = {"a": 1, "b": 2, "c": 3}
+    assert jfoo(d) == foo(d)
+
+
 def test_any_lookaside(jit):
     jitting = False
 

--- a/thunder/tests/test_jit_general.py
+++ b/thunder/tests/test_jit_general.py
@@ -42,13 +42,32 @@ def _detect_has_args_tensor_mask():
 _HAS_ARGS_TENSOR_MASK = _detect_has_args_tensor_mask()
 
 
-def _autograd_function_apply_kwargs(args_tensor_mask, non_differentiable_idx=None):
+def _detect_has_saved_for_backward_idx():
+    """Check if autograd_function_apply requires saved_for_backward_idx.
+
+    PyTorch >= 2.12 requires a ``saved_for_backward_idx`` kwarg.
+    """
+    try:
+        from torch._functorch.autograd_function import AutogradFunctionApply
+
+        source = inspect.getsource(AutogradFunctionApply.__call__)
+        return "saved_for_backward_idx" in source
+    except (ImportError, AttributeError, OSError):
+        return False
+
+
+_HAS_SAVED_FOR_BACKWARD_IDX = _detect_has_saved_for_backward_idx()
+
+
+def _autograd_function_apply_kwargs(args_tensor_mask, non_differentiable_idx=None, saved_for_backward_idx=None):
     """Create kwargs for autograd_function_apply that work with both stable and nightly PyTorch."""
     kwargs = {}
     if _HAS_ARGS_TENSOR_MASK:
         kwargs["args_tensor_mask"] = args_tensor_mask
     if non_differentiable_idx is not None:
         kwargs["non_differentiable_idx"] = non_differentiable_idx
+    if _HAS_SAVED_FOR_BACKWARD_IDX and saved_for_backward_idx is not None:
+        kwargs["saved_for_backward_idx"] = saved_for_backward_idx
     return kwargs
 
 
@@ -1324,7 +1343,7 @@ def test_autograd_function_apply():
             fwd,
             bwd,
             x,
-            **_autograd_function_apply_kwargs([True], non_differentiable_idx=[]),
+            **_autograd_function_apply_kwargs([True], non_differentiable_idx=[], saved_for_backward_idx=[0]),
         )
 
     jitted = thunder_jit(my_sin)
@@ -1363,7 +1382,7 @@ def test_autograd_function_apply():
             fwd,
             wrong_bwd,
             x,
-            **_autograd_function_apply_kwargs([True], non_differentiable_idx=[]),
+            **_autograd_function_apply_kwargs([True], non_differentiable_idx=[], saved_for_backward_idx=[0]),
         )
 
     jitted = thunder_jit(my_sin_with_wrong_backward)
@@ -1416,7 +1435,7 @@ def test_autograd_function_apply_with_no_grad():
             forward,
             backward,
             x,
-            **_autograd_function_apply_kwargs([True], non_differentiable_idx=[]),
+            **_autograd_function_apply_kwargs([True], non_differentiable_idx=[], saved_for_backward_idx=[0]),
         )
         return res
 
@@ -1465,7 +1484,7 @@ def test_autograd_function_apply_with_no_grad():
             forward,
             backward,
             x,
-            **_autograd_function_apply_kwargs([True], non_differentiable_idx=[]),
+            **_autograd_function_apply_kwargs([True], non_differentiable_idx=[], saved_for_backward_idx=[0]),
         )
         return res
 

--- a/thunder/torch/__init__.py
+++ b/thunder/torch/__init__.py
@@ -6715,6 +6715,7 @@ def autograd_function_apply(
     *args: Any,
     args_tensor_mask: Sequence[bool] | None = None,
     non_differentiable_idx: Sequence[int] | None = None,
+    saved_for_backward_idx: Sequence[int] | None = None,
 ) -> TensorProxy | tuple[TensorProxy, ...]:
     # TODO: Remove this once this autograd API becomes stable.
     # On stable PyTorch, fwd expects ctx as first argument
@@ -6733,6 +6734,7 @@ def augmented_forward_autograd_function_apply(
     *args: Any,
     args_tensor_mask: Sequence[bool] | None = None,
     non_differentiable_idx: Sequence[int] | None = None,
+    saved_for_backward_idx: Sequence[int] | None = None,
 ) -> tuple[TensorProxy | tuple[TensorProxy, ...], tuple[Any, ...]]:
     # TODO: Remove this once this autograd API becomes stable.
     # On stable PyTorch, fwd expects ctx as first argument


### PR DESCRIPTION
<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this discussed/approved via a Github issue? (related to torch-nightly compat, e.g. #2807)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/pytorch-lightning/blob/main/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to update the docs? (no docs changes needed)
- [x] Did you write any new necessary tests?

</details>

## What does this PR do?

Restores **PyTorch 2.12** compatibility. On `torch >= 2.12` the `core` CI suites go red (`latest`/`nightly`) while `oldest` stays green — affecting all `test_nanogpt_*_DynamoThunder_*`, ~40 `test_dynamo.py` cases, `test_autograd_function_apply*`, and `test_higher_order_inplace_alias_update`.

Root cause: tracing the dynamo `GraphModule` makes thunder interpret torch's fx **codegen** and `autograd_function_apply`, both of which changed internals in 2.12.

**Interpreter** (`thunder/core/interpreter.py`)
- `generator has no len()` — fx unpacks a generator as `*args`; materialize it before indexing.
- `NotImplementedError: Sequence.insert` — implement the stubbed `list.insert`.
- `MappingKeysView has no len()` — add `__len__` to the mapping views.

**autograd_function_apply** (`thunder/core/jit_ext.py`, `thunder/torch/__init__.py`)
- `KeyError: 'saved_for_backward_idx'` — accept (and ignore) the new kwarg.
- `trying to set ._code …` — fx `recompile()` writes `_code`/`_graph` into `__dict__`; stop recording non-trackable module-member writes.
- wrong shape (`[]` vs `[2]`) — dynamo wraps the output in a tuple and indexes it (`…apply(...)[0]`); preserve the output structure instead of collapsing it.

**Cleanup:** drop the unused `torchaudio` dev dependency.

All fixes are **version-agnostic** (no version gating): inputs are just handled more generally, the new kwarg is optional, and a bare output stays bare while a tuple stays a tuple. `oldest`/`latest`/`nightly` CI covers both ends.

**Tests:** new focused interpreter tests (generator unpack, `list.insert`, mapping-view `len`), each verified to fail pre-fix; autograd tests extended for `saved_for_backward_idx` (mirroring `_detect_has_args_tensor_mask`).

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
