### PR TITLE
Fix `import thunder` on PyTorch 2.13 (named tensor removal)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,10 @@ markers = [
 ]
 filterwarnings = [
     "error::FutureWarning",
+    # torch reads this deprecated dynamo config at import time, as a default argument in
+    # torch/testing/_internal/common_utils.py, which fails collection of the distributed tests
+    # todo: drop once torch stops reading it
+    "ignore:torch._dynamo.config.inline_inbuilt_nn_modules is deprecated:FutureWarning",
 ]
 timeout = 900
 # xfail_strict = true  # todo

--- a/thunder/constants.py
+++ b/thunder/constants.py
@@ -1,0 +1,7 @@
+import operator
+
+from lightning_utilities.core.imports import compare_version
+
+# PyTorch version constants
+# `use_base_version` so that dev builds like "2.13.0a0+gitabc123" compare as "2.13.0"
+_TORCH_GREATER_EQUAL_2_13 = compare_version("torch", operator.ge, "2.13.0", use_base_version=True)

--- a/thunder/tests/test_auto_register_torchops.py
+++ b/thunder/tests/test_auto_register_torchops.py
@@ -5,6 +5,7 @@ from itertools import islice
 import pytest
 import thunder
 import thunder.torch.default_torch_ops as ops
+from thunder.constants import _TORCH_GREATER_EQUAL_2_13
 from thunder.torch import _get_torch_function_name
 import torch
 
@@ -248,3 +249,13 @@ def test_query_autoreg_ops(executor, device: str, _):
         cfn(a)
         ops = thunder.get_auto_registered_torch_op_names(cfn)
         assert expect == ops
+
+
+def test_named_tensor_ops_follow_torch():
+    # torch 2.13 removed named tensors, and this table is built at import time.
+    named_tensor_methods = {"align_as", "align_to", "refine_names", "rename"}
+    registered = {fn.__name__ for fn in ops.torch_auto_registered_ops[torch.Tensor]}
+    if _TORCH_GREATER_EQUAL_2_13:
+        assert not (named_tensor_methods & registered)
+    else:
+        assert named_tensor_methods <= registered

--- a/thunder/torch/default_torch_ops.py
+++ b/thunder/torch/default_torch_ops.py
@@ -1,5 +1,20 @@
 import torch
 
+from thunder.constants import _TORCH_GREATER_EQUAL_2_13
+
+# torch 2.13 removed named tensors (pytorch/pytorch#173895), and this table is built at import
+# time, so referencing the removed methods would break `import thunder` there.
+_named_tensor_methods = (
+    []
+    if _TORCH_GREATER_EQUAL_2_13
+    else [
+        torch.Tensor.align_as,
+        torch.Tensor.align_to,
+        torch.Tensor.refine_names,
+        torch.Tensor.rename,
+    ]
+)
+
 torch_auto_registered_ops = {
     torch: [
         torch._native_multi_head_attention,
@@ -358,8 +373,8 @@ torch_auto_registered_ops = {
         torch.Tensor.addmv,
         torch.Tensor.addr,
         torch.Tensor.adjoint,
-        torch.Tensor.align_as,
-        torch.Tensor.align_to,
+        # align_as, align_to, refine_names and rename, on torch versions that still have them
+        *_named_tensor_methods,
         torch.Tensor.aminmax,
         torch.Tensor.angle,
         torch.Tensor.arccos,
@@ -520,8 +535,6 @@ torch_auto_registered_ops = {
         torch.Tensor.quantile,
         torch.Tensor.rad2deg,
         torch.Tensor.ravel,
-        torch.Tensor.refine_names,
-        torch.Tensor.rename,
         torch.Tensor.renorm,
         torch.Tensor.reshape_as,
         torch.Tensor.resize,


### PR DESCRIPTION
## What does this PR do?

Fixes `import thunder` failing on PyTorch 2.13.

torch 2.13 removed the named tensor feature, so `Tensor.align_as`, `align_to`, `has_names`, `refine_names` and `rename` are gone. `default_torch_ops.py` references all five inside `torch_auto_registered_ops`, a module-level dict literal — so the lookups happen at import time and the whole package fails to load:

```
AttributeError: type object 'Tensor' has no attribute 'align_as'
```

This gates those five entries on a new `_TORCH_GREATER_EQUAL_2_13` constant so they are simply not registered on torch 2.13+.

> [!NOTE]
> Stacked on #2830 and #2831, both merged into this branch so CI here is not drowned by failures that belong to those. Diff shrinks as they land.

<details>
<summary>How it surfaced</summary>

Downstream, in [litgpt#2295](https://github.com/Lightning-AI/litgpt/pull/2295). litgpt's `constants.py` probes thunder with `RequirementCache("thunder")`; on torch 2.13 that probe raises, breaking all CPU test collection on Linux. That PR caps `torch<2.13` as a stopgap and notes it should be dropped once thunder supports 2.13 — this is the thunder-side fix. thunder itself is unpinned (`torch >=2.7.1`), so the break is latent for anyone on 2.13; litgpt just hit it first.

The removal landed via ghstack (see [pytorch#173895](https://github.com/pytorch/pytorch/pull/173895), which shows closed rather than merged). Its `torch/overrides.py` diff is the authoritative list: `Tensor.align_as`, `align_to`, `has_names`, `names`, `refine_names`, `rename`, `_update_names`, plus `torch.align_tensors`. Of those, only the five above ever appear in this repo.

</details>
