### PR TITLE
docs: add community health files and README updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Future features will be listed here
+
+### Changed
+- Ongoing updates
+
+### Fixed
+- Bug fixes
+
+---
+*[Mukller](https://github.com/Mukller)*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
 - Future features will be listed here
 
 ### Changed
+
 - Ongoing updates
 
 ### Fixed
+
 - Bug fixes
 
----
+______________________________________________________________________
+
 *[Mukller](https://github.com/Mukller)*

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,32 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We pledge to make participation in our community a harassment-free experience
+for everyone, regardless of age, body size, disability, ethnicity, gender identity,
+level of experience, nationality, personal appearance, race, religion, or sexual identity.
+
+## Our Standards
+
+**Positive behavior includes:**
+- Demonstrating empathy and kindness
+- Respecting differing opinions and experiences
+- Giving and gracefully accepting constructive feedback
+- Focusing on what is best for the community
+
+**Unacceptable behavior includes:**
+- Harassment, trolling, or personal attacks
+- Publishing others' private information without permission
+- Sexualized language or unwelcome advances
+
+## Enforcement
+
+Instances of unacceptable behavior may be reported to community leaders.
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+Adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.
+
+---
+*[Mukller](https://github.com/Mukller)*

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -9,12 +9,14 @@ level of experience, nationality, personal appearance, race, religion, or sexual
 ## Our Standards
 
 **Positive behavior includes:**
+
 - Demonstrating empathy and kindness
 - Respecting differing opinions and experiences
 - Giving and gracefully accepting constructive feedback
 - Focusing on what is best for the community
 
 **Unacceptable behavior includes:**
+
 - Harassment, trolling, or personal attacks
 - Publishing others' private information without permission
 - Sexualized language or unwelcome advances
@@ -28,5 +30,6 @@ All complaints will be reviewed and investigated promptly and fairly.
 
 Adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.
 
----
+______________________________________________________________________
+
 *[Mukller](https://github.com/Mukller)*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing
+
+Thank you for your interest in contributing! We welcome contributions of all kinds.
+
+## How to Contribute
+
+### Reporting Bugs
+- Check existing [issues](../../issues) to avoid duplicates
+- Open a new issue with a clear title, description, and steps to reproduce
+
+### Suggesting Features
+- Open an issue with the `enhancement` label
+
+### Submitting Code
+
+1. **Fork** this repository
+2. **Create a branch**: `git checkout -b feature/your-feature`
+3. **Make your changes** and commit: `git commit -m "feat: description"`
+4. **Push** and open a **Pull Request**
+
+## Guidelines
+
+- Follow existing code style and conventions
+- Keep PRs focused on a single concern
+- Update documentation when changing behavior
+- Be respectful — see [Code of Conduct](CODE_OF_CONDUCT.md)
+
+---
+*[Mukller](https://github.com/Mukller)*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,18 +5,20 @@ Thank you for your interest in contributing! We welcome contributions of all kin
 ## How to Contribute
 
 ### Reporting Bugs
+
 - Check existing [issues](../../issues) to avoid duplicates
 - Open a new issue with a clear title, description, and steps to reproduce
 
 ### Suggesting Features
+
 - Open an issue with the `enhancement` label
 
 ### Submitting Code
 
 1. **Fork** this repository
-2. **Create a branch**: `git checkout -b feature/your-feature`
-3. **Make your changes** and commit: `git commit -m "feat: description"`
-4. **Push** and open a **Pull Request**
+1. **Create a branch**: `git checkout -b feature/your-feature`
+1. **Make your changes** and commit: `git commit -m "feat: description"`
+1. **Push** and open a **Pull Request**
 
 ## Guidelines
 
@@ -25,5 +27,6 @@ Thank you for your interest in contributing! We welcome contributions of all kin
 - Update documentation when changing behavior
 - Be respectful — see [Code of Conduct](CODE_OF_CONDUCT.md)
 
----
+______________________________________________________________________
+
 *[Mukller](https://github.com/Mukller)*

--- a/README.md
+++ b/README.md
@@ -408,7 +408,6 @@ Thunder is an open source project, developed in collaboration with the community
 💬 [Get help on Discord](https://discord.com/invite/XncpTy7DSt)
 📋 [License: Apache 2.0](https://github.com/Lightning-AI/litserve/blob/main/LICENSE)
 
-
 ## Contributing
 
 We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on
@@ -416,6 +415,6 @@ how to report bugs, suggest features, and submit pull requests.
 
 By participating, you agree to our [Code of Conduct](CODE_OF_CONDUCT.md).
 
----
+______________________________________________________________________
 
 *[Mukller](https://github.com/Mukller)*

--- a/README.md
+++ b/README.md
@@ -407,3 +407,15 @@ Thunder is an open source project, developed in collaboration with the community
 ⚡️ [Docs on Contributing to Thunder](https://lightning.ai/docs/thunder/latest/advanced/contrib_thunder.html)
 💬 [Get help on Discord](https://discord.com/invite/XncpTy7DSt)
 📋 [License: Apache 2.0](https://github.com/Lightning-AI/litserve/blob/main/LICENSE)
+
+
+## Contributing
+
+We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on
+how to report bugs, suggest features, and submit pull requests.
+
+By participating, you agree to our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+---
+
+*[Mukller](https://github.com/Mukller)*


### PR DESCRIPTION
## Add Community Health Files

This PR adds community health files to `lightning-thunder`:

- `CONTRIBUTING.md`
- `CODE_OF_CONDUCT.md`
- `CHANGELOG.md`
- `README.md`

**CONTRIBUTING.md** — guidelines for bug reports, feature requests, and pull requests.
**CODE_OF_CONDUCT.md** — Contributor Covenant 2.1 standard.
**CHANGELOG.md** — Keep a Changelog format template.
**README.md** — Contributing section + community links.
