### PR TITLE
Ignore deprecated dynamo config FutureWarning from torch test utils

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,10 @@ markers = [
 ]
 filterwarnings = [
     "error::FutureWarning",
+    # torch reads this deprecated dynamo config at import time, as a default argument in
+    # torch/testing/_internal/common_utils.py, which fails collection of the distributed tests
+    # todo: drop once torch stops reading it
+    "ignore:torch._dynamo.config.inline_inbuilt_nn_modules is deprecated:FutureWarning",
 ]
 timeout = 900
 # xfail_strict = true  # todo


### PR DESCRIPTION
## What does this PR do?

Fixes collection of the distributed tests failing on newer torch with:

```
FutureWarning: torch._dynamo.config.inline_inbuilt_nn_modules is deprecated and does not
do anything, inline_inbuilt_nn_modules is always True.
```

`torch/testing/_internal/common_utils.py` reads that deprecated config as a **default argument**:

```python
def skipIfNNModuleInlined(
    msg="test doesn't currently work with nn module inlining",
    condition=torch._dynamo.config.inline_inbuilt_nn_modules,
):
```

Default arguments are evaluated when the module is imported, so the warning fires on import alone — thunder never calls that helper. `thunder/tests/distributed/helper.py` imports `common_utils`, and with `filterwarnings = ["error::FutureWarning"]` that turns into a collection error for all 15 distributed test files.

This ignores that one message. Every other `FutureWarning` stays fatal.

<details>
<summary>Note</summary>

The offending read is inside PyTorch, so there is nothing to fix on our side beyond the filter. Also unblocks CI on #2829, which hits this on `main` and is otherwise unrelated.

</details>
