### PR TITLE
Remove F405 from Ruff ignore list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,7 +156,6 @@ ignore = [
     # TODO(crcrpar): Resolves the following ignores as these are added while enabling ruff check in pre-commit
     "F821",  # https://docs.astral.sh/ruff/rules/undefined-name/
     "E402",  # https://docs.astral.sh/ruff/rules/module-import-not-at-top-of-file/
-    "F405",  # https://docs.astral.sh/ruff/rules/undefined-local-with-import-star-usage/
     "E712",  # https://docs.astral.sh/ruff/rules/true-false-comparison/
     "E721",  # https://docs.astral.sh/ruff/rules/type-comparison/
 ]

--- a/thunder/__init__.py
+++ b/thunder/__init__.py
@@ -155,7 +155,14 @@ __all__ = [
 ]
 
 
-from thunder.__about__ import *  # noqa: F403
+from thunder.__about__ import (
+    __author__ as __author__,
+    __author_email__ as __author_email__,
+    __copyright__ as __copyright__,
+    __docs__ as __docs__,
+    __homepage__ as __homepage__,
+    __version__ as __version__,
+)
 
 
 # TODO maybe move these aliases to the core language?

--- a/thunder/core/utils.py
+++ b/thunder/core/utils.py
@@ -15,7 +15,16 @@ import torch
 import thunder.core.dtypes as dtypes
 from thunder.core.pytree import tree_flatten, tree_unflatten, tree_map
 from thunder.core.proxies import Proxy, NumberProxy, TensorProxy, variableify, CONSTRAINT, Variable
+from thunder.core.baseutils import (
+    BoundSymbolInterface,
+    TensorProxyInterface,
+    check,
+    check_type,
+    check_valid_length,
+    check_valid_shape,
+)
 from thunder.core.baseutils import *  # noqa: F403
+from thunder.core.codeutils import SigInfo
 from thunder.core.codeutils import *  # noqa: F403
 from thunder.core.trace import TraceCtx, tracectx
 import thunder.core.prims as prims


### PR DESCRIPTION
Removes `F405` from Ruff’s global ignore list by importing the names used in `thunder.core.utils` explicitly. The intentional wildcard imports stay in place so the module namespace does not change. The metadata wildcard import is replaced with explicit re-exports.

Addresses part of #2218.

Testing:
- `ruff check . --select F405`
- `ruff check thunder/core/utils.py thunder/__init__.py`
- `pytest thunder/tests/test_core.py -q` (161 passed)